### PR TITLE
Fixed gh repo creation to deal with relative paths.

### DIFF
--- a/conda_smithy/conda_smithy.py
+++ b/conda_smithy/conda_smithy.py
@@ -95,7 +95,7 @@ class GithubCreate(Subcommand):
         else:
             # Use the organization provided.
             user_or_org = gh.get_organization(args.organization)
-        repo = user_or_org.create_repo(os.path.basename(args.feedstock_directory),
+        repo = user_or_org.create_repo(os.path.basename(os.path.abspath(args.feedstock_directory)),
                                        has_wiki=False,
                                        description='A conda-smithy repository for {}.'.format(meta.name()))
         print('Created {} on github'.format(repo.full_name))


### PR DESCRIPTION
Steps to make a feedstock:

```
$ conda smithy init conda_smithy.recipe --feedstock-directory=../conda-smithy-feedstock
Initialized empty Git repository in /Users/pelson/dev/conda-forge/conda-smithy-feedstock/.git/
[master (root-commit) dbd083f] Initial commit of the conda-smithy feedstock.
 10 files changed, 329 insertions(+)
 create mode 100644 .gitignore
 create mode 100644 .travis.yml
 create mode 100644 README
 create mode 100644 appveyor.yml
 create mode 100755 ci_support/run_docker_build.sh
 create mode 100755 ci_support/upload_or_check_non_existence.py
 create mode 100644 circle.yml
 create mode 100644 conda-forge.yml
 create mode 100644 recipe/build.sh
 create mode 100644 recipe/meta.yaml

$ conda smithy github-create --organization conda-forge ../conda-smithy-feedstock
Created conda-forge/conda-smithy-feedstock on github

$ cd ../conda-smithy-feedstock

$ conda smithy register-feedstock-ci ./
CI Summary for conda-forge/conda-smithy-feedstock (may take some time):
 * Goto https://circleci.com/add-projects
 * Goto https://ci.appveyor.com/projects/new
 * Goto https://travis-ci.org/profile/conda-forge to register the project

$ # tap tap tap, after registering on circle, appveyor and travis
$ conda smithy register-feedstock-ci ./
CI Summary for conda-forge/conda-smithy-feedstock (may take some time):
 * Goto https://circleci.com/add-projects
 * conda-forge/conda-smithy-feedstock already enabled on appveyor
 * conda-forge/conda-smithy-feedstock already enabled on travis-ci

$ git remote add upstream git@github.com:conda-forge/conda-smithy-feedstock.git
$ git push upstream master
```

Phew. Still too many LOC, but already better than having to do it **all** by hand...