### PR TITLE
BLD: Add pygithub to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Jinja2
 requests
 conda-build
 conda
+pygithub


### PR DESCRIPTION
Self-explanatory. I thought I'd save future users a step -- unless you have a reason to want this to be an optional dependency.