### PR TITLE
Remove the use of requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,1 @@
-Jinja2
-requests
-conda-build
-conda
-conda-build-all
-pygithub <2
-gitpython
-# ruamel.yaml
-pycrypto
+# Please see conda_smithy.recipe/meta.yaml for the canonical runtime requirements.

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,6 @@ from setuptools import setup, find_packages
 import versioneer
 
 
-with open('requirements.txt') as f:
-    requirements = f.read().splitlines()
-
-
 def main():
     skw = dict(
         name='conda-smithy',
@@ -21,7 +17,6 @@ def main():
         entry_points=dict(console_scripts=[
             'conda-smithy = conda_smithy.cli:main']),
         packages=find_packages(),
-        install_requires=requirements,
         include_package_data=True,
         # As conda-smithy has resources as part of the codebase, it is
         # not zip-safe.


### PR DESCRIPTION
It is:
(a) redundant (the same list exists in the conda recipe)
(b) not that useful, as you need to install via conda really (since it depends on conda anyway)
(c) harmful: it is patently incorrect with regards to the dependency on ruamel.core. https://github.com/conda-forge/conda-smithy/pull/36#issuecomment-170365818