### PR TITLE
Added a feedstocks CLI to simplify feedstock management.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+BSD 3-clause
+Copyright (c) conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Overview
 Installation
 ------------
 
-Clone this repo then `python setup.py install`.
+See the requirements list in conda_smithy.recipe/meta.yaml, then clone this
+repo and `python setup.py install`.
 
 Setup
 -----
@@ -36,6 +37,8 @@ instead of an organization by replacing the organization argument with
 `conda smithy register-feedstock-ci --organization conda-forge foo-feedstock`.
 This requires tokens for the CI services. You can give the name of a user instead
 of organization with `--user github_user_name`.
+4. Regenerate the feedstock with ``conda smithy regenerate foo-feedstock``
+5. Commit the changes ``cd foo-feedstock && git commit``, then push ``git push upstream master``.
 
 Running a build
 ---------------

--- a/conda_smithy/feedstocks.py
+++ b/conda_smithy/feedstocks.py
@@ -1,0 +1,104 @@
+from __future__ import absolute_import
+import glob
+import os
+
+from git import Repo, GitCommandError
+from github import Github
+
+from . import github as smithy_github
+
+
+def feedstock_repos(gh_organization):
+    token = smithy_github.gh_token()
+    gh = Github(token)
+    org = gh.get_organization(gh_organization)
+    repos = []
+    for repo in org.get_repos():
+        if repo.name.endswith('-feedstock'):
+            repos.append(repo)
+    return sorted(repos, key=lambda repo: repo.name)
+
+
+def list(gh_organization):
+    for repo in feedstock_repos(gh_organization):
+        print(repo.name)
+
+
+def cloned_feedstocks(feedstocks_directory):
+    """
+    Return a generator of all cloned feedstock directories.
+
+    """
+    pattern = os.path.abspath(os.path.join(feedstocks_directory, '*-feedstock'))
+    return sorted(glob.glob(pattern))
+
+
+def fetch_feedstocks(feedstock_directory):
+    for repo_dir in cloned_feedstocks(feedstock_directory):
+        repo = Repo(repo_dir)
+        print('Fetching for {}'.format(os.path.basename(repo_dir)))
+        for remote in repo.remotes:
+            try:
+                remote.fetch()
+            except GitCommandError:
+                print("Failed to fetch {} from {}.".format(remote.name, remote.url))
+
+
+def feedstocks_list_handle_args(args):
+    return list(args.organization)
+
+
+def feedstocks_list_cloned_handle_args(args):
+    for feedstock_directory in cloned_feedstocks(args.feedstocks_directory):
+        print(os.path.basename(feedstock_directory))
+
+
+def feedstocks_apply_cloned_handle_args(args):
+    import subprocess
+    for feedstock_directory in cloned_feedstocks(args.feedstocks_directory):
+        feedstock_basename = os.path.basename(feedstock_directory)
+        feedstock_package = feedstock_basename.rsplit('-feedstock', 1)[0]
+        env = os.environ.copy()
+        context = {'FEEDSTOCK_DIRECTORY': feedstock_directory,
+                   'FEEDSTOCK_BASENAME': feedstock_basename,
+                   'FEEDSTOCK_NAME': feedstock_package}
+        env.update(context)
+        cmd = [item.format(feedstock_directory, **context) for item in args.cmd]
+        print('\nRunning "{}" for {}:'.format(' '.join(cmd), feedstock_package))
+        subprocess.check_call(cmd, env=env, cwd=feedstock_directory)
+
+
+def feedstocks_fetch_handle_args(args):
+    return fetch_feedstocks(args.feedstocks_directory)
+
+
+def feedstocks_fetch_handle_args(args):
+    return fetch_feedstocks(args.feedstocks_directory)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    list_feedstocks = subparsers.add_parser('list', help='List all of the feedstocks available on the GitHub organization.')
+    list_feedstocks.set_defaults(func=feedstocks_list_handle_args)
+    list_feedstocks.add_argument("--organization", default="conda-forge")
+
+    list_cloned_feedstocks = subparsers.add_parser('list-cloned', help='List all of the feedstocks which have been cloned.')
+    list_cloned_feedstocks.set_defaults(func=feedstocks_list_cloned_handle_args)
+    list_cloned_feedstocks.add_argument("--feedstocks-directory", default="./")
+
+    apply_cloned_feedstocks = subparsers.add_parser('apply-cloned', help='Apply a subprocess to all of the all feedstocks which have been cloned.')
+    apply_cloned_feedstocks.set_defaults(func=feedstocks_apply_cloned_handle_args)
+    apply_cloned_feedstocks.add_argument("--feedstocks-directory", default="./")
+    apply_cloned_feedstocks.add_argument('cmd', nargs='+',
+                                         help=('Command arguments, expanded by FEEDSTOCK_NAME, FEEDSTOCK_DIRECTORY, FEEDSTOCK_BASENAME '
+                                               'env variables, run with the cwd set to the feedstock.'))
+
+    fetch_feedstocks = subparsers.add_parser('fetch', help='Run git fetch on all of the cloned feedstocks.')
+    fetch_feedstocks.set_defaults(func=feedstocks_fetch_handle_args)
+    fetch_feedstocks.add_argument("--feedstocks-directory", default="./")
+
+    args = parser.parse_args()
+    return args.func(args)

--- a/conda_smithy/github.py
+++ b/conda_smithy/github.py
@@ -1,0 +1,56 @@
+from __future__ import absolute_import
+
+import os
+
+import github
+from github import Github
+from github.GithubException import GithubException
+
+from . import configure_feedstock
+
+
+def gh_token():
+        try:
+            with open(os.path.expanduser('~/.conda-smithy/github.token'), 'r') as fh:
+                token = fh.read().strip()
+        except IOError:
+            print('No github token. Put one in ~/.conda-smithy/github.token')
+        return token
+
+
+def create_github_repo(args):
+    token = gh_token()
+    meta = configure_feedstock.meta_of_feedstock(args.feedstock_directory)
+
+    from git import Repo
+    gh = Github(token)
+    if args.user is not None:
+        pass
+        # User has been defined, and organization has not.
+        user_or_org = gh.get_user()
+    else:
+        # Use the organization provided.
+        user_or_org = gh.get_organization(args.organization)
+
+    repo_name = os.path.basename(os.path.abspath(args.feedstock_directory))
+    try:
+        gh_repo = user_or_org.create_repo(repo_name, has_wiki=False,
+                                          description='A conda-smithy repository for {}.'.format(meta.name()))
+        print('Created {} on github'.format(gh_repo.full_name))
+    except GithubException as gh_except:
+        if gh_except.data.get('errors', [{}])[0].get('message', '') != u'name already exists on this account':
+            raise
+        gh_repo = user_or_org.get_repo(repo_name)
+        print('Github repository already exists.')
+
+    # Now add this new repo as a remote on the local clone.
+    repo = Repo(args.feedstock_directory)
+    remote_name = args.remote_name.strip()
+    if remote_name:
+        if remote_name in [remote.name for remote in repo.remotes]:
+            existing_remote = repo.remotes[remote_name]
+            if existing_remote.url != gh_repo.ssh_url:
+                print("Remote {} already exists, and doesn't point to {} "
+                      "(it points to {}).".format(remote_name, gh_repo.ssh_url, existing_remote.url))
+        else:
+            repo.create_remote(remote_name, gh_repo.ssh_url)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-import os.path
-
 from setuptools import setup, find_packages
 import versioneer
 
@@ -15,6 +13,7 @@ def main():
         author_email='pelson.pub@gmail.com',
         url='https://github.com/conda-forge/conda-smithy',
         entry_points=dict(console_scripts=[
+            'feedstocks = conda_smithy.feedstocks:main',
             'conda-smithy = conda_smithy.cli:main']),
         packages=find_packages(),
         include_package_data=True,


### PR DESCRIPTION
Adds a new ``feedstocks`` CLI.

With this:

```
feedstocks --help
usage: feedstocks [-h] {list,list-cloned,apply-cloned,fetch} ...

positional arguments:
  {list,list-cloned,apply-cloned,fetch}
    list                List all of the feedstocks available on the GitHub
                        organization.
    clone               Clone all of the feedstocks available on the GitHub
                        organization.
    list-cloned         List all of the feedstocks which have been cloned.
    apply-cloned        Apply a subprocess to all of the all feedstocks which
                        have been cloned.
    fetch               Run git fetch on all of the cloned feedstocks.

optional arguments:
  -h, --help            show this help message and exit
```

```
$ feedstocks apply-cloned -- git remote -v
```


