### PR TITLE
Fix: make it possible to change the recipe dir name

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -14,7 +14,7 @@ from . import lint_recipe
 
 
 def generate_feedstock_content(target_directory, recipe_dir):
-    target_recipe_dir = os.path.join(target_directory, 'recipe')
+    target_recipe_dir = os.path.join(target_directory, recipe_dir)
     if not os.path.exists(target_recipe_dir):
         os.makedirs(target_recipe_dir)
     configure_feedstock.copytree(recipe_dir, target_recipe_dir)
@@ -24,7 +24,7 @@ def generate_feedstock_content(target_directory, recipe_dir):
         with open(forge_yml, 'w') as fh:
             fh.write('[]')
 
-    configure_feedstock.main(target_directory)
+    configure_feedstock.main(target_directory, recipe_dir)
 
 
 def init_git_repo(target):

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -71,8 +71,7 @@ def copy_feedstock_content(forge_dir):
     copytree(feedstock_content, forge_dir, 'README')
 
 
-def meta_of_feedstock(forge_dir):
-    recipe_dir = 'recipe'
+def meta_of_feedstock(forge_dir, recipe_dir):
     meta_dir = os.path.join(forge_dir, recipe_dir)
     if not os.path.exists(meta_dir):
         raise IOError("The given directory isn't a feedstock.")
@@ -87,8 +86,7 @@ def compute_build_matrix(meta):
     return mtx
 
 
-def main(forge_file_directory):
-    recipe_dir = 'recipe'
+def main(forge_file_directory, recipe_dir):
     config = {'docker': {'image': 'pelson/obvious-ci:latest_x64', 'command': 'bash'},
               'templates': {'run_docker_build': 'run_docker_build_matrix.tmpl'},
               'travis': [],
@@ -108,7 +106,7 @@ def main(forge_file_directory):
         # values. (XXX except dicts within dicts need to be dealt with!)
         config.update(file_config)
 
-    config['package'] = meta = meta_of_feedstock(forge_file_directory)
+    config['package'] = meta = meta_of_feedstock(forge_file_directory, recipe_dir)
     
     matrix = compute_build_matrix(meta)
     if matrix:


### PR DESCRIPTION
the recipe-dir name was hardcoded in most functions and even if passed in as an argument not used.

This now works for a `conda smithy init recipes`