### PR TITLE
COMPAT: import and str vs bytes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
     - rm -rf ${CONDA_INSTALL_LOCN}/pkgs && ln -s ${HOME}/cache/pkgs ${CONDA_INSTALL_LOCN}/pkgs
 
     # Now do the things we need to do to install it.
-    - conda install --file requirements.txt nose python=${PYTHON} --yes --quiet -c conda-forge
+    - conda install --file requirements.txt nose mock python=${PYTHON} --yes --quiet -c conda-forge
     - python setup.py install
 
 script:

--- a/conda_smithy/tests/test_encrypt.py
+++ b/conda_smithy/tests/test_encrypt.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+import mock
+import textwrap
+import unittest
+
+import six
+
+import conda_smithy.ci_register as ci
+
+class TestEncrypt(unittest.TestCase):
+
+    @mock.patch('conda_smithy.vendored.travis_encrypt.get_public_key')
+    def test_encryt_stringlike(self, mymock):
+        # sample from http://phpseclib.sourceforge.net/rsa/examples.html
+        mymock.return_value = textwrap.dedent(
+            '''-----BEGIN PUBLIC KEY-----
+            MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0
+            FPqri0cb2JZfXJ/DgYSF6vUpwmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/
+            3j+skZ6UtW+5u09lHNsj6tQ51s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQAB
+            -----END PUBLIC KEY-----'''
+        )
+        slug = 'user/project'
+        item = 'BINSTAR_TOKEN="secret"'
+
+        result = ci._encrypt_binstar_token(slug, item)
+        self.assertTrue(isinstance(result, six.string_types))
+

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ def main():
         # not zip-safe.
         zip_safe=False,
         cmdclass=versioneer.get_cmdclass(),
+        extras_require={
+            'test': ['six']
+        }
         )
     setup(**skw)
 


### PR DESCRIPTION
Fixes a couple issues I had with me first run through

- importing a vendored module failed
- travis encryption failed since the cryptographic routine expected bytes and got a unicode string (in py3)

I tried adding tests, but this is a bit tricky of a library to test since it's doing so much IO. Happy to adjust those as needed.

I'm not entirely sure I didn't break anything with this changes. For example, my [appveyor build](https://ci.appveyor.com/project/tomaugspurger/statsmodels-feedstock/build/job/scs99a28d0f78cld) failed to upload to my [Anaconda](https://anaconda.org/taugspurger/statsmodels/files) account since it didn't find a binstar token. That's likely unrelated though.

Thanks for the project btw. I'm hoping to setup statsmodels with it so they always have development versions available on all 3 platforms.