### PR TITLE
Add `about` section to the recipe

### DIFF
--- a/conda_smithy.recipe/meta.yaml
+++ b/conda_smithy.recipe/meta.yaml
@@ -31,3 +31,8 @@ test:
     - conda_smithy
     - conda_smithy.ci_register
     - conda_smithy.configure_feedstock
+
+about:
+  home: https://github.com/conda-forge/conda-smithy
+  license: BSD 3-clause
+  summary: A package to create repositories for conda recipes, and automate their building with CI tools on Linux, OSX and Windows.


### PR DESCRIPTION
Basically borrowed from the `setup.py` file.

Sorry, I couldn't help myself. Mainly I was bothered by the undetermined license badge on Anaconda. :fearful:

[![Anaconda-Server Badge](https://anaconda.org/conda-forge/conda-smithy/badges/license.svg)](https://anaconda.org/conda-forge/conda-smithy)