### PR TITLE
Update all on CircleCI tmpl

### DIFF
--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -37,7 +37,10 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artefacts.
 conda clean --lock
 
+conda update --yes --all
+
 conda info
+
 {%if build_setup %}
 {{ build_setup }}{% endif %}
 


### PR DESCRIPTION
Closes #72 

I need this for feedstocks that require the latest conda-build (like `hdfeos2` and `hdfeos5`).