### PR TITLE
Check for unknown license.

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -42,6 +42,11 @@ def lintify(meta, recipe_dir=None):
         if not a_test_file_exists:
             lints.append('The recipe must have some tests.')
 
+    # 5: License cannot be 'unknown.'
+    license = meta.get('about', {}).get('license', '').lower()
+    if 'unknown' == license.strip():
+        lints.append('The recipe license cannot be unknown.')
+
     return lints
 
 

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -36,6 +36,14 @@ class Test_linter(unittest.TestCase):
         expected_message = "The summary item is expected in the about section."
         self.assertIn(expected_message, lints)
 
+    def test_bad_about_license(self):
+        meta = {'about': {'home': 'a URL',
+                          'summary': 'A test summary',
+                          'license': 'unknown'}}
+        lints = linter.lintify(meta)
+        expected_message = "The recipe license cannot be unknown."
+        self.assertIn(expected_message, lints)
+
     def test_missing_about_home(self):
         meta = {'about': {'license': 'BSD',
                           'summary': 'A test summary'}}
@@ -62,7 +70,7 @@ class Test_linter(unittest.TestCase):
 
         lints = linter.lintify({'extra': {'recipe-maintainers': []}})
         self.assertIn(expected_message, lints)
-    
+
         # No extra section at all.
         lints = linter.lintify({})
         self.assertIn(expected_message, lints)
@@ -108,7 +116,7 @@ class TestCLI_recipe_lint(unittest.TestCase):
                                      stdout=subprocess.PIPE)
             child.communicate()
             self.assertEqual(child.returncode, 1)
- 
+
     def test_cli_success(self):
         with tmp_directory() as recipe_dir:
             with open(os.path.join(recipe_dir, 'meta.yaml'), 'w') as fh:


### PR DESCRIPTION
Raises an error when the license is 'unknown'. The motivation is to avoid pushing recipes with conda's skeleton default 'unknown' string.