### PR TITLE
Keep disabled CI (AppVeyor) configuration files around

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -106,13 +106,19 @@ def render_appveyor(jinja_env, forge_config, forge_dir):
         matrix = cases_not_skipped
 
     target_fname = os.path.join(forge_dir, 'appveyor.yml')
+    target_fname_disabled = os.path.join(forge_dir, 'disabled_appveyor.yml')
 
     if not matrix:
         # There are no cases to build (not even a case without any special
         # dependencies), so remove the appveyor.yml if it exists.
         if os.path.exists(target_fname):
-            os.remove(target_fname)
+            if os.path.exists(target_fname_disabled):
+                os.remove(target_fname_disabled)
+            os.rename(target_fname, target_fname_disabled)
     else:
+        if os.path.exists(target_fname_disabled):
+            os.remove(target_fname_disabled)
+
         forge_config = forge_config.copy()
         forge_config['matrix'] = matrix
 


### PR DESCRIPTION
In order to speed up CIs and avoid long queues, we decided to remove CI files if the package was not configured. While this is a great system and definitely helps, it increases the barrier (slightly) to adding back support. Namely, we need to add this file back. This could be intimidating to a new user or someone just trying to get something working quickly. For instance, they might worry that portions of these files are unique to each feedstock.

This proposal suggests that instead of deleting these files entirely, we just rename them. That way the file remains around and CI remains disabled. However, if we want to try quickly to re-enable this functionality we simply move the file back.