### PR TITLE
Moved ahead with numpy and python versions.

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -161,7 +161,7 @@ def meta_of_feedstock(forge_dir):
 def compute_build_matrix(meta):
     index = conda.api.get_index()
     mtx = special_case_version_matrix(meta, index)
-    mtx = list(filter_cases(mtx, ['python >=2.7,<3|>=3.4', 'numpy >=1.9']))
+    mtx = list(filter_cases(mtx, ['python >=2.7,<3|>=3.4', 'numpy >=1.10']))
     return mtx
 
 


### PR DESCRIPTION
Slightly more controversial this PR. Ping @conda-forge/core as a heads up - this will impact the build matrix of every single feedstock. We will no longer be building py3.4, nor numpy 1.9.

Whilst I appreciate similar arguments can be made for legacy python (2.7), let's not go down that road here - we want conda-forge to be as useful as reasonably possible without the huge burden of carrying around unnecessary versions. :wink: 