### PR TITLE
Fixed writing of hex encoded AppVeyor secret on py3.

### DIFF
--- a/conda_smithy/ci_register.py
+++ b/conda_smithy/ci_register.py
@@ -100,7 +100,7 @@ def appveyor_encrypt_binstar_token(feedstock_directory, user, project):
     if not code:
         code = {}
 
-    code.setdefault('appveyor', {}).setdefault('secure', {})['BINSTAR_TOKEN'] = response.content
+    code.setdefault('appveyor', {}).setdefault('secure', {})['BINSTAR_TOKEN'] = response.content.decode('utf-8')
     with open(forge_yaml, 'w') as fh:
         fh.write(ruamel.yaml.dump(code, Dumper=ruamel.yaml.RoundTripDumper))
 


### PR DESCRIPTION
Fixes the issue found by https://github.com/conda-forge/django-grappelli-feedstock/issues/1.

MNT PRs will have to go out to each of the affected feedstocks.