### PR TITLE
Remove homebrew

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -27,6 +27,9 @@ env:
 {%- endif %}
 {% endblock %}
 
+before install:
+    - brew remove --force $(brew list)
+
 install:
     - |
       MINICONDA_URL="http://repo.continuum.io/miniconda"


### PR DESCRIPTION
Remove all homebrew Software that is pre-installed in the Travis-CI OS X image.

PS: I wonder what sort of issues we will find once we start re-building everything without the software from homebrew.