### PR TITLE
Use `curl` on Mac (Travis CI)

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -34,7 +34,7 @@ install:
     - |
       MINICONDA_URL="http://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      wget "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH


### PR DESCRIPTION
Mac doesn't come with `wget`. This was supplied through `brew`. As we have uninstalled everything from `brew`, we can't use `wget` any more.

Fortunately, Mac does come with `curl`. The syntax is only slightly different, but we get exactly the same effect. Once Miniconda is installed we can install anything we are willing to build so it is smooth sailing from here on out. :sailboat: 