### PR TITLE
Specify the type of BSD License as 3-Clause for feedstocks

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -5,7 +5,7 @@ Home: {{ package.meta.about.home }}
 
 Package license: {{ package.meta.about.license }}
 
-Feedstock license: BSD
+Feedstock license: BSD 3-Clause
 
 Summary: {{ package.meta.about.summary }}
 


### PR DESCRIPTION
Even though the license file is right there, this felt a little unclear to me so I specified the BSD license version in the feedstock README. Also, felt a little bad having others specify this while we have this glaring omission. So, this should ease our collective conscience. :smile: