### PR TITLE
Provide a mechanism for installing/documenting yum requirements (Pt. 2)

### DIFF
--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -44,6 +44,9 @@ conda update --yes --all
 conda install --yes conda-build==1.18.2
 conda info
 
+# Installs anything from a \`yum_requirements.txt\` file in a recipe with \`yum\`.
+test -f "recipe_root/yum_requirements.txt" && (cat "recipe_root/yum_requirements.txt" | xargs -r yum install -y) || true
+
 {% if build_setup %}
 {{ build_setup }}{% endif -%}
 {%- block build %}


### PR DESCRIPTION
Closes https://github.com/conda-forge/conda-smithy/pull/134 (as we had decided to go this route instead)

This is a very simple proposal that comes out of this discussion on this issue ( https://github.com/conda-forge/conda-forge.github.io/issues/82 ) and this proposed PR ( https://github.com/conda-forge/conda-smithy/pull/134 ). Also, this is the sister proposal of this PR ( https://github.com/conda-forge/staged-recipes/pull/346 ).

Simply continues the same model in PR ( https://github.com/conda-forge/staged-recipes/pull/346 ) where yum requirements are installed from the `yum_requirements.txt` file in the recipe directory (if present and not empty).

To see this in action see this PR ( https://github.com/conda-forge/pyopengl-feedstock/pull/3 ).