### PR TITLE
Pin conda-build to 1.20.0

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -41,7 +41,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       {%- for channel in channels.get('sources', []) %}
       conda config --add channels {{ channel }}
       {% endfor %}


### PR DESCRIPTION
It appears that conda-build 1.20.1 introduced a bug when trying to fix shebangs as explained in this issue ( https://github.com/conda/conda-build/issues/889 ). We are applying this change as part of the pinning fixes in this feedstock ( https://github.com/conda-forge/vigra-feedstock/pull/4 ).