### PR TITLE
Fixes #142

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -15,6 +15,11 @@ class NullUndefined(jinja2.Undefined):
     def __unicode__(self):
         return unicode(self._undefined_name)
 
+    def __getattr__(self, name):
+        return unicode('{}.{}'.format(self, name))
+
+    def __getitem__(self, name):
+        return '{}["{}"]'.format(self, name)
 
 def get_section(parent, name, lints):
     section = parent.get(name, {})

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -222,6 +222,32 @@ class TestCLI_recipe_lint(unittest.TestCase):
             out, _ = child.communicate()
             self.assertEqual(child.returncode, 0, out)
 
+    def test_cli_environ(self):
+        with tmp_directory() as recipe_dir:
+            with open(os.path.join(recipe_dir, 'meta.yaml'), 'w') as fh:
+                fh.write(textwrap.dedent("""
+                    package:
+                        name: 'test_package'
+                    build:
+                        number: 0
+                    test:
+                        requires:
+                            - python {{ environ['PY_VER'] + '*' }}  # [win]
+                    about:
+                        home: something
+                        license: something else
+                        summary: a test recipe
+                    extra:
+                        recipe-maintainers:
+                            - a
+                            - b
+                    """))
+            child = subprocess.Popen(['conda-smithy', 'recipe-lint',
+                                      recipe_dir],
+                                     stdout=subprocess.PIPE)
+            out, _ = child.communicate()
+            self.assertEqual(child.returncode, 0, out)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Not sure we need the `__getattr__` too, but I thought it does not hurt. The test is a simple CLI with `environ` defined for tests like we have in some of the recipes.

Closes #142