### PR TITLE
Workaround Python 3.4 64-bit failure on AppVeyor

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -60,6 +60,10 @@ install:
     - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    # Workaround for Python 3.4 and x64 bug in latest conda-build.
+    # FIXME: Remove once there is a release that fixes the upstream issue
+    # ( https://github.com/conda/conda-build/issues/895 ).
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off


### PR DESCRIPTION
Add workaround for this issue ( https://github.com/conda/conda-build/issues/895 ). Related change in staged-recipes ( https://github.com/conda-forge/staged-recipes/pull/452 ). Related issue ( https://github.com/conda-forge/staged-recipes/issues/448 ).

Applies this workaround only to Python 3.4 64-bit where the issues were seen. This way Python 2.7 64-bit on Windows still benefits from the nice fixes from @patricksnape and @msarahan.