### PR TITLE
Clear Homebrew packages after removal

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -28,7 +28,10 @@ env:
 {% endblock %}
 
 before_install:
+    # Remove homebrew.
     - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
 
 install:
     - |


### PR DESCRIPTION
Even after removing Homebrew packages, the tarballs remain afterwards. These use up memory on the CI, which could be used for other things like intensive compilation. Here we make sure all remnants of these are deleted. The whole process is pretty quick. Similar change is proposed for `staged-recipes` in this PR ( https://github.com/conda-forge/staged-recipes/pull/468 ).