### PR TITLE
Remove the check, and just always register with CircleCI.

### DIFF
--- a/conda_smithy/ci_register.py
+++ b/conda_smithy/ci_register.py
@@ -44,25 +44,16 @@ def add_project_to_circle(user, project):
                'Accept': 'application/json'}
     url_template = ('https://circleci.com/api/v1/{component}?'
                     'circle-token={token}')
-    url = url_template.format(component='projects', token=circle_token)
-    data = {'username': user, 'repo': project}
-    response = requests.get(url, headers=headers)
 
-    if response.status_code != 201:
+    # Note, we used to check to see whether the project was already registered, but it started
+    # timing out once we had too many repos, so now the approach is simply "add it always".
+
+    url = url_template.format(component='project/{}/{}/follow'.format(user, project).lower(), token=circle_token)
+    response = requests.post(url, headers={})
+    # It is a strange response code, but is doing what was asked...
+    if response.status_code != 400:
         response.raise_for_status()
-
-    repos = response.json()
-    matching = [repo for repo in repos if repo['username'] == data['username'] and repo['reponame'] == data['repo']]
-
-    if matching and matching[0].get('followed', False):
-        print(' * {}/{} already enabled on CircleCI'.format(user, project))
-    else:
-        url = url_template.format(component='project/{}/{}/follow'.format(user, project).lower(), token=circle_token)
-        response = requests.post(url, headers={})
-        # It is a strange response code, but is doing what was asked...
-        if response.status_code != 400:
-            response.raise_for_status()
-        print(' * Added to circle-ci')
+    print(' * {}/{} enabled on CircleCI')
 
 
 def add_project_to_appveyor(user, project):


### PR DESCRIPTION
I got sick of the unpredictable response, and wouldn't be surprised if it was because we have too many repos for the API to handle. This PR removes the check before asking to follow a repo, and just *always* follows the repo instead (same effect, less data transferred).