### PR TITLE
Switches to the org image

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -167,7 +167,7 @@ def compute_build_matrix(meta):
 
 def main(forge_file_directory):
     recipe_dir = 'recipe'
-    config = {'docker': {'image': 'pelson/obvious-ci:latest_x64', 'command': 'bash'},
+    config = {'docker': {'image': 'condaforge/linux-anvil', 'command': 'bash'},
               'templates': {'run_docker_build': 'run_docker_build_matrix.tmpl'},
               'travis': [],
               'circle': [],

--- a/conda_smithy/feedstock_content/circle.yml
+++ b/conda_smithy/feedstock_content/circle.yml
@@ -6,8 +6,7 @@ dependencies:
   # Note, we used to use the naive caching of docker images, but found that it was quicker
   # just to pull each time. #rollondockercaching
   override:
-    - docker pull pelson/obvious-ci:latest_x64
-#    - docker pull pelson/conda32_obvious_ci
+    - docker pull condaforge/linux-anvil
 
 test:
   override:


### PR DESCRIPTION
Switches from `pelson/obvious-ci:latest_x64` to `condaforge/obvious-ci`. The source for this image is now maintained in this repo ( https://github.com/conda-forge/docker-images ). It is exactly the same source from before it is just moving to the org. In fact, the source was moved over in this PR ( https://github.com/conda-forge/docker-images/pull/5 ). Similar change proposed to staged-recipes in this PR ( https://github.com/conda-forge/staged-recipes/pull/514 ).