### PR TITLE
Unpin `conda-build` on Circle CI builds

### DIFF
--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -41,7 +41,7 @@ echo "$config" > ~/.condarc
 conda clean --lock
 
 conda update --yes --all
-conda install --yes conda-build==1.18.2
+conda install --yes conda-build
 conda info
 
 {% if build_setup %}


### PR DESCRIPTION
After some [discussion]( https://github.com/conda-forge/staged-recipes/pull/524/files/fb5563b6fd1c9b80b964200ea12b5bd6039b9a62#r61819818 ), we have decided we can drop the pinning to `conda-build` that was originally added in this PR ( https://github.com/conda-forge/conda-smithy/pull/100 ). So, that is what we are doing here.