### PR TITLE
WIP: Add the conda-team channel

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -172,7 +172,10 @@ def main(forge_file_directory):
               'travis': [],
               'circle': [],
               'appveyor': [],
-              'channels': {'sources': ['conda-forge'], 'targets': [['conda-forge', 'main']]},
+              'channels': {
+                  'sources': ['conda-team', 'conda-team/label/dev', 'conda-forge'],
+                  'targets': [['conda-forge', 'main']]
+              },
               'recipe_dir': recipe_dir}
     forge_dir = os.path.abspath(forge_file_directory)
 

--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -56,10 +56,13 @@ install:
     - cmd: set PYTHONUNBUFFERED=1
 
     - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-team
+    - cmd: conda config --add channels conda-team/label/dev
+    - cmd: conda config --add channels conda-forge
     - cmd: conda install -c http://conda.binstar.org/pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    - cmd: conda update --yes --quiet --all
     # Workaround for Python 3.4 and x64 bug in latest conda-build.
     # FIXME: Remove once there is a release that fixes the upstream issue
     # ( https://github.com/conda/conda-build/issues/895 ).

--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -63,10 +63,6 @@ install:
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
     - cmd: conda update --yes --quiet --all
-    # Workaround for Python 3.4 and x64 bug in latest conda-build.
-    # FIXME: Remove once there is a release that fixes the upstream issue
-    # ( https://github.com/conda/conda-build/issues/895 ).
-    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -15,7 +15,7 @@ config=$(cat <<CONDARC
 channels:
 {%- for channel in channels.get('sources', []) | sort %}
  - {{ channel }}
-{% endfor %}
+{%- endfor %}
  - defaults # As we need conda-build
 
 conda-build:

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -47,7 +47,7 @@ install:
       conda config --add channels {{ channel }}
       {%- endfor %}
       conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda install --yes conda-build jinja2 anaconda-client
 
 script:
   - conda build ./{{ recipe_dir }}

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -43,11 +43,11 @@ install:
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
       conda config --set show_channel_urls true
-      conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       {%- for channel in channels.get('sources', []) %}
       conda config --add channels {{ channel }}
-      {% endfor %}
+      {%- endfor %}
+      conda update --yes conda
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
 
 script:
   - conda build ./{{ recipe_dir }}


### PR DESCRIPTION
The conda-team channel is where development builds of `conda-build` are being placed. By adding it to our channels, this will give us a better chance at trying out new features or bug fixes in `conda-build` that are not official released. Hopefully by doing this, we can work with Continuum to iron out any issues before an official release. Also, this should help us try out things that believe are potential fixes.

In addition, this reverts the `conda-build` 1.20.0 pinning on AppVeyor that was added by this PR ( https://github.com/conda-forge/conda-smithy/pull/145 ) as this issue should be resolved in the latest development release by this PR ( https://github.com/conda/conda-build/pull/900 ) ( thanks to the hard work of @msarahan and @mingwandroid 🎉 ). It also reverts the `conda-build` 1.20.0 pinning on Travis CI introduced by this PR ( https://github.com/conda-forge/conda-smithy/pull/143 ) as it should be fixed by this PR ( https://github.com/conda/conda-build/pull/892 ).

cc @msarahan @pelson @ocefpaf

xref: [Gitter message]( https://gitter.im/conda-forge/conda-forge.github.io?at=572d33f53170252648f4b871 )
xref: https://github.com/conda-forge/staged-recipes/pull/571