### PR TITLE
BUG: Make sure file_config is actually a dictionary

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -318,15 +318,16 @@ def main(forge_file_directory):
     else:
         with open(forge_yml, "r") as fh:
             file_config = list(yaml.load_all(fh))[0]
-        # The config is just the union of the defaults, and the overriden
-        # values.
-        for key, value in file_config.items():
-            config_item = config.setdefault(key, value)
-            # Deal with dicts within dicts.
-            if isinstance(value, dict):
-                config_item.update(value)
+        if file_config:
+            # The config is just the union of the defaults, and the overriden
+            # values.
+            for key, value in file_config.items():
+                config_item = config.setdefault(key, value)
+                # Deal with dicts within dicts.
+                if isinstance(value, dict):
+                    config_item.update(value)
     config['package'] = meta = meta_of_feedstock(forge_file_directory)
-    
+
     tmplt_dir = os.path.join(conda_forge_content, 'templates')
     # Load templates from the feedstock in preference to the smithy's templates.
     env = Environment(loader=FileSystemLoader([os.path.join(forge_dir, 'templates'),

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -318,7 +318,7 @@ def main(forge_file_directory):
     else:
         with open(forge_yml, "r") as fh:
             file_config = list(yaml.load_all(fh))[0]
-        if file_config:
+        if isinstance(file_config, dict):
             # The config is just the union of the defaults, and the overriden
             # values.
             for key, value in file_config.items():


### PR DESCRIPTION
at this point in the code path, it is likely that conda-forge.yml was already
created in cli:generate_feedstock_content() where it defaults to an empty list.
Iterating over that empty list raises the following stack trace:

Traceback (most recent call last):
  File "/Users/travis/miniconda/bin/conda-smithy", line 9, in <module>
    load_entry_point('conda-smithy==0.10.0', 'console_scripts', 'conda-smithy')()
  File "/Users/travis/miniconda/lib/python3.5/site-packages/conda_smithy/cli.py", line 228, in main
    args.subcommand_func(args)
  File "/Users/travis/miniconda/lib/python3.5/site-packages/conda_smithy/cli.py", line 101, in __call__
    generate_feedstock_content(feedstock_directory, args.recipe_directory, meta)
  File "/Users/travis/miniconda/lib/python3.5/site-packages/conda_smithy/cli.py", line 32, in generate_feedstock_content
    configure_feedstock.main(target_directory)
  File "/Users/travis/miniconda/lib/python3.5/site-packages/conda_smithy/configure_feedstock.py", line 323, in main
    for key, value in file_config.items():
AttributeError: 'list' object has no attribute 'items'