### PR TITLE
BUG: Gave the jinja rendering in the linter the os namespace.

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -21,6 +21,7 @@ class NullUndefined(jinja2.Undefined):
     def __getitem__(self, name):
         return '{}["{}"]'.format(self, name)
 
+
 def get_section(parent, name, lints):
     section = parent.get(name, {})
     if not isinstance(section, dict):
@@ -137,7 +138,7 @@ def main(recipe_dir):
     env = jinja2.Environment(undefined=NullUndefined)
 
     with open(recipe_meta, 'r') as fh:
-        content = env.from_string(''.join(fh)).render()
+        content = env.from_string(''.join(fh)).render(os=os)
         meta = ruamel.yaml.load(content, ruamel.yaml.RoundTripLoader)
     results = lintify(meta, recipe_dir)
     return results

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -138,6 +138,19 @@ class Test_linter(unittest.TestCase):
             assert_selector("name: foo_py3  #[py3k]", is_good=False)
             assert_selector("name: foo_py3 # [py3k]", is_good=False)
 
+    def test_jinja_os_environ(self):
+        # Test that we can use os.environ in a recipe. We don't care about
+        # the results here.
+        with tmp_directory() as recipe_dir:
+            with open(os.path.join(recipe_dir, 'meta.yaml'), 'w') as fh:
+                fh.write("""
+                        {% set version = os.environ.get('WIBBLE') %}
+                        package:
+                           name: foo
+                           version: {{ version }}
+                         """)
+            lints = linter.main(recipe_dir)
+
     def test_missing_build_number(self):
         expected_message = "The recipe must have a `build/number` section."
 


### PR DESCRIPTION
Not planning to cut a release immediately after merging - we can live without this for a few days.