### PR TITLE
Revert `conda-build` 1.20.0 downgrade to Python 3.4 64-bit AppVeyor

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -56,10 +56,6 @@ install:
     - cmd: conda config --add channels conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
-    # Workaround for Python 3.4 and x64 bug in latest conda-build.
-    # FIXME: Remove once there is a release that fixes the upstream issue
-    # ( https://github.com/conda/conda-build/issues/895 ).
-    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off


### PR DESCRIPTION
Reverts this PR ( https://github.com/conda-forge/conda-smithy/pull/145 ).

This was a workaround for `conda-build` 1.20.1 on AppVeyor Python 3.4 64-bit builds due to this issue ( https://github.com/conda/conda-build/issues/895 ), which was discussed in this issue ( https://github.com/conda-forge/staged-recipes/issues/448 ) at some length by various affected parties. This is believed to be fixed in `conda-build` 1.20.2; so, we are unpinning it here. A similar change has been proposed to staged-recipes ( https://github.com/conda-forge/staged-recipes/pull/618 ).