### PR TITLE
CI Tmplts: Do not make `pip` and `setuptools` dependencies of `python`

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -52,6 +52,7 @@ install:
     - cmd: set PYTHONUNBUFFERED=1
 
     - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --set add_pip_as_python_depedency false
     - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels conda-forge
     - cmd: conda info

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -22,6 +22,7 @@ conda-build:
  root-dir: /feedstock_root/build_artefacts
 
 show_channel_urls: true
+add_pip_as_python_depedency: false
 
 CONDARC
 )

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -43,6 +43,7 @@ install:
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
       conda config --set show_channel_urls true
+      conda config --set add_pip_as_python_depedency false
       conda update --yes conda
       conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       {%- for channel in channels.get('sources', []) %}


### PR DESCRIPTION
This disables adding `pip` and `setuptools` as dependencies of `python`. By doing this, it should make it easier for us to figure out if something requires `setuptools` to install as it will error out if `setuptools` is not listed as a build dependency. Similarly nothing will be able to try to use `pip` to install stuff. This will make it easier to figure out what dependencies we are missing on a package. Further, this will be helpful for packaging `pip` ( https://github.com/conda-forge/staged-recipes/pull/552 ) and `setuptools` ( https://github.com/conda-forge/staged-recipes/pull/551 ) too.

Related change proposed to `staged-recipes` in this PR ( https://github.com/conda-forge/staged-recipes/pull/629 ).