### PR TITLE
Unpin `conda-build` on Travis CI in templates

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -69,10 +69,12 @@ Terminology
 
 Current build status
 ====================
-{% set appveyor_name = github.repo_name.replace('_', '-').replace('.', '-') %}
+{%- set appveyor_badge_name = github.repo_name.replace('_', '-') %}
+{%- set appveyor_url_name = appveyor_badge_name.replace('.', '-') %}
+
 Linux: [![Circle CI](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}}.svg?style=svg)](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}})
 OSX: [![TravisCI](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}}.svg?branch=master)](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}}) 
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/{{github.user_or_org}}/{{appveyor_name}}?svg=True)](https://ci.appveyor.com/project/{{github.user_or_org}}/{{appveyor_name}}/branch/master)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/{{github.user_or_org}}/{{appveyor_badge_name}}?svg=True)](https://ci.appveyor.com/project/{{github.user_or_org}}/{{appveyor_url_name}}/branch/master)
 
 Current release info
 ====================

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -71,7 +71,7 @@ Current build status
 ====================
 {% set appveyor_name = github.repo_name.replace('_', '-').replace('.', '-') %}
 Linux: [![Circle CI](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}}.svg?style=svg)](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}})
-OSX: [![TravisCI](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}}.svg?branch=master)](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}})
+OSX: [![TravisCI](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}}.svg?branch=master)](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}}) 
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/{{github.user_or_org}}/{{appveyor_name}}?svg=True)](https://ci.appveyor.com/project/{{github.user_or_org}}/{{appveyor_name}}/branch/master)
 
 Current release info

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -44,7 +44,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda install --yes conda-build jinja2 anaconda-client
       {%- for channel in channels.get('sources', []) %}
       conda config --add channels {{ channel }}
       {% endfor %}


### PR DESCRIPTION
Reverts https://github.com/conda-forge/conda-smithy/pull/143

Reverts the pinning introduced in this PR ( https://github.com/conda-forge/conda-smithy/pull/143 ). As 1.20.2 is out soon and it should fix a shebang bug ( https://github.com/conda/conda-build/issues/889 ) we were running into on Travis CI, we should upgrade to it. Corresponding change proposed to staged-recipes in this PR ( https://github.com/conda-forge/staged-recipes/pull/608 ).