### PR TITLE
Honor channels -> sources in appveyor

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -54,8 +54,7 @@ install:
     - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
     {%- for channel in channels.get('sources', []) %}
-    - cmd: conda config --add channels {{ channel }}
-    {% endfor %}
+    - cmd: conda config --add channels {{ channel }}{% endfor %}
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
     # Workaround for Python 3.4 and x64 bug in latest conda-build.

--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -53,7 +53,9 @@ install:
 
     - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    {%- for channel in channels.get('sources', []) %}
+    - cmd: conda config --add channels {{ channel }}
+    {% endfor %}
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
     # Workaround for Python 3.4 and x64 bug in latest conda-build.


### PR DESCRIPTION
Up to now the conda-forge channel was hardcoded...

Fixes: https://github.com/conda-forge/conda-smithy/issues/178