### PR TITLE
Fix missing newline in anaconda auth example

### DIFF
--- a/conda_smithy/ci_register.py
+++ b/conda_smithy/ci_register.py
@@ -38,7 +38,7 @@ except KeyError:
             anaconda_token = fh.read().strip()
     except IOError:
         print('No anaconda token. Create a token via\n'
-              '  anaconda auth --create --name conda-smithy --scopes "repos conda api"'
+              '  anaconda auth --create --name conda-smithy --scopes "repos conda api"\n'
               'and put it in ~/.conda-smithy/anaconda.token')
 
 def add_token_to_circle(user, project):


### PR DESCRIPTION
Fixes the problem noticed in https://github.com/conda-forge/conda-smithy/pull/177