### PR TITLE
Make the badge URLs configureable

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -309,6 +309,7 @@ def main(forge_file_directory):
               'circle': {},
               'appveyor': {},
               'channels': {'sources': ['conda-forge'], 'targets': [['conda-forge', 'main']]},
+              'github': {'user_or_org': 'conda-forge', 'repo_name': ''},
               'recipe_dir': recipe_dir}
     forge_dir = os.path.abspath(forge_file_directory)
 
@@ -326,6 +327,8 @@ def main(forge_file_directory):
             if isinstance(value, dict):
                 config_item.update(value)
     config['package'] = meta = meta_of_feedstock(forge_file_directory)
+    if not config['github']['repo_name']:
+        config['github']['repo_name'] = meta.name()+'-feedstock'
     
     tmplt_dir = os.path.join(conda_forge_content, 'templates')
     # Load templates from the feedstock in preference to the smithy's templates.

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -69,10 +69,10 @@ Terminology
 
 Current build status
 ====================
-{% set appveyor_name = package.name().replace('_', '-').replace('.', '-') %}
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/{{package.name()}}-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/{{package.name()}}-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/{{package.name()}}-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/{{package.name()}}-feedstock) 
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/{{appveyor_name}}-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/{{appveyor_name}}-feedstock/branch/master)
+{% set appveyor_name = github.repo_name.replace('_', '-').replace('.', '-') %}
+Linux: [![Circle CI](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}}.svg?style=svg)](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}})
+OSX: [![TravisCI](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}}.svg?branch=master)](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}})
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/{{github.user_or_org}}/{{appveyor_name}}?svg=True)](https://ci.appveyor.com/project/{{github.user_or_org}}/{{appveyor_name}}/branch/master)
 
 Current release info
 ====================


### PR DESCRIPTION
before they hardcoded both the conda-forge github or and the name of the repo to *-feedstock. Now this is overwriteable
by setting a conda-forge.yml setting:

github:
  user_or_org: github-username
  repo_name: github-repo-name

closes: https://github.com/conda-forge/conda-smithy/issues/180