### PR TITLE
Reintroduce whitespace into README.

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -71,7 +71,7 @@ Current build status
 ====================
 {% set appveyor_name = github.repo_name.replace('_', '-').replace('.', '-') %}
 Linux: [![Circle CI](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}}.svg?style=svg)](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}})
-OSX: [![TravisCI](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}}.svg?branch=master)](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}})
+OSX: [![TravisCI](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}}.svg?branch=master)](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}}) 
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/{{github.user_or_org}}/{{appveyor_name}}?svg=True)](https://ci.appveyor.com/project/{{github.user_or_org}}/{{appveyor_name}}/branch/master)
 
 Current release info


### PR DESCRIPTION
Not something I want to do frequently, but in order to avoid PRs for each and every feedstock which fixes just one character, I will re-introduce this whitespace for the v0.10.4 release and revert for the v1.0.