### PR TITLE
Start using `conda-forge-build-setup` to do CI configuration

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -55,12 +55,9 @@ install:
     - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
     {%- for channel in channels.get('sources', []) %}
     - cmd: conda config --add channels {{ channel }}{% endfor %}
-    - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
-    # Workaround for Python 3.4 and x64 bug in latest conda-build.
-    # FIXME: Remove once there is a release that fixes the upstream issue
-    # ( https://github.com/conda/conda-build/issues/895 ).
-    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
+    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -42,7 +42,8 @@ conda clean --lock
 
 conda update --yes --all
 conda install --yes conda-build
-conda info
+conda install --yes conda-forge-build-setup
+source run_conda_forge_build_setup
 
 {% if build_setup %}
 {{ build_setup }}{% endif -%}

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -42,12 +42,14 @@ install:
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
-      conda config --set show_channel_urls true
-      conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       {%- for channel in channels.get('sources', []) %}
       conda config --add channels {{ channel }}
       {% endfor %}
+      conda config --set show_channel_urls true
+      conda update --yes conda
+      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes --quiet conda-forge-build-setup
+      source run_conda_forge_build_setup
 
 script:
   - conda build ./{{ recipe_dir }}


### PR DESCRIPTION
Related https://github.com/conda-forge/staged-recipes/pull/705

Installs `conda-forge-build-setup` and uses the script `run_conda_forge_build_setup` to configure the CIs appropriately for each VM. This is basically the same as what is being done in `staged-recipes` via this PR ( https://github.com/conda-forge/staged-recipes/pull/705 ).

This could use a good careful review.

cc @pelson @ocefpaf