### PR TITLE
[strawman] Add defaults channel explicitly for conda 4.1

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -308,7 +308,7 @@ def main(forge_file_directory):
               'travis': {},
               'circle': {},
               'appveyor': {},
-              'channels': {'sources': ['conda-forge'], 'targets': [['conda-forge', 'main']]},
+              'channels': {'sources': ['defaults', 'conda-forge'], 'targets': [['conda-forge', 'main']]},
               'github': {'user_or_org': 'conda-forge', 'repo_name': ''},
               'recipe_dir': recipe_dir}
     forge_dir = os.path.abspath(forge_file_directory)


### PR DESCRIPTION
On conda 4.1, the behavior of the inclusion of `defaults` has changed:
https://github.com/Anaconda-Platform/support/issues/45

Would just adding `defaults` explicitly avoid any ordering heisenbugs?

