### PR TITLE
Workaround bug drop_defaults

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -51,10 +51,10 @@ install:
     - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
     {%- for channel in channels.get('sources', []) %}
     - cmd: conda config --add channels {{ channel }}{% endfor %}
+    - cmd: conda config --set show_channel_urls true
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
     # Workaround for Python 3.4 and x64 bug in latest conda-build.

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -42,11 +42,11 @@ install:
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
-      conda config --set show_channel_urls true
       conda update --yes conda
       conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       {%- for channel in channels.get('sources', []) %}
       conda config --add channels {{ channel }}
+      conda config --set show_channel_urls true
       {% endfor %}
 
 script:


### PR DESCRIPTION
Workaround issue https://github.com/conda/conda/issues/2669

PS: We probably won't need to merge this as the issue was already resolved. We just need to wait for a new `conda-build` release :wink: 

----
Edit: I am using this to manually re-render a few feedstocks that are failing.