### PR TITLE
unpin conda-build on travis

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -44,7 +44,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda install --yes conda-build jinja2 anaconda-client
       {%- for channel in channels.get('sources', []) %}
       conda config --add channels {{ channel }}
       {% endfor %}


### PR DESCRIPTION
Not sure if the latest `conda-build` is ready for prime time on OS X, but I do know that the pinning is bringing some pain and @gillins and @jakirkham are removing the pin in some feedstocks to fix that.

Ping @msarahan and @pelson.