### PR TITLE
Unpin `conda-build` on Travis CI in templates (v0.10.5?)

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -44,7 +44,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda install --yes conda-build jinja2 anaconda-client
       {%- for channel in channels.get('sources', []) %}
       conda config --add channels {{ channel }}
       {% endfor %}


### PR DESCRIPTION
Reverts https://github.com/conda-forge/conda-smithy/pull/143
Closes https://github.com/conda-forge/conda-smithy/pull/173
Closes https://github.com/conda-forge/conda-smithy/pull/200

Reverts the pinning introduced in this PR ( https://github.com/conda-forge/conda-smithy/pull/143 ). As 1.20.2 is out soon and it should fix a shebang bug ( https://github.com/conda/conda-build/issues/889 ) we were running into on Travis CI, we should upgrade to it. Corresponding change proposed to staged-recipes in this PR ( https://github.com/conda-forge/staged-recipes/pull/608 ).

The situation is become a bit desperate w.r.t. this pinning on Travis CI. Keeping this is resulting in packages that are totally broken (read cannot be installed). This is because this version of `conda-build` packages the `activate`, `conda`, and `deactivate` symlinks generated by `conda`/`conda-env` with the package. However, these should not ever be with any package. As the links don't get fixed, it fails on install. See this issue ( https://github.com/conda-forge/hdf5-feedstock/issues/23 ) for an example. This is widespread.

While some of us are aware of the problem and have been fixing it manually, there are many feedstocks being generated that have not done this and thus are most likely generating broken OS X packages. The sooner we can get this out, the better for all of us. 

Because of how pressing this is I have placed the contents of PR ( https://github.com/conda-forge/conda-smithy/pull/173 ) this against v0.10.x in the hopes of getting v0.10.5 ASAP.

cc @pelson @ocefpaf @msarahan @gillins 

xref: https://github.com/conda-forge/conda-smithy/pull/173
xref: https://github.com/conda-forge/conda-smithy/pull/200