### PR TITLE
Change "User-Agent" in Travis CI header

### DIFF
--- a/conda_smithy/ci_register.py
+++ b/conda_smithy/ci_register.py
@@ -136,7 +136,7 @@ def appveyor_configure(user, project):
 def add_project_to_travis(user, project):
     headers = {
                # If the user-agent isn't defined correctly, we will recieve a 403.
-               'User-Agent': 'MyClient/1.0.0',
+               'User-Agent': 'Travis/1.0',
                'Accept': 'application/vnd.travis-ci.2+json',
                }
     endpoint = 'https://api.travis-ci.org'


### PR DESCRIPTION
So, the `User-Agent` was added to the Travis CI request header in this PR ( https://github.com/conda-forge/conda-smithy/pull/36 ). Not quite sure why this particular `User-Agent` was chosen. Maybe it was just copied from the example in the [Travis CI docs]( https://docs.travis-ci.com/api#with-a-github-token )? Unfortunately Travis CI's docs are mum on this AFAICT. Though they do drop the pearl of wisdom below. Maybe we have to login with the bot periodically? Yuck, but if that helps it should be pretty easy to do.

> Note that therefore the API cannot be used to create new user accounts. The user will have to log in at least once via the web interface before interfacing with the API by other means.

While this seemed to work fine for awhile, it now is causing us grief when trying to generate some feedstocks. Here are some cases where it has failed ( https://github.com/conda-forge/staged-recipes/issues/900#issuecomment-229178358 ) ( https://github.com/conda-forge/staged-recipes/issues/923#issuecomment-229826566 ) ( https://github.com/conda-forge/staged-recipes/issues/923#issuecomment-229828379 ). Though it is not every feedstock that suffers from this issue, it definitely recurs with the same feedstock reliably. In other words, this is really just a brick wall that we hit sometimes, but when we hit we can't go past it.

At @isuruf found this gem ( https://github.com/travis-ci/travis-ci/issues/5649 ), which suggest setting the `User-Agent` to `Travis/1.0`. Though the issue seems to compare this to having no user agent, which is a known failure as pointed out in this [code comment]( https://github.com/conda-forge/conda-smithy/pull/36/files#diff-8666415dcccfaf789819c990341084c8R110 ) from PR ( https://github.com/conda-forge/conda-smithy/pull/36 ). We did have `User-Agent` set to something here, but it just wan't `Travis/1.0`. Here we change it to `Travis/1.0`. I don't really have a good explanation or any evidence for why this should be a better `User-Agent`. That being said, people seem to be having success with it. Maybe we should give it a go?