### PR TITLE
Drop `disabled_appveyor.yml`

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -202,19 +202,13 @@ def render_appveyor(jinja_env, forge_config, forge_dir):
     matrix = sorted(full_matrix, key=sort_without_target_arch)
 
     target_fname = os.path.join(forge_dir, 'appveyor.yml')
-    target_fname_disabled = os.path.join(forge_dir, 'disabled_appveyor.yml')
 
     if not matrix:
         # There are no cases to build (not even a case without any special
         # dependencies), so remove the appveyor.yml if it exists.
         if os.path.exists(target_fname):
-            if os.path.exists(target_fname_disabled):
-                os.remove(target_fname_disabled)
-            os.rename(target_fname, target_fname_disabled)
+            os.remove(target_fname)
     else:
-        if os.path.exists(target_fname_disabled):
-            os.remove(target_fname_disabled)
-
         matrix = prepare_matrix_for_env_vars(matrix)
         forge_config = update_matrix(forge_config, matrix)
         template = jinja_env.get_template('appveyor.yml.tmpl')


### PR DESCRIPTION
This initially seemed like a good idea. Honestly though it feels a bit half-baked in retrospect and doesn't server a very useful purpose. So this reverts PR ( https://github.com/conda-forge/conda-smithy/pull/94 ) to clean out some unnecessary stuff.