### PR TITLE
Specify Travis CI content type as JSON

### DIFF
--- a/conda_smithy/ci_register.py
+++ b/conda_smithy/ci_register.py
@@ -138,6 +138,7 @@ def add_project_to_travis(user, project):
                # If the user-agent isn't defined correctly, we will recieve a 403.
                'User-Agent': 'Travis/1.0',
                'Accept': 'application/vnd.travis-ci.2+json',
+               'Content-Type': 'application/json'
                }
     endpoint = 'https://api.travis-ci.org'
     url = '{}/auth/github'.format(endpoint)


### PR DESCRIPTION
Looks like this may help fix our Travis CI issues. Tested on a large scale locally. Let me explain some history first.

When this first started occurring, @isuruf noted this issue ( https://github.com/travis-ci/travis-ci/issues/5649 ). Based on the changes by others and the discussion in the issue itself, it seemed the takeaway message was that one had to specify a `User-Agent`. We already had one, but we thought we might need to change it. So, we tried PR ( https://github.com/conda-forge/conda-smithy/pull/204 ). While that was not yet put into production, we did test the `User-Agent` in PR ( https://github.com/conda-forge/conda-smithy/pull/206 ) and found it made no difference there. At the time there had been some serious Travis CI issues, so it made sense to @pelson and I to chalk it up to that and wait for the situation to improve before putting any more time into it.

So, I went to apply PR ( https://github.com/conda-forge/conda-smithy/pull/206 ) (disables Travis CI builds if `.travis.yml` file is not present via a setting switch) to all the existing feedstocks. I had already tested it on one and verified it had the intended effect. Also it seems like a pretty non-controversial (and it is pretty easy to change back if needed). Plus, it is a no-op for every feedstock currently. However, since we are moving towards solving issue ( https://github.com/conda-forge/conda-smithy/issues/205 ), I figured we should start flipping these switches on all feedstocks. This would also make for a better test of the code.

However, I kept having issues with the Travis CI API booting me almost immediately. For those unfamiliar, this has plagued us at staged-recipes with issues like ( https://github.com/conda-forge/staged-recipes/issues/900 ) and ( https://github.com/conda-forge/staged-recipes/issues/923 ). Basically it had forced us to call off merging PRs several times at staged-recipes for long periods of time. It has also forced us to manually manage the content in staged-recipes. All of these problems have wrecked havoc on our users and admins. An example traceback of what I saw locally is shown below. Though similar tracebacks can be found elsewhere.

```
Traceback (most recent call last):
  File "/zopt/conda2/bin/conda-smithy", line 9, in <module>
    load_entry_point('conda-smithy==0.10.5.dev17+add.travis.config', 'console_scripts', 'conda-smithy')()
  File "/zopt/conda2/lib/python2.7/site-packages/conda_smithy/cli.py", line 234, in main
    args.subcommand_func(args)
  File "/zopt/conda2/lib/python2.7/site-packages/conda_smithy/cli.py", line 157, in __call__
    ci_register.add_project_to_travis(owner, repo)
  File "/zopt/conda2/lib/python2.7/site-packages/conda_smithy/ci_register.py", line 147, in add_project_to_travis
    response.raise_for_status()
  File "/zopt/conda2/lib/python2.7/site-packages/requests/models.py", line 844, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://api.travis-ci.org/auth/github
```

I looked at TravisPy and there was [nothing relevant there]( https://github.com/menegazzo/travispy/blob/3bdbf9b0fa3b89b8efbdccef50e077ef8f27fad8/travispy/travispy.py#L48-L51 ). They seem to do the same thing we do, but is less sophisticated. I looked at some other people's changes in response to issue ( https://github.com/travis-ci/travis-ci/issues/5649 ). However, they appeared to be adding the `User-Agent` and possibly nothing else. I almost gave up when I noticed they specified another header, `Content-Type: application/json`.

As this is something we don't already include, I went ahead and made this change to PR ( https://github.com/conda-forge/conda-smithy/pull/206 ). It seemed to make a huge difference. Before long I had run the `conda smithy register-ci` CI on 90 feedstocks without issues. Now after the 90th one it started to have issues again. Still I never got through more than 1 or 2 before. It may be that Travis CI also implements rate limiting like GitHub. In fact this SO [question]( http://stackoverflow.com/questions/32608501/what-are-travis-ci-api-rate-limits ) and connected comments suggest this may very well be the case. Further it suggest that when I got cutoff I may very well have been close. Am asking about Travis CI's rate limit in this issue ( https://github.com/travis-ci/travis-ci/issues/6257 ).

In any event, this is a simple and productive change. It may not solve the whole problem, but it is a big enough fix that is worth merging and potentially worthy of a bugfix release.