### PR TITLE
WIP: Activate conda environment on AppVeyor

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -48,7 +48,7 @@ install:
     - cmd: rmdir C:\cygwin /s /q
     - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
     - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
-    - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
+    - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
     - cmd: conda config --set show_channel_urls true


### PR DESCRIPTION
This changes to running the activate script on AppVeyor to properly activate the conda `root` environment. Basically lifted from this PR ( https://github.com/bollwyvl/nb_conda_kernels-feedstock/pull/1 ) by @msarahan. Similar change proposed for `staged-recipes` in PR (https://github.com/conda-forge/staged-recipes/pull/982 ). @msarahan, could you please double check that this is done correctly?