### PR TITLE
Fixes a typo in the README template

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -9,7 +9,7 @@ Feedstock license: BSD 3-Clause
 
 Summary: {{ package.meta.about.summary }}
 
-{% if package.meta.extra and package.meta.extra.description %}{{ pacakge.meta.extra.description }}{% endif %}
+{% if package.meta.extra and package.meta.extra.description %}{{ package.meta.extra.description }}{% endif %}
 
 Installing {{ package.name() }}
 ==========={{ '=' * package.name()|length }}


### PR DESCRIPTION
Corrects `pacakge` -> `package`.