### PR TITLE
Disabled CI badge

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -40,6 +40,7 @@ def render_run_docker_build(jinja_env, forge_config, forge_dir):
         if os.path.exists(target_fname):
             os.remove(target_fname)
     else:
+        forge_config["ci_enabled"].append("circle")
         matrix = prepare_matrix_for_env_vars(matrix)
         forge_config = update_matrix(forge_config, matrix)
 
@@ -128,6 +129,7 @@ def render_travis(jinja_env, forge_config, forge_dir):
         if os.path.exists(target_fname):
             os.remove(target_fname)
     else:
+        forge_config["ci_enabled"].append("travis")
         matrix = prepare_matrix_for_env_vars(matrix)
         forge_config = update_matrix(forge_config, matrix)
         template = jinja_env.get_template('travis.yml.tmpl')
@@ -229,6 +231,7 @@ def render_appveyor(jinja_env, forge_config, forge_dir):
         if os.path.exists(target_fname):
             os.remove(target_fname)
     else:
+        forge_config["ci_enabled"].append("appveyor")
         matrix = prepare_matrix_for_env_vars(matrix)
         forge_config = update_matrix(forge_config, matrix)
         template = jinja_env.get_template('appveyor.yml.tmpl')
@@ -319,6 +322,7 @@ def main(forge_file_directory):
     recipe_dir = 'recipe'
     config = {'docker': {'image': 'condaforge/linux-anvil', 'command': 'bash'},
               'templates': {'run_docker_build': 'run_docker_build_matrix.tmpl'},
+              'ci_enabled': [],
               'travis': {},
               'circle': {},
               'appveyor': {},

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -349,7 +349,17 @@ def main(forge_file_directory):
     config['package'] = meta = meta_of_feedstock(forge_file_directory)
     if not config['github']['repo_name']:
         config['github']['repo_name'] = meta.name()+'-feedstock'
-    
+
+    for each_ci in ["travis", "circle", "appveyor"]:
+        if config[each_ci].pop("enabled", None):
+            warnings.warn(
+                "It is not allowed to set the `enabled` parameter for `%s`."
+                " All CIs are enabled by default. To disable a CI, please"
+                " add `skip: true` to the `build` section of `meta.yaml`"
+                " and an appropriate selector so as to disable the build." \
+                % each_ci
+            )
+
     tmplt_dir = os.path.join(conda_forge_content, 'templates')
     # Load templates from the feedstock in preference to the smithy's templates.
     env = Environment(loader=FileSystemLoader([os.path.join(forge_dir, 'templates'),

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -298,7 +298,11 @@ def copytree(src, dst, ignore=(), root_dst=None):
 def copy_feedstock_content(forge_dir):
     feedstock_content = os.path.join(conda_forge_content,
                                      'feedstock_content')
-    copytree(feedstock_content, forge_dir, 'README')
+    copytree(
+        feedstock_content,
+        forge_dir,
+        ['README', 'ci_support/disabled.svg']
+    )
 
 
 def meta_of_feedstock(forge_dir):

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -37,10 +37,11 @@ def render_run_docker_build(jinja_env, forge_config, forge_dir):
     if not matrix:
         # There are no cases to build (not even a case without any special
         # dependencies), so remove the run_docker_build.sh if it exists.
+        forge_config["circle"]["enabled"] = False
         if os.path.exists(target_fname):
             os.remove(target_fname)
     else:
-        forge_config["ci_enabled"].append("circle")
+        forge_config["circle"]["enabled"] = True
         matrix = prepare_matrix_for_env_vars(matrix)
         forge_config = update_matrix(forge_config, matrix)
 
@@ -126,10 +127,11 @@ def render_travis(jinja_env, forge_config, forge_dir):
     if not matrix:
         # There are no cases to build (not even a case without any special
         # dependencies), so remove the .travis.yml if it exists.
+        forge_config["travis"]["enabled"] = False
         if os.path.exists(target_fname):
             os.remove(target_fname)
     else:
-        forge_config["ci_enabled"].append("travis")
+        forge_config["travis"]["enabled"] = True
         matrix = prepare_matrix_for_env_vars(matrix)
         forge_config = update_matrix(forge_config, matrix)
         template = jinja_env.get_template('travis.yml.tmpl')
@@ -228,10 +230,11 @@ def render_appveyor(jinja_env, forge_config, forge_dir):
     if not matrix:
         # There are no cases to build (not even a case without any special
         # dependencies), so remove the appveyor.yml if it exists.
+        forge_config["appveyor"]["enabled"] = False
         if os.path.exists(target_fname):
             os.remove(target_fname)
     else:
-        forge_config["ci_enabled"].append("appveyor")
+        forge_config["appveyor"]["enabled"] = True
         matrix = prepare_matrix_for_env_vars(matrix)
         forge_config = update_matrix(forge_config, matrix)
         template = jinja_env.get_template('appveyor.yml.tmpl')
@@ -322,7 +325,6 @@ def main(forge_file_directory):
     recipe_dir = 'recipe'
     config = {'docker': {'image': 'condaforge/linux-anvil', 'command': 'bash'},
               'templates': {'run_docker_build': 'run_docker_build_matrix.tmpl'},
-              'ci_enabled': [],
               'travis': {},
               'circle': {},
               'appveyor': {},

--- a/conda_smithy/feedstock_content/ci_support/disabled.svg
+++ b/conda_smithy/feedstock_content/ci_support/disabled.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="92" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <mask id="a">
+        <rect width="92" height="20" rx="3" fill="#fff" />
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h37v20H0z" />
+        <path fill="#9f9f9f" d="M37 0h55v20H37z" />
+        <path fill="url(#b)" d="M0 0h92v20H0z" />
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="18.5" y="15" fill="#010101" fill-opacity=".3">build</text>
+        <text x="18.5" y="14">build</text>
+        <text x="63.5" y="15" fill="#010101" fill-opacity=".3">disabled</text>
+        <text x="63.5" y="14">disabled</text>
+    </g>
+</svg>

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -73,17 +73,17 @@ Current build status
 {%- set appveyor_url_name = appveyor_badge_name.replace('.', '-') %}
 {%- set disabled_badge_url = "https://cdn.rawgit.com/conda-forge/conda-smithy/922e8b413e290a1dc5d012134abc179dd5080153/conda_smithy/feedstock_content/ci_support/disabled.svg" %}
 {# #}
-{%- if "circle" in ci_enabled %}
+{%- if circle.enabled %}
 Linux: [![Circle CI](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}}.svg?style=svg)](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}})
 {%- else %}
 Linux: ![]({{ disabled_badge_url }})
 {%- endif %}
-{%- if "travis" in ci_enabled %}
+{%- if travis.enabled %}
 OSX: [![TravisCI](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}}.svg?branch=master)](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}})
 {%- else %}
 OSX: ![]({{ disabled_badge_url }})
 {%- endif %}
-{%- if "appveyor" in ci_enabled %}
+{%- if appveyor.enabled %}
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/{{github.user_or_org}}/{{appveyor_badge_name}}?svg=True)](https://ci.appveyor.com/project/{{github.user_or_org}}/{{appveyor_url_name}}/branch/master)
 {%- else %}
 Windows: ![]({{ disabled_badge_url }})

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -71,7 +71,7 @@ Current build status
 ====================
 {%- set appveyor_badge_name = github.repo_name.replace('_', '-') %}
 {%- set appveyor_url_name = appveyor_badge_name.replace('.', '-') %}
-{%- set disabled_badge_url = "ci_support/disabled.svg" %}
+{%- set disabled_badge_url = "https://cdn.rawgit.com/%s/%s/master/ci_support/disabled.svg"|format(github.user_or_org, github.repo_name) %}
 {# #}
 {%- if "circle" in ci_enabled %}
 Linux: [![Circle CI](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}}.svg?style=svg)](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}})

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -71,7 +71,7 @@ Current build status
 ====================
 {%- set appveyor_badge_name = github.repo_name.replace('_', '-') %}
 {%- set appveyor_url_name = appveyor_badge_name.replace('.', '-') %}
-{%- set disabled_badge_url = "https://cdn.rawgit.com/%s/%s/master/ci_support/disabled.svg"|format(github.user_or_org, github.repo_name) %}
+{%- set disabled_badge_url = "https://cdn.rawgit.com/conda-forge/conda-smithy/922e8b413e290a1dc5d012134abc179dd5080153/conda_smithy/feedstock_content/ci_support/disabled.svg" %}
 {# #}
 {%- if "circle" in ci_enabled %}
 Linux: [![Circle CI](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}}.svg?style=svg)](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}})

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -71,10 +71,23 @@ Current build status
 ====================
 {%- set appveyor_badge_name = github.repo_name.replace('_', '-') %}
 {%- set appveyor_url_name = appveyor_badge_name.replace('.', '-') %}
-
+{%- set disabled_badge_url = "ci_support/disabled.svg" %}
+{# #}
+{%- if "circle" in ci_enabled %}
 Linux: [![Circle CI](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}}.svg?style=svg)](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}})
+{%- else %}
+Linux: ![]({{ disabled_badge_url }})
+{%- endif %}
+{%- if "travis" in ci_enabled %}
 OSX: [![TravisCI](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}}.svg?branch=master)](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}})
+{%- else %}
+OSX: ![]({{ disabled_badge_url }})
+{%- endif %}
+{%- if "appveyor" in ci_enabled %}
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/{{github.user_or_org}}/{{appveyor_badge_name}}?svg=True)](https://ci.appveyor.com/project/{{github.user_or_org}}/{{appveyor_url_name}}/branch/master)
+{%- else %}
+Windows: ![]({{ disabled_badge_url }})
+{%- endif %}
 
 Current release info
 ====================


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-smithy/issues/119

This places a disabled CI badge in place of any CI that is not operational. It also removes any link to that CI. As soon as the `skip` condition in the `meta.yaml` changes and the recipe is re-rendered, the badge will change back to the CI status and properly link to it. This basically works and is ready to go. Here is an [example]( https://github.com/conda-forge/inkscape-feedstock/blob/fde93d04d76b09ae135314752ed82885ad1c54cd/README.md ).

cc @ocefpaf @pelson @janschulz