### PR TITLE
Fix `description` addition to the README template

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -9,7 +9,7 @@ Feedstock license: BSD 3-Clause
 
 Summary: {{ package.meta.about.summary }}
 
-{% if package.meta.extra and package.meta.extra.description %}{{ package.meta.extra.description }}{% endif %}
+{% if package.meta.about.description %}{{ package.meta.about.description }}{% endif %}
 
 Installing {{ package.name() }}
 ==========={{ '=' * package.name()|length }}


### PR DESCRIPTION
This follows-on from PR ( https://github.com/conda-forge/conda-smithy/pull/227 ). We were trying to pickup the `description` from `extra` previously. Though I believe we wanted to pick this up from `about`. Feel free to correct me if I'm misunderstanding something.