### PR TITLE
Correctly set the headers for *all* Travis requests.

### DIFF
--- a/conda_smithy/ci_register.py
+++ b/conda_smithy/ci_register.py
@@ -151,8 +151,9 @@ def appveyor_configure(user, project):
     content = response.json()
     settings = content['settings']
     skip_appveyor = u'skipBranchesWithoutAppveyorYml'
-    print('{: <30}: Current setting for {} = {}.'
-          ''.format(project, skip_appveyor, settings[skip_appveyor]))
+    if not settings[skip_appveyor]:
+        print('{: <30}: Current setting for {} = {}.'
+              ''.format(project, skip_appveyor, settings[skip_appveyor]))
     settings[skip_appveyor] = True
     url = 'https://ci.appveyor.com/api/projects'.format(user, project)
 

--- a/conda_smithy/vendored/travis_encrypt.py
+++ b/conda_smithy/vendored/travis_encrypt.py
@@ -42,16 +42,14 @@ def handle_args():
 
 def get_public_key(repo):
     keyurl = 'https://api.travis-ci.org/repos/{0}/key'.format(repo)
-    try:
-        r = requests.get(keyurl)
-        r.raise_for_status()
-    except Exception as e:
-        raise SystemExit(e)
-    else:
-        try:
-            key = r.json()
-        except Exception as e:
-            raise SystemExit(e)
+    r = requests.get(keyurl,
+                     headers={
+                       # If the user-agent isn't defined correctly, we will recieve a 403.
+                       'User-Agent': 'Travis/1.0',
+                       'Accept': 'application/vnd.travis-ci.2+json',
+                       'Content-Type': 'application/json'})
+    r.raise_for_status()
+    key = r.json()
 
     return key.get('key')
 


### PR DESCRIPTION
Tidies up some unnecessary std out, and uses appropriate headers when requesting the public key with the Travis API.