### PR TITLE
Fast finish fallback if CircleCI skip fails

### DIFF
--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -1,4 +1,4 @@
-{%- block env -%}
+{%- block env_branches -%}
 {%- if not matrix -%}
 general:
   branches:
@@ -7,6 +7,8 @@ general:
 
 {% endif -%}
 {% endblock -%}
+{% block env_dependencies -%}
+{%- if matrix -%}
 machine:
   services:
     - docker
@@ -17,8 +19,16 @@ dependencies:
   override:
     - docker pull condaforge/linux-anvil
 
+{% endif -%}
+{% endblock -%}
 test:
   override:
+{%- block env_test %}
+{%- if matrix %}
     # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
     - ./ci_support/run_docker_build.sh
-{# Keep the terminal newline. #}
+{% else %}
+    # In case the skip fails for some reason, do a fast finish.
+    - exit 0
+{% endif -%}
+{%- endblock %}


### PR DESCRIPTION
If a recipe does not build on Linux, we made a changed to the `circle.yml` so that CircleCI does not build the feedstock. This was done in PR ( https://github.com/conda-forge/conda-smithy/pull/218 ). It was demonstrated to work correctly in some test cases. Also this has worked largely for CircleCI builds encountered thus far.

However, today I noticed a [build failure]( https://circleci.com/gh/conda-forge/anypytools-feedstock/1 ) for the [anypytools-feedstock]( https://github.com/conda-forge/anypytools-feedstock ) even though that feedstock should only build on AppVeyor. To see if something was systemically going wrong, I added PR ( https://github.com/conda-forge/anypytools-feedstock/pull/1 ), which appeared to do the right thing and generate a [skipped build]( https://circleci.com/gh/conda-forge/anypytools-feedstock/2 ). So, I went ahead and added a [post]( https://discuss.circleci.com/t/circleci-built-skipped-branch-commit/5285 ) on CircleCI's discussion board to see what caused this unusual failure.

In the event that this happens again, it seems prudent for us to have a fallback that generates a passing status and runs quickly. This PR proposes the following changes. We still keep the skip as this largely works well. If the skip is ignored, we do not pull the docker image as we don't intend to use it nor do we have the script to. Also, we override the test phase to simply run `true`, which will pass. This should make the build finish fast and exit with a clean status if it runs.