### PR TITLE
try to improve README.md template a bit

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -90,8 +90,8 @@ package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
-conda-forge channel, whereupon the built conda packages will be available for
-everybody to install and use from `conda-forge` channel.
+`conda-forge` channel, whereupon the built conda packages will be available for
+everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/{{ package.name() }}-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -85,12 +85,17 @@ Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/{{package.
 Updating {{ package.name() }}-feedstock
 ========={{ '=' * package.name()|length }}==========
 
-If you would like to improve the {{ package.name() }} recipe, please take the normal
-route of forking this repository and submitting a PR. Upon submission, your changes will
-be run on the appropriate platforms to give the reviewer an opportunity to confirm that the
-changes result in a successful build. Once merged, the recipe will be re-built and uploaded
-automatically to the conda-forge channel, whereupon they will be available for everybody to
-install and use.
+If you would like to improve the {{ package.name() }} recipe or build a new
+package version, please fork this repository and submit a PR. Upon submission,
+your changes will be run on the appropriate platforms to give the reviewer an
+opportunity to confirm that the changes result in a successful build. Once
+merged, the recipe will be re-built and uploaded automatically to the
+conda-forge channel, whereupon the built conda packages will be available for
+everybody to install and use from `conda-forge` channel.
+Note that all branches in the conda-forge/{{ package.name() }}-feedstock are
+immediately built and any created packages are uploaded, so PRs should be based
+on branches in forks and branches in the main repository should only be used to
+build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase


### PR DESCRIPTION
Mostly to clarify the implications of pushing branches to the main feedstock repository, which immediately deploy built packages (in contrast to PRs from forks).