### PR TITLE
Use shield style CircleCI badge

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -72,7 +72,7 @@ Current build status
 {%- set appveyor_badge_name = github.repo_name.replace('_', '-') %}
 {%- set appveyor_url_name = appveyor_badge_name.replace('.', '-') %}
 
-Linux: [![Circle CI](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}}.svg?style=svg)](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}})
+Linux: [![Circle CI](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}}.svg?style=shield)](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}})
 OSX: [![TravisCI](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}}.svg?branch=master)](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}})
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/{{github.user_or_org}}/{{appveyor_badge_name}}?svg=True)](https://ci.appveyor.com/project/{{github.user_or_org}}/{{appveyor_url_name}}/branch/master)
 


### PR DESCRIPTION
Changes the CircleCI badge to look a bit more like the other CI badges by using the shield style.

For an example, re-rendered the [rank_filter feedstock]( https://github.com/conda-forge/rank_filter-feedstock ) in PR ( https://github.com/conda-forge/rank_filter-feedstock/pull/10 ). See an example of the new CircleCI badge in this [README]( https://github.com/conda-forge/rank_filter-feedstock/blob/00420a91da28f2435f3b8bfa17855c68789a4aa2/README.md#current-build-status ).