### PR TITLE
More info why circle ci could be skipped

### DIFF
--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -28,7 +28,7 @@ test:
     # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
     - ./ci_support/run_docker_build.sh
 {% else %}
-    # In case the skip fails for some reason, do a fast finish.
+    # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.
     - exit 0
 {% endif -%}
 {%- endblock %}


### PR DESCRIPTION
As per the discussion in https://github.com/conda-forge/conda-smithy/pull/242/files/8bdc89c7284fa19f6a8d71fc1674123bfff7e0a7#r73888812