### PR TITLE
Unicode no longer raises within the linter + test

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -1,3 +1,4 @@
+import io
 import os
 import re
 
@@ -90,7 +91,7 @@ def lintify(meta, recipe_dir=None):
         bad_selectors = []
         # Good selectors look like ".*\s\s#\s[...]"
         good_selectors_pat = re.compile(r'(.+?)\s{2,}#\s\[(.+)\](?(2).*)$')
-        with open(meta_fname, 'r') as fh:
+        with io.open(meta_fname, 'rt') as fh:
             for selector_line in selector_lines(fh):
                 if not good_selectors_pat.match(selector_line):
                     bad_selectors.append(selector_line)
@@ -142,7 +143,7 @@ def main(recipe_dir):
 
     env = jinja2.Environment(undefined=NullUndefined)
 
-    with open(recipe_meta, 'r') as fh:
+    with io.open(recipe_meta, 'rt') as fh:
         content = env.from_string(''.join(fh)).render(os=os)
         meta = ruamel.yaml.load(content, ruamel.yaml.RoundTripLoader)
     results = lintify(meta, recipe_dir)

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -279,6 +279,7 @@ class TestCLI_recipe_lint(unittest.TestCase):
                         home: something
                         license: something else
                         summary: αβɣ
+                        description: moɿɘ uniɔobɘ!
                          """)
             # Just run it and make sure it does not raise.
             linter.main(recipe_dir)

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -1,6 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 from __future__ import print_function
 from collections import OrderedDict
 from contextlib import contextmanager
+import io
 import os
 import shutil
 import subprocess
@@ -261,6 +264,24 @@ class TestCLI_recipe_lint(unittest.TestCase):
             out, _ = child.communicate()
             self.assertEqual(child.returncode, 0, out)
 
+    def test_unicode(self):
+        """
+        Tests that unicode does not confuse the linter.
+        """
+        with tmp_directory() as recipe_dir:
+            with io.open(os.path.join(recipe_dir, 'meta.yaml'), 'wt') as fh:
+                fh.write(u"""
+                    package:
+                        name: 'test_package'
+                    build:
+                        number: 0
+                    about:
+                        home: something
+                        license: something else
+                        summary: αβɣ
+                         """)
+            # Just run it and make sure it does not raise.
+            linter.main(recipe_dir)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As the title says - this simple PR makes sure the linter can parse files with unicode under Python 2.7 (it did already work before that on Python 3.5). I did not test the full chain up to sending the reports to Github - only that the linter no longer raises if it encounters a file with non-ASCII chars.

I've already hit this bug twice using conda-forge and I hope this alleviates it a bit.