### PR TITLE
Set OS on Travis CI

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -6,7 +6,9 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yaml and/or the recipe/meta.yaml.
 
-language: objective-c
+language: generic
+
+os: osx
 
 {% block env -%}
 {% if matrix[0] or travis.secure -%}


### PR DESCRIPTION
Sets OS X on Travis CI explicitly. Uses a generic VM otherwise.

See PR ( https://github.com/conda-forge/libgfortran-feedstock/pull/5 ) for a test of this re-rendering.