### PR TITLE
Fix AppVeyor badge again

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -69,12 +69,11 @@ Terminology
 
 Current build status
 ====================
-{%- set appveyor_badge_name = github.repo_name.replace('_', '-') %}
-{%- set appveyor_url_name = appveyor_badge_name.replace('.', '-') %}
+{%- set appveyor_url_name = github.repo_name.replace('_', '-').replace('.', '-') %}
 
 Linux: [![Circle CI](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}}.svg?style=svg)](https://circleci.com/gh/{{github.user_or_org}}/{{github.repo_name}})
 OSX: [![TravisCI](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}}.svg?branch=master)](https://travis-ci.org/{{github.user_or_org}}/{{github.repo_name}})
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/{{github.user_or_org}}/{{appveyor_badge_name}}?svg=True)](https://ci.appveyor.com/project/{{github.user_or_org}}/{{appveyor_url_name}}/branch/master)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/{{github.user_or_org}}/{{github.repo_name}}?svg=True)](https://ci.appveyor.com/project/{{github.user_or_org}}/{{appveyor_url_name}}/branch/master)
 
 Current release info
 ====================


### PR DESCRIPTION
Another tweak to how we handle AppVeyor badges following PR ( https://github.com/conda-forge/conda-smithy/pull/195 ).

Appears that AppVeyor made a change to how they handle the badge icon (not the link). In particular, they now want to keep underscores ( `_` ) in the icon if they can. See PR ( https://github.com/conda-forge/line_profiler-feedstock/pull/2 ) for an example of this problem or any feedstock building on AppVeyor that has an underscore. So this is a tweak to handle that problem.

Examples of this re-rendering can be seen in the PRs below.

* https://github.com/conda-forge/line_profiler-feedstock/pull/4
* https://github.com/conda-forge/pyomo.extras-feedstock/pull/10 (no-op as expected)
* https://github.com/conda-forge/thredds_crawler-feedstock/pull/8

Used the commit immediately after [`v1.0.3`]( https://github.com/conda-forge/conda-smithy/releases/tag/v1.0.3 ), which is commit ( https://github.com/conda-forge/conda-smithy/commit/cc27a51e366c7df42c5998c953f9193b112ccdd1 ). Did this to reduce noise in the diffs. Also re-rendered after solving merge conflicts with `master`. The AppVeyor badges were unchanged in all cases and remained visible.