### PR TITLE
Error out on Travis upload failure

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -53,8 +53,6 @@ install:
 
 script:
   - conda build ./{{ recipe_dir }}
-
-after_success:
 {% for owner, channel in channels['targets'] %}
   - ./ci_support/upload_or_check_non_existence.py ./{{ recipe_dir }} {{ owner }} --channel={{ channel }}
 {% endfor %}


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-smithy/issues/267

Previously if an upload failed on Travis CI, the build still passed. This is because [`after_success`]( https://github.com/conda-forge/conda-smithy/blob/3f49bcea082d55b638f36bef2435b30ff6259c67/conda_smithy/templates/travis.yml.tmpl#L57-L60 ) simply [ignores any exit code]( https://docs.travis-ci.com/user/customizing-the-build#Breaking-the-Build ) (even non-zero ones). As a result, it wouldn't be obvious that an upload failed or that one should check at all. Moving the upload section into the `script` section should at least ensure that if the upload fails the exit status will be respected and thus fail the build. As a result, users should be able to see this failure clearly.
