### PR TITLE
adjust fudge_subdir for non-global config in conda-build 2

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -20,8 +20,8 @@ conda_forge_content = os.path.abspath(os.path.dirname(__file__))
 
 
 def render_run_docker_build(jinja_env, forge_config, forge_dir):
-    with fudge_subdir('linux-64'):
-        meta = forge_config['package']
+    meta = forge_config['package']
+    with fudge_subdir('linux-64', meta):
         meta.parse_again()
         matrix = compute_build_matrix(meta, forge_config.get('matrix'))
         cases_not_skipped = []
@@ -79,8 +79,8 @@ def render_run_docker_build(jinja_env, forge_config, forge_dir):
 
 
 def render_circle(jinja_env, forge_config, forge_dir):
-    with fudge_subdir('linux-64'):
-        meta = forge_config['package']
+    meta = forge_config['package']
+    with fudge_subdir('linux-64', meta):
         meta.parse_again()
         matrix = compute_build_matrix(meta, forge_config.get('matrix'))
 
@@ -101,7 +101,7 @@ def render_circle(jinja_env, forge_config, forge_dir):
 
 
 @contextmanager
-def fudge_subdir(subdir):
+def fudge_subdir(subdir, meta=None):
     """
     Override the subdir (aka platform) that conda and conda_build see
     both when fetching the index and in parsing conda build MetaData.
@@ -109,22 +109,25 @@ def fudge_subdir(subdir):
     """
     # Store conda-build and conda.config's existing settings.
     conda_orig = conda.config.subdir
-    cb_orig = conda_build.metadata.subdir
+    if meta:
+        cb_orig = meta.config.subdir
 
     # Set them to what we want.
     conda.config.subdir = subdir
-    conda_build.metadata.subdir = subdir
+    if meta:
+        meta.config.subdir = subdir
 
     yield
 
     # Set them back to what they were
     conda.config.subdir = conda_orig
-    conda_build.metadata.subdir = cb_orig
+    if meta:
+        meta.config.subdir = cb_orig
 
 
 def render_travis(jinja_env, forge_config, forge_dir):
-    with fudge_subdir('osx-64'):
-        meta = forge_config['package']
+    meta = forge_config['package']
+    with fudge_subdir('osx-64', meta):
         meta.parse_again()
         matrix = compute_build_matrix(meta, forge_config.get('matrix'))
 
@@ -221,8 +224,8 @@ def sort_without_target_arch(case):
 def render_appveyor(jinja_env, forge_config, forge_dir):
     full_matrix = []
     for platform, arch in [['win-32', 'x86'], ['win-64', 'x64']]:
-        with fudge_subdir(platform):
-            meta = forge_config['package']
+        meta = forge_config['package']
+        with fudge_subdir(platform, meta):
             meta.parse_again()
             matrix = compute_build_matrix(meta, forge_config.get('matrix'))
 

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -109,20 +109,26 @@ def fudge_subdir(subdir, meta=None):
     """
     # Store conda-build and conda.config's existing settings.
     conda_orig = conda.config.subdir
-    if meta:
+    if meta and hasattr(meta, 'config'):
         cb_orig = meta.config.subdir
+    else:
+        cb_meta_orig = conda_build.metadata.subdir
 
     # Set them to what we want.
     conda.config.subdir = subdir
-    if meta:
+    if meta and hasattr(meta, 'config'):
         meta.config.subdir = subdir
+    else:
+        conda_build.metadata.subdir = subdir
 
     yield
 
     # Set them back to what they were
     conda.config.subdir = conda_orig
-    if meta:
+    if meta and hasattr(meta, 'config'):
         meta.config.subdir = cb_orig
+    else:
+        conda_build.metadata.subdir = cb_meta_orig
 
 
 def render_travis(jinja_env, forge_config, forge_dir):

--- a/conda_smithy/tests/test_configure_feedstock.py
+++ b/conda_smithy/tests/test_configure_feedstock.py
@@ -28,11 +28,11 @@ class Test_fudge_subdir(unittest.TestCase):
                            name: foo_the_rest  # [not (win or osx)]
                          """)
             meta = conda_build.metadata.MetaData(recipe_dir)
-            with cnfgr_fdstk.fudge_subdir('win-64'):
+            with cnfgr_fdstk.fudge_subdir('win-64', meta):
                 meta.parse_again()
                 self.assertEqual(meta.name(), 'foo_win')
 
-            with cnfgr_fdstk.fudge_subdir('osx-64'):
+            with cnfgr_fdstk.fudge_subdir('osx-64', meta):
                 meta.parse_again()
                 self.assertEqual(meta.name(), 'foo_osx')
 

--- a/conda_smithy/tests/test_configure_feedstock.py
+++ b/conda_smithy/tests/test_configure_feedstock.py
@@ -37,11 +37,21 @@ class Test_fudge_subdir(unittest.TestCase):
                 self.assertEqual(meta.name(), 'foo_osx')
 
     def test_fetch_index(self):
+        with tmp_directory() as recipe_dir:
+            with open(os.path.join(recipe_dir, 'meta.yaml'), 'w') as fh:
+                fh.write("""
+                        package:
+                            name: foo_win  # [win]
+                            name: foo_osx  # [osx]
+                            name: foo_the_rest  # [not (win or osx)]
+                            """)
+            meta = conda_build.metadata.MetaData(recipe_dir)
+
         # Get the index for OSX and Windows. They should be different.
 
-        with cnfgr_fdstk.fudge_subdir('win-64'):
+        with cnfgr_fdstk.fudge_subdir('win-64', meta):
             win_index = conda.api.get_index()
-        with cnfgr_fdstk.fudge_subdir('osx-64'):
+        with cnfgr_fdstk.fudge_subdir('osx-64', meta):
             osx_index = conda.api.get_index()
         self.assertNotEqual(win_index.keys(), osx_index.keys(),
                             ('The keys for the Windows and OSX index were the same.'


### PR DESCRIPTION
Same story here as conda-build-all.  Changes are pretty minor, and strictly to account for the non-global config.

I'm intentionally not setting up Travis here to use the canary channel, since it's hung on the conda-build-all PR.  This PR will be failing until we get that issue sorted out, or until conda-build sees a general release.