### PR TITLE
Added a name for the Linux case in conda_smithy.tests.test_configure_feedstock.Test_fudge_subdir.

### DIFF
--- a/conda_smithy/tests/test_configure_feedstock.py
+++ b/conda_smithy/tests/test_configure_feedstock.py
@@ -25,6 +25,7 @@ class Test_fudge_subdir(unittest.TestCase):
                         package:
                            name: foo_win  # [win]
                            name: foo_osx  # [osx]
+                           name: foo_the_rest  # [not (win or osx)]
                          """)
             meta = conda_build.metadata.MetaData(recipe_dir)
             with cnfgr_fdstk.fudge_subdir('win-64'):


### PR DESCRIPTION
Closes #276.