### PR TITLE
TST: Rename temporary recipe directory

### DIFF
--- a/conda_smithy/tests/test_configure_feedstock.py
+++ b/conda_smithy/tests/test_configure_feedstock.py
@@ -12,7 +12,7 @@ import conda_smithy.configure_feedstock as cnfgr_fdstk
 
 @contextmanager
 def tmp_directory():
-    tmp_dir = tempfile.mkdtemp('recipe_')
+    tmp_dir = tempfile.mkdtemp('_recipe')
     yield tmp_dir
     shutil.rmtree(tmp_dir)
 


### PR DESCRIPTION
We want the underscore before not after as the first argument is the [suffix]( https://docs.python.org/2/library/tempfile.html#tempfile.mkdtemp ).