### PR TITLE
Activate `conda`'s `root` environment on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ env:
 install:
     - mkdir -p ${HOME}/cache/pkgs
     - "[ ! -f ${HOME}/cache/miniconda.sh ] && wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ${HOME}/cache/miniconda.sh || :"
-    - bash ${HOME}/cache/miniconda.sh -b -p ${CONDA_INSTALL_LOCN} && export PATH=${CONDA_INSTALL_LOCN}/bin:$PATH
+    - bash ${HOME}/cache/miniconda.sh -b -p ${CONDA_INSTALL_LOCN}
+    - source ${CONDA_INSTALL_LOCN}/bin/activate root
 
     # Re-use the packages in the cache, and download any new ones into that location.
     - rm -rf ${CONDA_INSTALL_LOCN}/pkgs && ln -s ${HOME}/cache/pkgs ${CONDA_INSTALL_LOCN}/pkgs

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -42,7 +42,7 @@ install:
       curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
-      export PATH=/Users/travis/miniconda3/bin:$PATH
+      source /Users/travis/miniconda3/bin/activate root
 
       {%- for channel in channels.get('sources', []) %}
       conda config --add channels {{ channel }}


### PR DESCRIPTION
Seems we are just monkeying with the path in our CI testing here and in the feedstocks when using Travis CI. This changes both to properly activate the `root` environment instead.

Example re-rendering on a feedstock: https://github.com/conda-forge/libgfortran-feedstock/pull/7