### PR TITLE
Provide setup overrides

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -69,6 +69,25 @@ def render_run_docker_build(jinja_env, forge_config, forge_dir):
         matrix = prepare_matrix_for_env_vars(matrix)
         forge_config = update_matrix(forge_config, matrix)
 
+        build_setup = ""
+
+        # If the recipe supplies its own conda-forge-build-setup script,
+        # we use it instead of the global one.
+        cfbs_fpath = os.path.join(forge_dir, 'recipe',
+                                  'run_conda_forge_build_setup_linux')
+        if os.path.exists(cfbs_fpath):
+            build_setup += textwrap.dedent("""\
+                # Overriding global conda-forge-build-setup with local copy.
+                source /recipe_root/run_conda_forge_build_setup_linux
+
+            """)
+        else:
+            build_setup += textwrap.dedent("""\
+                conda install --yes --quiet conda-forge-build-setup
+                source run_conda_forge_build_setup
+
+            """)
+
         # If there is a "yum_requirements.txt" file in the recipe, we honour it.
         yum_requirements_fpath = os.path.join(forge_dir, 'recipe',
                                               'yum_requirements.txt')
@@ -80,7 +99,8 @@ def render_run_docker_build(jinja_env, forge_config, forge_dir):
                 raise ValueError("No yum requirements enabled in the "
                                  "yum_requirements.txt, please remove the file "
                                  "or add some.")
-            build_setup = textwrap.dedent("""\
+            build_setup += textwrap.dedent("""\
+
                 # Install the yum requirements defined canonically in the
                 # "recipe/yum_requirements.txt" file. After updating that file,
                 # run "conda smithy rerender" and this line be updated
@@ -89,7 +109,19 @@ def render_run_docker_build(jinja_env, forge_config, forge_dir):
 
 
             """.format(' '.join(requirements)))
-            forge_config['build_setup'] = build_setup
+
+        forge_config['build_setup'] = build_setup
+
+        # If the recipe supplies its own conda-forge-build-setup upload script,
+        # we use it instead of the global one.
+        upload_fpath = os.path.join(forge_dir, 'recipe',
+                                    'upload_or_check_non_existence.py')
+        if os.path.exists(upload_fpath):
+            forge_config['upload_script'] = (
+                "/recipe_root/upload_or_check_non_existence.py"
+            )
+        else:
+            forge_config['upload_script'] = "upload_or_check_non_existence"
 
         # TODO: Conda has a convenience for accessing nested yaml content.
         templates = forge_config.get('templates', {})
@@ -188,6 +220,42 @@ def render_travis(jinja_env, forge_config, forge_dir):
         forge_config["travis"]["enabled"] = True
         matrix = prepare_matrix_for_env_vars(matrix)
         forge_config = update_matrix(forge_config, matrix)
+
+        build_setup = ""
+
+        # If the recipe supplies its own conda-forge-build-setup script,
+        # we use it instead of the global one.
+        cfbs_fpath = os.path.join(forge_dir, 'recipe',
+                                  'run_conda_forge_build_setup_osx')
+        if os.path.exists(cfbs_fpath):
+            build_setup += textwrap.dedent("""\
+                # Overriding global conda-forge-build-setup with local copy.
+                source {recipe_dir}/run_conda_forge_build_setup_osx
+            """.format(recipe_dir=forge_config["recipe_dir"]))
+        else:
+            build_setup += textwrap.dedent("""\
+                conda install --yes --quiet conda-forge-build-setup
+                source run_conda_forge_build_setup
+            """)
+
+        build_setup = build_setup.strip()
+        build_setup = build_setup.replace("\n", "\n      ")
+
+        forge_config['build_setup'] = build_setup
+
+        # If the recipe supplies its own conda-forge-build-setup upload script,
+        # we use it instead of the global one.
+        upload_fpath = os.path.join(forge_dir, 'recipe',
+                                    'upload_or_check_non_existence.py')
+        if os.path.exists(upload_fpath):
+            forge_config['upload_script'] = (
+                "{recipe_dir}/upload_or_check_non_existence.py".format(
+                    recipe_dir=forge_config["recipe_dir"]
+                )
+            )
+        else:
+            forge_config['upload_script'] = "upload_or_check_non_existence"
+
         template = jinja_env.get_template('travis.yml.tmpl')
         with write_file(target_fname) as fh:
             fh.write(template.render(**forge_config))
@@ -317,6 +385,44 @@ def render_appveyor(jinja_env, forge_config, forge_dir):
         del old_matrix
 
         forge_config = update_matrix(forge_config, matrix)
+
+        build_setup = ""
+
+        # If the recipe supplies its own conda-forge-build-setup script,
+        # we use it instead of the global one.
+        cfbs_fpath = os.path.join(forge_dir, 'recipe',
+                                  'run_conda_forge_build_setup_osx')
+        if os.path.exists(cfbs_fpath):
+            build_setup += textwrap.dedent("""\
+                # Overriding global conda-forge-build-setup with local copy.
+                {recipe_dir}\\run_conda_forge_build_setup_win
+            """.format(recipe_dir=forge_config["recipe_dir"]))
+        else:
+            build_setup += textwrap.dedent("""\
+
+                conda install -n root --quiet --yes conda-forge-build-setup
+                run_conda_forge_build_setup
+            """)
+
+        build_setup = build_setup.rstrip()
+        build_setup = build_setup.replace("\n", "\n    - cmd: ")
+        build_setup = build_setup.lstrip()
+
+        forge_config['build_setup'] = build_setup
+
+        # If the recipe supplies its own conda-forge-build-setup upload script,
+        # we use it instead of the global one.
+        upload_fpath = os.path.join(forge_dir, 'recipe',
+                                    'upload_or_check_non_existence.py')
+        if os.path.exists(upload_fpath):
+            forge_config['upload_script'] = (
+                "{recipe_dir}\\upload_or_check_non_existence".format(
+                    recipe_dir=forge_config["recipe_dir"]
+                )
+            )
+        else:
+            forge_config['upload_script'] = "upload_or_check_non_existence"
+
         template = jinja_env.get_template('appveyor.yml.tmpl')
         with write_file(target_fname) as fh:
             fh.write(template.render(**forge_config))

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -83,7 +83,6 @@ def render_run_docker_build(jinja_env, forge_config, forge_dir):
             """)
         else:
             build_setup += textwrap.dedent("""\
-                conda install --yes --quiet conda-forge-build-setup
                 source run_conda_forge_build_setup
 
             """)
@@ -234,7 +233,6 @@ def render_travis(jinja_env, forge_config, forge_dir):
             """.format(recipe_dir=forge_config["recipe_dir"]))
         else:
             build_setup += textwrap.dedent("""\
-                conda install --yes --quiet conda-forge-build-setup
                 source run_conda_forge_build_setup
             """)
 
@@ -400,7 +398,6 @@ def render_appveyor(jinja_env, forge_config, forge_dir):
         else:
             build_setup += textwrap.dedent("""\
 
-                conda install -n root --quiet --yes conda-forge-build-setup
                 run_conda_forge_build_setup
             """)
 

--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -60,6 +60,7 @@ install:
     - cmd: set PYTHONUNBUFFERED=1
 
     - cmd: conda install -n root --quiet --yes obvious-ci
+    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     {% if build_setup -%}
     {{ build_setup }}{% endif %}
 

--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -60,8 +60,8 @@ install:
     - cmd: set PYTHONUNBUFFERED=1
 
     - cmd: conda install -n root --quiet --yes obvious-ci
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
-    - cmd: run_conda_forge_build_setup
+    {% if build_setup -%}
+    {{ build_setup }}{% endif %}
 
 # Skip .NET project specific build phase.
 build: off
@@ -70,5 +70,5 @@ test_script:
     - "%CMD_IN_ENV% conda build {{ recipe_dir }} --quiet"
 deploy_script:
 {%- for owner, channel in channels['targets'] %}
-    - cmd: upload_or_check_non_existence .\{{ recipe_dir }} {{ owner }} --channel={{ channel }}
+    - cmd: {{ upload_script }} .\{{ recipe_dir }} {{ owner }} --channel={{ channel }}
 {% endfor %}

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -40,6 +40,7 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artefacts.
 conda clean --lock
 
+conda install --yes --quiet conda-forge-build-setup
 {% if build_setup -%}
 {{ build_setup }}{% endif -%}
 

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -40,15 +40,13 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artefacts.
 conda clean --lock
 
-conda install --yes --quiet conda-forge-build-setup
-source run_conda_forge_build_setup
-
-{% if build_setup %}
+{% if build_setup -%}
 {{ build_setup }}{% endif -%}
+
 {%- block build %}
 conda build /recipe_root --quiet || exit 1
 {%- for owner, channel in channels['targets'] %}
-upload_or_check_non_existence /recipe_root {{ owner }} --channel={{ channel }} || exit 1
+{{ upload_script }} /recipe_root {{ owner }} --channel={{ channel }} || exit 1
 {%- endfor -%}
 {%- endblock -%}
 

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -49,6 +49,7 @@ install:
       conda config --add channels {{ channel }}
       {%- endfor %}
       conda config --set show_channel_urls true
+      conda install --yes --quiet conda-forge-build-setup
       {% if build_setup -%}
       {{ build_setup }}{% endif %}
 

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -49,11 +49,11 @@ install:
       conda config --add channels {{ channel }}
       {%- endfor %}
       conda config --set show_channel_urls true
-      conda install --yes --quiet conda-forge-build-setup
-      source run_conda_forge_build_setup
+      {% if build_setup -%}
+      {{ build_setup }}{% endif %}
 
 script:
   - conda build ./{{ recipe_dir }}
 {% for owner, channel in channels['targets'] %}
-  - upload_or_check_non_existence ./{{ recipe_dir }} {{ owner }} --channel={{ channel }}
+  - {{ upload_script }} ./{{ recipe_dir }} {{ owner }} --channel={{ channel }}
 {% endfor %}


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-smithy/issues/284

Provides a way to bootstrap `conda-forge-build-setup`. Also provides the ability for feedstocks to override their configurations manually at a local level if needed. This should hopefully give everyone a little bit of what they want while addressing a notable issue.

Testing of this can be seen in PR ( https://github.com/conda-forge/conda-forge-build-setup-feedstock/pull/30 ).

**TODO:**
- [x] Handle changes to the upload script. ( https://github.com/conda-forge/conda-smithy/pull/301 )
