### PR TITLE
Test CircleCI PR merge commits

### DIFF
--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -9,6 +9,13 @@ general:
 {% endblock -%}
 {% block env_dependencies -%}
 {%- if matrix -%}
+checkout:
+  post:
+    # Checkout the merged PR for testing as CircleCI will just use the PR head otherwise.
+    - if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then git fetch origin +refs/pull/$CIRCLE_PR_NUMBER/head:pr/$CIRCLE_PR_NUMBER/head ; fi
+    - if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then git fetch origin +refs/pull/$CIRCLE_PR_NUMBER/merge:pr/$CIRCLE_PR_NUMBER/merge ; fi
+    - if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then git checkout -qf pr/$CIRCLE_PR_NUMBER/merge ; fi
+
 machine:
   services:
     - docker


### PR DESCRIPTION
Unlike other CIs, CircleCI does not test the merge commit of a PR with its base branch. Instead it tests the PR's head commit. The problem with this is the PR's status could differ when it is merged with the base branch. For instance, if one needs changes in the base branch to get their PR to pass, they must rebase/merge to get them into the history the PR. This normally isn't a problem, but sometimes things do go wrong when doing this merge/rebase, which adds a new unneeded difficulty. Alternatively, a passing PR could turn out to fail when merged into the base branch because some new content in the base branch was not tested against in the PR.

To solve these issues, we checkout the merge ref for a PR (if it is a PR) from GitHub. However, it should be noted that the merge ref can be out-of-date in some cases w.r.t. the base branch as explained in issue ( https://github.com/isaacs/github/issues/757 ). Still this is the commonly used strategy on Travis CI and AppVeyor. If we had enough info, we could ideally terminate a build that has merge conflicts. Unfortunately it doesn't seem that CircleCI gives us this info. However, now that the linter complains about merge conflicts thanks to PR ( https://github.com/conda-forge/conda-forge-webservices/pull/55 ). This should provide end users the needed info to determine a CircleCI build in those cases is unreliable.

Testing of this can be seen in PR ( https://github.com/conda-forge/freeglut-feedstock/pull/5 ).

The impetus for writing this comes from this [discussion]( https://github.com/conda-forge/freeglut-feedstock/pull/2#issuecomment-244528852 ).

Proposing a similar change to staged-recipes in PR ( https://github.com/conda-forge/staged-recipes/pull/1486 ).