### PR TITLE
Pin `setuptools` as CI failure workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
     - rm -rf ${CONDA_INSTALL_LOCN}/pkgs && ln -s ${HOME}/cache/pkgs ${CONDA_INSTALL_LOCN}/pkgs
 
     # Now do the things we need to do to install it.
-    - conda install --file requirements.txt nose mock python=${PYTHON} ${CONDA_PKGS} --yes --quiet -c conda-forge
+    - conda install --file requirements.txt nose mock python=${PYTHON} setuptools=23.0.0 ${CONDA_PKGS} --yes --quiet -c conda-forge
     - python setup.py install
 
 script:


### PR DESCRIPTION
Workaround for issue ( https://github.com/conda-forge/conda-smithy/issues/289 ).

This temporarily pins `setuptools` to a known working version. The underlying problem is going to take a bit to get sorted out and resolved. In the meantime, this should at least ensure CI is working here again until it gets fixed.

cc @msarahan