### PR TITLE
Fix VC9 Win64 build on AppVeyor

### DIFF
--- a/appveyor/setup_x64.bat
+++ b/appveyor/setup_x64.bat
@@ -1,0 +1,13 @@
+regedit /s x64\VC_OBJECTS_PLATFORM_INFO.reg
+
+regedit /s x64\600dd186-2429-11d7-8bf6-00b0d03daa06.reg
+regedit /s x64\600dd187-2429-11d7-8bf6-00b0d03daa06.reg
+regedit /s x64\600dd188-2429-11d7-8bf6-00b0d03daa06.reg
+regedit /s x64\600dd189-2429-11d7-8bf6-00b0d03daa06.reg
+regedit /s x64\656d875f-2429-11d7-8bf6-00b0d03daa06.reg
+regedit /s x64\656d8760-2429-11d7-8bf6-00b0d03daa06.reg
+regedit /s x64\656d8763-2429-11d7-8bf6-00b0d03daa06.reg
+regedit /s x64\656d8766-2429-11d7-8bf6-00b0d03daa06.reg
+
+copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcpackages\AMD64.VCPlatform.config" "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcpackages\AMD64.VCPlatform.Express.config"
+copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcpackages\Itanium.VCPlatform.config" "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcpackages\Itanium.VCPlatform.Express.config"

--- a/appveyor/setup_x64.bat
+++ b/appveyor/setup_x64.bat
@@ -12,3 +12,4 @@ regedit /s x64\656d8766-2429-11d7-8bf6-00b0d03daa06.reg
 set "common_dir=C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\"
 copy "%common_dir%\vcpackages\\AMD64.VCPlatform.config"   "%common_dir%\vcpackages\\AMD64.VCPlatform.Express.config"
 copy "%common_dir%\vcpackages\\Itanium.VCPlatform.config" "%common_dir%\vcpackages\\Itanium.VCPlatform.Express.config"
+copy "%common_dir%\bin\\vcvars64.bat"                     "%common_dir%\bin\\amd64\\vcvarsamd64.bat"

--- a/appveyor/setup_x64.bat
+++ b/appveyor/setup_x64.bat
@@ -9,5 +9,6 @@ regedit /s x64\656d8760-2429-11d7-8bf6-00b0d03daa06.reg
 regedit /s x64\656d8763-2429-11d7-8bf6-00b0d03daa06.reg
 regedit /s x64\656d8766-2429-11d7-8bf6-00b0d03daa06.reg
 
-copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcpackages\AMD64.VCPlatform.config" "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcpackages\AMD64.VCPlatform.Express.config"
-copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcpackages\Itanium.VCPlatform.config" "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\vcpackages\Itanium.VCPlatform.Express.config"
+set "common_dir=C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\"
+copy "%common_dir%\vcpackages\\AMD64.VCPlatform.config"   "%common_dir%\vcpackages\\AMD64.VCPlatform.Express.config"
+copy "%common_dir%\vcpackages\\Itanium.VCPlatform.config" "%common_dir%\vcpackages\\Itanium.VCPlatform.Express.config"

--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -57,6 +57,9 @@ install:
     - cmd: conda config --add channels {{ channel }}{% endfor %}
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
+    # This needs to be updated to conda-forge channel before PR
+    - appveyor DownloadFile "https://raw.githubusercontent.com/shadowwalkersb/conda-smithy/fix-appveyor-vc9-64/appveyor/setup_x64.bat"
+    - cmd: call setup_x64.bat
 
 # Skip .NET project specific build phase.
 build: off


### PR DESCRIPTION
It seems that Visual Studio 2008 Win64 builds fail on AppVoyer, see [here](https://ci.appveyor.com/project/GorgonCryoEM/freeglut-feedstock/build/1.0.23) and [here](https://ci.appveyor.com/project/GorgonCryoEM/gorgon-hello-feedstock/build/1.0.26). Per the conversations in https://github.com/conda/conda-build/issues/1327 and @msarahan 's suggestion, this PR provides a  temporary workaround by integrating @patricksnape 's solution ( https://github.com/conda/conda-build/blob/master/appveyor.yml#L72-L73 ) into `conda-smithy`.

Some questions/concerns/todo:

- Is it possible to fix this more elegantly in `conda-smithy` or somewhere else?
- Is the location where `setup_x64.bat` is downloaded and called OK?
- [ ] Change hard-coded file link to point to `conda-forge`, before merging PR, if accepted.