### PR TITLE
Supporting building as a non-root user

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -159,7 +159,7 @@ def render_circle(jinja_env, forge_config, forge_dir):
                 # "recipe/yum_requirements.txt" file. After updating that file,
                 # run "conda smithy rerender" and this line be updated
                 # automatically.
-                yum install -y {}
+                /usr/bin/sudo -n yum install -y {}
 
 
             """.format(' '.join(requirements)))

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -25,11 +25,22 @@ show_channel_urls: true
 CONDARC
 )
 
+# In order for the conda-build process in the container to write to the mounted
+# volumes, we need to run with the same id as the host machine, which is
+# normally the owner of the mounted volumes, or at least has write permission
+HOST_USER_ID=$(id -u)
+# Check if docker-machine is being used (normally on OSX) and get the uid from
+# the VM
+if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
+    HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
+fi
+
 rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
 
 cat << EOF | {{ docker.executable }} run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
+                        -e HOST_USER_ID="${HOST_USER_ID}" \
                         -a stdin -a stdout -a stderr \
                         {{ docker.image }} \
                         {{ docker.command }} || exit 1

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -34,7 +34,10 @@ cat << EOF | {{ docker.executable }} run -i \
                         {{ docker.image }} \
                         {{ docker.command }} || exit 1
 
+set -e
+set +x
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
+set -x
 export PYTHONUNBUFFERED=1
 
 echo "$config" > ~/.condarc


### PR DESCRIPTION
These are the changes necessary to build using the docker image built by https://github.com/conda-forge/docker-images/pull/36

After https://github.com/conda-forge/docker-images/pull/39 is merged these changes should work just fine, even though the docker image still runs as root by default
