### PR TITLE
Include commit command in rerender output

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -184,6 +184,8 @@ class Regenerate(Subcommand):
         try:
             configure_feedstock.main(args.feedstock_directory)
             print("\nCI support files regenerated. These need to be pushed to github!")
+            print("\nYou can commit the changes with:\n\n"
+                  "    git commit -am 'MNT: rerender with conda-smithy %s'" % __version__)
         except RuntimeError as e:
             print(e)
 


### PR DESCRIPTION
copy/paste-able commit message for rerender, including conda-smithy version

If `commit -am` is undesirable, I still think it would be useful to report the conda-smithy version at the end of rerender.