### PR TITLE
Update CircleCI merge PRs

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -45,13 +45,18 @@ def render_run_docker_build(jinja_env, forge_config, forge_dir):
                     cases_not_skipped.append(vars + sorted(pkgs))
         matrix = sorted(cases_not_skipped, key=sort_without_target_arch)
 
-    target_fname = os.path.join(forge_dir, 'ci_support', 'run_docker_build.sh')
     if not matrix:
         # There are no cases to build (not even a case without any special
         # dependencies), so remove the run_docker_build.sh if it exists.
         forge_config["circle"]["enabled"] = False
-        if os.path.exists(target_fname):
-            os.remove(target_fname)
+
+        target_fnames = [
+            os.path.join(forge_dir, 'ci_support', 'run_docker_build.sh'),
+            os.path.join(forge_dir, 'ci_support', 'checkout_merge_commit.sh'),
+        ]
+        for each_target_fname in target_fnames:
+            if os.path.exists(each_target_fname):
+                os.remove(each_target_fname)
     else:
         forge_config["circle"]["enabled"] = True
         matrix = prepare_matrix_for_env_vars(matrix)
@@ -85,6 +90,7 @@ def render_run_docker_build(jinja_env, forge_config, forge_dir):
                                       'run_docker_build_matrix.tmpl')
 
         template = jinja_env.get_template(template_name)
+        target_fname = os.path.join(forge_dir, 'ci_support', 'run_docker_build.sh')
         with open(target_fname, 'w') as fh:
             fh.write(template.render(**forge_config))
         st = os.stat(target_fname)

--- a/conda_smithy/feedstock_content/ci_support/checkout_merge_commit.sh
+++ b/conda_smithy/feedstock_content/ci_support/checkout_merge_commit.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+
+# Update PR refs for testing.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    FETCH_REFS="${FETCH_REFS} +refs/pull/${CIRCLE_PR_NUMBER}/head:pr/${CIRCLE_PR_NUMBER}/head"
+    FETCH_REFS="${FETCH_REFS} +refs/pull/${CIRCLE_PR_NUMBER}/merge:pr/${CIRCLE_PR_NUMBER}/merge"
+fi
+
+# Retrieve the refs.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    git fetch -u origin ${FETCH_REFS}
+fi
+
+# Checkout the PR merge ref.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    git checkout -qf "pr/${CIRCLE_PR_NUMBER}/merge"
+fi
+
+# Check for merge conflicts.
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+then
+    git checkout -qf "pr/${CIRCLE_PR_NUMBER}/merge"
+    git branch --merged | grep "pr/${CIRCLE_PR_NUMBER}/head" > /dev/null
+fi

--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -11,10 +11,7 @@ general:
 {%- if matrix -%}
 checkout:
   post:
-    # Checkout the merged PR for testing as CircleCI will just use the PR head otherwise.
-    - if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then git fetch origin +refs/pull/$CIRCLE_PR_NUMBER/head:pr/$CIRCLE_PR_NUMBER/head ; fi
-    - if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then git fetch origin +refs/pull/$CIRCLE_PR_NUMBER/merge:pr/$CIRCLE_PR_NUMBER/merge ; fi
-    - if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then git checkout -qf pr/$CIRCLE_PR_NUMBER/merge ; fi
+    - ./ci_support/checkout_merge_commit.sh
 
 machine:
   services:


### PR DESCRIPTION
This makes some improvements on PR ( https://github.com/conda-forge/conda-smithy/pull/293 ) w.r.t. how we get PR refs. The main tweak is to make sure there is one `git fetch` step for all the refs so that they won't be out of sync. Other than that there is some minor stylistic improvements by putting the code in one block.

Based on updates to PR ( https://github.com/conda-forge/staged-recipes/pull/1486 ).

Edit: Testing in PR ( https://github.com/conda-forge/freeglut-feedstock/pull/6 ).