### PR TITLE
Tweak re-render commit info

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -185,7 +185,8 @@ class Regenerate(Subcommand):
             configure_feedstock.main(args.feedstock_directory)
             print("\nCI support files regenerated. These need to be pushed to github!")
             print("\nYou can commit the changes with:\n\n"
-                  "    git commit -am 'MNT: rerender with conda-smithy %s'" % __version__)
+                  "    git add -A\n"
+                  "    git commit -m 'MNT: rerender with conda-smithy %s'" % __version__)
         except RuntimeError as e:
             print(e)
 


### PR DESCRIPTION
Tweaks the post-rerendering message added in PR ( https://github.com/conda-forge/conda-smithy/pull/307 ). Suggests running `git add -A` and then committing after. This way we pick up newly added untracked files.

cc @minrk @pelson