### PR TITLE
Handle dropping old files from feedstocks

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -391,6 +391,7 @@ def main(forge_file_directory):
     # remove those now.
     old_files = [
         'disabled_appveyor.yml',
+        os.path.join('ci_support', 'upload_or_check_non_existence.py'),
     ]
     for old_file in old_files:
         fpath = os.path.join(forge_dir, old_file)

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -394,6 +394,15 @@ def main(forge_file_directory):
               'recipe_dir': recipe_dir}
     forge_dir = os.path.abspath(forge_file_directory)
 
+    # An older conda-smithy used to have some files which should no longer exist,
+    # remove those now.
+    old_files = [
+    ]
+    for old_file in old_files:
+        fpath = os.path.join(forge_dir, old_file)
+        if os.path.exists(fpath):
+            os.remove(fpath)
+
     forge_yml = os.path.join(forge_dir, "conda-forge.yml")
     if not os.path.exists(forge_yml):
         warnings.warn('No conda-forge.yml found. Assuming default options.')

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -390,6 +390,7 @@ def main(forge_file_directory):
     # An older conda-smithy used to have some files which should no longer exist,
     # remove those now.
     old_files = [
+        'disabled_appveyor.yml',
     ]
     for old_file in old_files:
         fpath = os.path.join(forge_dir, old_file)

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -263,13 +263,6 @@ def render_appveyor(jinja_env, forge_config, forge_dir):
 
     target_fname = os.path.join(forge_dir, 'appveyor.yml')
 
-    # Clean up any stray `disabled_appveyor.yml` files.
-    # This should be removed after everything is re-render
-    # with `conda-smithy` version 1.0.0 or later.
-    target_fname_disabled = os.path.join(forge_dir, 'disabled_appveyor.yml')
-    if os.path.exists(target_fname_disabled):
-        os.remove(target_fname_disabled)
-
     if not matrix:
         # There are no cases to build (not even a case without any special
         # dependencies), so remove the appveyor.yml if it exists.


### PR DESCRIPTION
Partially a follow-up on PR ( https://github.com/conda-forge/conda-smithy/pull/301 ) to clean `upload_or_check_non_existence.py` from feedstocks. Based heavily on this [commit]( https://github.com/conda-forge/conda-smithy/pull/193/commits/3e46d10c195cc127b0698a2e8090cefacb2f37ac ).

* Standardize cleanup of old files since dropped from feedstocks.
* Handle `disabled_appveyor.yml` cleanup in the same fashion.
* Handle removal of `upload_or_check_non_existence.py`.

cc @pelson