### PR TITLE
Drop extra PR merge ref checkout on CircleCI

### DIFF
--- a/conda_smithy/feedstock_content/ci_support/checkout_merge_commit.sh
+++ b/conda_smithy/feedstock_content/ci_support/checkout_merge_commit.sh
@@ -23,6 +23,5 @@ fi
 # Check for merge conflicts.
 if [[ -n "${CIRCLE_PR_NUMBER}" ]]
 then
-    git checkout -qf "pr/${CIRCLE_PR_NUMBER}/merge"
     git branch --merged | grep "pr/${CIRCLE_PR_NUMBER}/head" > /dev/null
 fi


### PR DESCRIPTION
Apparently left in an extra checkout command. :facepalm: This drops it out.