### PR TITLE
Handle missing `-feedstock` suffix during re-rendering

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -419,7 +419,10 @@ def main(forge_file_directory):
                 config_item.update(value)
     config['package'] = meta = meta_of_feedstock(forge_file_directory, config=build_config)
     if not config['github']['repo_name']:
-        config['github']['repo_name'] = os.path.basename(forge_dir)
+        feedstock_name = os.path.basename(forge_dir)
+        if not feedstock_name.endswith("-feedstock"):
+            feedstock_name += "-feedstock"
+        config['github']['repo_name'] = feedstock_name
 
     for each_ci in ["travis", "circle", "appveyor"]:
         if config[each_ci].pop("enabled", None):


### PR DESCRIPTION
Adds the `-feedstock` suffix if it is missing for re-rendering. This will make this work nicely on the feedstocks repo, but allows PR ( https://github.com/conda-forge/conda-smithy/pull/320 ) to do what it intended to do as well.

xref: https://github.com/conda-forge/conda-smithy/issues/319#issuecomment-250877367