### PR TITLE
Require OS X 10.9/XCode 6.1

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -9,6 +9,7 @@
 language: generic
 
 os: osx
+osx_image: beta-xcode6.1
 
 {% block env -%}
 {% if matrix[0] or travis.secure -%}


### PR DESCRIPTION
@conda-forge/core, this is **urgent**!

This sets the base Travis CI image so it requires OS X 10.9/XCode 6.1 explicitly as the Travis CI default changed appears to have changed to OS X 10.11/XCode 7.3. Please see [build]( https://travis-ci.org/conda-forge/staged-recipes/builds/164921320#L4 ), which appears to be the last build on `master` using OS X 10.9/XCode 6.1. Note that the next [build]( https://travis-ci.org/conda-forge/staged-recipes/builds/165091878#L4 ) and every subsequent build now appears to be using OS X 10.11/XCode 7.3 by default.

A similar change has been proposed to `staged-recipes` in PR ( https://github.com/conda-forge/staged-recipes/pull/1716 ). Once that change checks out this should be merged and released ASAP.