### PR TITLE
Repo initialization adjustments

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -41,10 +41,24 @@ def init_git_repo(target):
 def create_git_repo(target, msg):
     init_git_repo(target)
     subprocess.check_call(['git', 'add', '-A'], cwd=target)
-    if sys.platform == "win32":
-        # Ensure shell scripts have executable permissions.
-        subprocess.check_call(['git', 'update-index', '--chmod=+x', 'ci_support/checkout_merge_commit.sh'], cwd=target)
-        subprocess.check_call(['git', 'update-index', '--chmod=+x', 'ci_support/run_docker_build.sh'], cwd=target)
+
+    # Ensure shell scripts have executable permissions.
+    executable_files = [
+        "ci_support/checkout_merge_commit.sh",
+        "ci_support/run_docker_build.sh",
+    ]
+    for each_executable_file in executable_files:
+        if os.path.exists(os.path.join(target, each_executable_file)):
+            subprocess.check_call(
+                [
+                    'git',
+                    'update-index',
+                    '--chmod=+x',
+                    each_executable_file
+                ],
+                cwd=target
+            )
+
     subprocess.check_call(['git', 'commit', '-m', msg], cwd=target)
 
 

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -40,7 +40,7 @@ def init_git_repo(target):
 
 def create_git_repo(target, msg):
     init_git_repo(target)
-    subprocess.check_call(['git', 'add', '*'], cwd=target)
+    subprocess.check_call(['git', 'add', '-A'], cwd=target)
     if sys.platform == "win32":
         # Ensure shell scripts have executable permissions.
         subprocess.check_call(['git', 'update-index', '--chmod=+x', 'ci_support/checkout_merge_commit.sh'], cwd=target)

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -42,9 +42,8 @@ def create_git_repo(target, msg):
     init_git_repo(target)
     subprocess.check_call(['git', 'add', '*'], cwd=target)
     if sys.platform == "win32":
-        # prevent this:
-        # bash: line 1: ./ci_support/run_docker_build.sh: Permission denied
-        # ./ci_support/run_docker_build.sh returned exit code 126
+        # Ensure shell scripts have executable permissions.
+        subprocess.check_call(['git', 'update-index', '--chmod=+x', 'ci_support/checkout_merge_commit.sh'], cwd=target)
         subprocess.check_call(['git', 'update-index', '--chmod=+x', 'ci_support/run_docker_build.sh'], cwd=target)
     subprocess.check_call(['git', 'commit', '-m', msg], cwd=target)
 


### PR DESCRIPTION
Follow up on PR ( https://github.com/conda-forge/conda-smithy/pull/309 ). Makes some adjustments to repo initialization. In particular, makes sure that `ci_support/checkout_merge_commit.sh` is added to `git`'s index with executable permissions. Also uses `git add -A` to ensure that all files are added to index regardless of our location. Lastly went ahead and dropped the OS check as there are all sorts of weird situations that could occur were the permissions are not correctly added. So it just makes sense to add them always. Checked on my Mac to verify it still worked fine.