### PR TITLE
Lint Redundant License

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -116,6 +116,12 @@ def lintify(meta, recipe_dir=None):
         lints.append('When defining a source/url please add a sha256, sha1 '
                      'or md5 checksum (sha256 preferably).')
 
+    # 10: License should not include the word 'license'.
+    license = about_section.get('license', '').lower()
+    if 'license' in license.lower():
+        lints.append('The recipe `license` should not include the word '
+                     '"License".')
+
     return lints
 
 

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -197,6 +197,15 @@ class Test_linter(unittest.TestCase):
         meta = {'source': {'url': None, 'md5': None}}
         self.assertNotIn(expected_message, linter.lintify(meta))
 
+    def test_redundant_license(self):
+        meta = {'about': {'home': 'a URL',
+                          'summary': 'A test summary',
+                          'license': 'MIT License'}}
+        lints = linter.lintify(meta)
+        expected_message = ('The recipe `license` should not include '
+                            'the word "License".')
+        self.assertIn(expected_message, lints)
+
 
 class TestCLI_recipe_lint(unittest.TestCase):
     def test_cli_fail(self):


### PR DESCRIPTION
Have the linter raise if the `license` includes the word "license" in it.

cc @goanpeca
