### PR TITLE
Fix permissions

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -41,10 +41,24 @@ def init_git_repo(target):
 def create_git_repo(target, msg):
     init_git_repo(target)
     subprocess.check_call(['git', 'add', '-A'], cwd=target)
-    if sys.platform == "win32":
-        # Ensure shell scripts have executable permissions.
-        subprocess.check_call(['git', 'update-index', '--chmod=+x', 'ci_support/checkout_merge_commit.sh'], cwd=target)
-        subprocess.check_call(['git', 'update-index', '--chmod=+x', 'ci_support/run_docker_build.sh'], cwd=target)
+
+    # Ensure shell scripts have executable permissions.
+    executable_files = [
+        "ci_support/checkout_merge_commit.sh",
+        "ci_support/run_docker_build.sh",
+    ]
+    for each_executable_file in executable_files:
+        if os.path.exists(os.path.join(target, each_executable_file)):
+            subprocess.check_call(
+                [
+                    'git',
+                    'update-index',
+                    '--chmod=+x',
+                    each_executable_file
+                ],
+                cwd=target
+            )
+
     subprocess.check_call(['git', 'commit', '-m', msg], cwd=target)
 
 

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -40,7 +40,7 @@ def init_git_repo(target):
 
 def create_git_repo(target, msg):
     init_git_repo(target)
-    subprocess.check_call(['git', 'add', '*'], cwd=target)
+    subprocess.check_call(['git', 'add', '-A'], cwd=target)
     if sys.platform == "win32":
         # Ensure shell scripts have executable permissions.
         subprocess.check_call(['git', 'update-index', '--chmod=+x', 'ci_support/checkout_merge_commit.sh'], cwd=target)

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -42,9 +42,8 @@ def create_git_repo(target, msg):
     init_git_repo(target)
     subprocess.check_call(['git', 'add', '*'], cwd=target)
     if sys.platform == "win32":
-        # prevent this:
-        # bash: line 1: ./ci_support/run_docker_build.sh: Permission denied
-        # ./ci_support/run_docker_build.sh returned exit code 126
+        # Ensure shell scripts have executable permissions.
+        subprocess.check_call(['git', 'update-index', '--chmod=+x', 'ci_support/checkout_merge_commit.sh'], cwd=target)
         subprocess.check_call(['git', 'update-index', '--chmod=+x', 'ci_support/run_docker_build.sh'], cwd=target)
     subprocess.check_call(['git', 'commit', '-m', msg], cwd=target)
 

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -94,7 +94,7 @@ def render_run_docker_build(jinja_env, forge_config, forge_dir):
         with open(target_fname, 'w') as fh:
             fh.write(template.render(**forge_config))
         st = os.stat(target_fname)
-        os.chmod(target_fname, st.st_mode | stat.S_IEXEC)
+        os.chmod(target_fname, st.st_mode | stat.S_IXOTH | stat.S_IXGRP | stat.S_IXUSR)
 
 
 def render_circle(jinja_env, forge_config, forge_dir):

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -93,8 +93,19 @@ def render_run_docker_build(jinja_env, forge_config, forge_dir):
         target_fname = os.path.join(forge_dir, 'ci_support', 'run_docker_build.sh')
         with open(target_fname, 'w') as fh:
             fh.write(template.render(**forge_config))
-        st = os.stat(target_fname)
-        os.chmod(target_fname, st.st_mode | stat.S_IXOTH | stat.S_IXGRP | stat.S_IXUSR)
+
+        # Fix permissions.
+        target_fnames = [
+            os.path.join(forge_dir, 'ci_support', 'run_docker_build.sh'),
+            os.path.join(forge_dir, 'ci_support', 'checkout_merge_commit.sh'),
+        ]
+        for each_target_fname in target_fnames:
+            if os.path.exists(each_target_fname):
+                st = os.stat(each_target_fname)
+                os.chmod(
+                    each_target_fname,
+                    st.st_mode | stat.S_IXOTH | stat.S_IXGRP | stat.S_IXUSR
+                )
 
 
 def render_circle(jinja_env, forge_config, forge_dir):


### PR DESCRIPTION
Adds executable permissions to `ci_support/checkout_merge_commit.sh` in a few places. It should have them anyways because the file already has executable permissions. However, there are some oddities on Windows that need to be addressed.

Also makes sure executable permissions are added for everyone, group, and user on both `ci_support/checkout_merge_commit.sh` and `ci_support/run_docker_build.sh`. We were just adding executable permissions for the user before however it seems `os.chmod` conferred them to group and everyone anyways. This appears to be inadvertent AFAICT. So we now do explicitly in this PR.