### PR TITLE
Stage re-rendering changes

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -198,7 +198,6 @@ class Regenerate(Subcommand):
             configure_feedstock.main(args.feedstock_directory)
             print("\nCI support files regenerated. These need to be pushed to github!")
             print("\nYou can commit the changes with:\n\n"
-                  "    git add -A\n"
                   "    git commit -m 'MNT: Re-rendered with conda-smithy %s'" % __version__)
         except RuntimeError as e:
             print(e)

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -21,6 +21,14 @@ from conda_build_all.version_matrix import special_case_version_matrix, filter_c
 from conda_build_all.resolved_distribution import ResolvedDistribution
 from jinja2 import Environment, FileSystemLoader
 
+from conda_smithy.feedstock_io import (
+    get_mode_file,
+    set_mode_file,
+    write_file,
+    remove_file,
+    copy_file,
+)
+
 conda_forge_content = os.path.abspath(os.path.dirname(__file__))
 
 
@@ -30,77 +38,6 @@ def meta_config(meta):
     else:
         config = conda_build.config
     return config
-
-
-def get_repo(path, search_parent_directories=True):
-    repo = None
-    try:
-        import git
-        repo = git.Repo(
-            path,
-            search_parent_directories=search_parent_directories
-        )
-    except ImportError:
-        pass
-    except git.InvalidGitRepositoryError:
-        pass
-
-    return repo
-
-
-def get_file_blob(repo, filename):
-    idx = repo.index
-    rel_filepath = os.path.relpath(filename, repo.working_dir)
-    blob = idx.iter_blobs(lambda _: _[1].path == rel_filepath).next()[1]
-    return blob
-
-
-def get_mode_file(filename):
-    repo = get_repo(filename)
-    if repo:
-        blob = get_file_blob(repo, filename)
-        mode = blob.mode
-    else:
-        mode = os.stat(filename).st_mode
-
-    return mode
-
-
-def set_mode_file(filename, mode):
-    repo = get_repo(filename)
-    if repo:
-        blob = get_file_blob(repo, filename)
-        blob.mode |= mode
-        repo.index.add([blob])
-
-    os.chmod(filename, mode)
-
-
-@contextmanager
-def write_file(filename):
-    with open(filename, "w") as fh:
-        yield fh
-
-    repo = get_repo(filename)
-    if repo:
-        repo.index.add([filename])
-
-
-def remove_file(filename):
-    if os.path.exists(filename):
-        repo = get_repo(filename)
-        if repo:
-            repo.index.remove([filename])
-
-        os.remove(filename)
-
-
-def copy_file(src, dst):
-    shutil.copy2(src, dst)
-
-    repo = get_repo(dst)
-    if repo:
-        repo.index.add([dst])
 
 
 def render_run_docker_build(jinja_env, forge_config, forge_dir):

--- a/conda_smithy/feedstock_io.py
+++ b/conda_smithy/feedstock_io.py
@@ -1,0 +1,74 @@
+from contextlib import contextmanager
+import os
+import shutil
+
+
+def get_repo(path, search_parent_directories=True):
+    repo = None
+    try:
+        import git
+        repo = git.Repo(
+            path,
+            search_parent_directories=search_parent_directories
+        )
+    except ImportError:
+        pass
+    except git.InvalidGitRepositoryError:
+        pass
+
+    return repo
+
+
+def get_file_blob(repo, filename):
+    idx = repo.index
+    rel_filepath = os.path.relpath(filename, repo.working_dir)
+    blob = idx.iter_blobs(lambda _: _[1].path == rel_filepath).next()[1]
+    return blob
+
+
+def get_mode_file(filename):
+    repo = get_repo(filename)
+    if repo:
+        blob = get_file_blob(repo, filename)
+        mode = blob.mode
+    else:
+        mode = os.stat(filename).st_mode
+
+    return mode
+
+
+def set_mode_file(filename, mode):
+    repo = get_repo(filename)
+    if repo:
+        blob = get_file_blob(repo, filename)
+        blob.mode |= mode
+        repo.index.add([blob])
+
+    os.chmod(filename, mode)
+
+
+@contextmanager
+def write_file(filename):
+    with open(filename, "w") as fh:
+        yield fh
+
+    repo = get_repo(filename)
+    if repo:
+        repo.index.add([filename])
+
+
+def remove_file(filename):
+    if os.path.exists(filename):
+        repo = get_repo(filename)
+        if repo:
+            repo.index.remove([filename])
+
+        os.remove(filename)
+
+
+def copy_file(src, dst):
+    shutil.copy2(src, dst)
+
+    repo = get_repo(dst)
+    if repo:
+        repo.index.add([dst])


### PR DESCRIPTION
This automatically stages changes from a re-rendering run in the index if the feedstock is a git repo. If it is not a git repo, it proceeds exactly the same as it would otherwise. By putting things directly into the index, we should be able to avoid file permission getting lost like in issue ( https://github.com/conda-forge/conda-smithy/issues/330 ).

Also provides the option to commit either with the editor popped up or automatically with a default message. Note that committing is not default behavior unlike staging.