### PR TITLE
Linter: check the license_family is valid

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -6,7 +6,7 @@ import re
 import jinja2
 import ruamel.yaml
 
-from conda_build.metadata import allowed_license_families
+from conda_build.metadata import ensure_valid_license_family
 
 # patch over differences between PY2 and PY3
 try:
@@ -137,10 +137,10 @@ def lintify(meta, recipe_dir=None):
                          'file.')
 
     # 12: License family must be valid (conda-build checks for that)
-    license_family = about_section.get('license_family', '')
-    if license_family and not license_family in allowed_license_families:
-        lints.append('The recipe license_family `{}` is invalid: must be one of {}.'
-                     ''.format(license_family, ', '.join(allowed_license_families)))
+    try:
+        ensure_valid_license_family(meta)
+    except RuntimeError as e:
+        lints.append(str(e))
 
     return lints
 

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -6,6 +6,8 @@ import re
 import jinja2
 import ruamel.yaml
 
+from conda_build.metadata import allowed_license_families
+
 # patch over differences between PY2 and PY3
 try:
     text_type = unicode
@@ -133,6 +135,13 @@ def lintify(meta, recipe_dir=None):
         if end_empty_lines_count != 1:
             lints.append('There should be one empty line at the end of the '
                          'file.')
+
+    # 12: License family must be valid (conda-build checks for that)
+    license_family = about_section.get('license_family', '')
+    if license_family and not license_family in allowed_license_families:
+        lints.append('The recipe license_family `{}` is invalid: must be one of {}.'
+                     ''.format(license_family, ', '.join(allowed_license_families)))
+
     return lints
 
 

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -48,6 +48,17 @@ class Test_linter(unittest.TestCase):
         expected_message = "The recipe license cannot be unknown."
         self.assertIn(expected_message, lints)
 
+    def test_bad_about_license_family(self):
+        meta = {'about': {'home': 'a URL',
+                          'summary': 'A test summary',
+                          'license': 'BSD 3-clause',
+                          'license_family': 'BSD3'}}
+        lints = linter.lintify(meta)
+        allowed = ', '.join(linter.allowed_license_families)
+        expected_message = ("The recipe license_family `BSD3` is invalid: "
+                            "must be one of {}.".format(allowed))
+        self.assertIn(expected_message, lints)
+
     def test_missing_about_home(self):
         meta = {'about': {'license': 'BSD',
                           'summary': 'A test summary'}}

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -54,10 +54,8 @@ class Test_linter(unittest.TestCase):
                           'license': 'BSD 3-clause',
                           'license_family': 'BSD3'}}
         lints = linter.lintify(meta)
-        allowed = ', '.join(linter.allowed_license_families)
-        expected_message = ("The recipe license_family `BSD3` is invalid: "
-                            "must be one of {}.".format(allowed))
-        self.assertIn(expected_message, lints)
+        expected = "about/license_family 'BSD3' not allowed"
+        self.assertTrue(any(lint.startswith(expected) for lint in lints))
 
     def test_missing_about_home(self):
         meta = {'about': {'license': 'BSD',


### PR DESCRIPTION
conda-build actually checks for that. Relates to #88.
