### PR TITLE
Handle a subtle case involving file removal during re-rendering

### DIFF
--- a/conda_smithy/feedstock_io.py
+++ b/conda_smithy/feedstock_io.py
@@ -57,13 +57,19 @@ def write_file(filename):
         repo.index.add([filename])
 
 
-def remove_file(filename):
-    if os.path.exists(filename):
-        repo = get_repo(filename)
-        if repo:
-            repo.index.remove([filename])
+def touch_file(filename):
+    with write_file(filename) as fh:
+        fh.write("")
 
-        os.remove(filename)
+
+def remove_file(filename):
+    touch_file(filename)
+
+    repo = get_repo(filename)
+    if repo:
+        repo.index.remove([filename])
+
+    os.remove(filename)
 
 
 def copy_file(src, dst):


### PR DESCRIPTION
In some cases a file may already be removed from the file system. However, the corresponding change may not have been added to the index. We were not able to handle this case previously as GitPython is unable to remove the file from the index if it is not already on the file system.

So we had to check that the file was on the file system first before trying to remove it from the index. The result being a file removed from the file system and not removed from the index could linger in the subsequent commit even if it should have been removed. This issue could crop up if someone tried to re-render the feedstock (resulting in some files being removed). Then backed out the changes from the index with `git reset` for some reason.

To solve this issue, this change creates an empty file on the file system and stages it to the index before trying to remove it. By doing this, we ensure to always have the file on the file system and in the index beforehand. Thus removal is always possible from both without
issue.
