### PR TITLE
follow redirects with curl

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -38,9 +38,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root


### PR DESCRIPTION
and get miniconda via https

http fetch of miniconda now redirects to https. Without `-L`, this results in mac builds failing to fetch miniconda.

cf https://travis-ci.org/conda-forge/metis-feedstock/builds/171745621