### PR TITLE
Handle empty directories

### DIFF
--- a/conda_smithy/feedstock_io.py
+++ b/conda_smithy/feedstock_io.py
@@ -49,6 +49,10 @@ def set_mode_file(filename, mode):
 
 @contextmanager
 def write_file(filename):
+    dirname = os.path.dirname(filename)
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
+
     with open(filename, "w") as fh:
         yield fh
 

--- a/conda_smithy/feedstock_io.py
+++ b/conda_smithy/feedstock_io.py
@@ -75,6 +75,10 @@ def remove_file(filename):
 
     os.remove(filename)
 
+    dirname = os.path.dirname(filename)
+    if not os.listdir(dirname):
+        os.removedirs(dirname)
+
 
 def copy_file(src, dst):
     shutil.copy2(src, dst)


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-smithy/issues/314
Improves on https://github.com/conda-forge/conda-smithy/pull/345

This handles two cases. First it handles a case where one tries to write to a file when its parent directory does not exist. Second it handles the case where the last file in a directory is removed leaving empty directory/directories.

The first case is handled by making all directories up to the parent directory of the file recursively until they all exist. This is of particular importance for `remove_file`, which runs `touch_file` before removal to ensure the file exists. More details about why that is done can be found in PR ( https://github.com/conda-forge/conda-smithy/pull/345 ). As a result, we can be sure the file can be written to whether or not those directories existed before.

The second case is handled during `remove_file` by checking to see if the directory is now empty. If it is, then run `os.removedirs`, which will remove empty directories recursively until there are no more directories or a non-empty directory is encountered. As the feedstock directory should always be non-empty (at least containing a recipe), this should never go out past the feedstock directory.