### PR TITLE
WIP: Fix-up setuptools use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
     - rm -rf ${CONDA_INSTALL_LOCN}/pkgs && ln -s ${HOME}/cache/pkgs ${CONDA_INSTALL_LOCN}/pkgs
 
     # Now do the things we need to do to install it.
-    - conda install --file requirements.txt nose mock python=${PYTHON} setuptools=23.0.0 ${CONDA_PKGS} --yes --quiet -c conda-forge
+    - conda install --file requirements.txt nose mock python=${PYTHON} ${CONDA_PKGS} --yes --quiet -c conda-forge
     - python setup.py install
 
 script:

--- a/conda_smithy.recipe/meta.yaml
+++ b/conda_smithy.recipe/meta.yaml
@@ -10,6 +10,9 @@ source:
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
+  entry_points:
+    - feedstocks = conda_smithy.feedstocks:main
+    - conda-smithy = conda_smithy.cli:main
 
 requirements:
   build:

--- a/conda_smithy.recipe/meta.yaml
+++ b/conda_smithy.recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
   run:
     - python
     - conda-build-all
-    - setuptools
     - conda
     - conda-build >=1.21.12
     - jinja2


### PR DESCRIPTION
* Drops the `setuptools` CI pinning.
* Uses `conda-build` entry points.