### PR TITLE
Unpin setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
     - rm -rf ${CONDA_INSTALL_LOCN}/pkgs && ln -s ${HOME}/cache/pkgs ${CONDA_INSTALL_LOCN}/pkgs
 
     # Now do the things we need to do to install it.
-    - conda install --file requirements.txt coverage=3 python-coveralls mock python=${PYTHON} setuptools=23.0.0 ${CONDA_PKGS} --yes --quiet -c conda-forge
+    - conda install --file requirements.txt coverage=3 python-coveralls mock python=${PYTHON} ${CONDA_PKGS} --yes --quiet -c conda-forge
     - python setup.py install
 
 script:


### PR DESCRIPTION
Please do **not** merge this. It exists for testing purposes only

This reverts PR ( https://github.com/conda-forge/conda-smithy/pull/294 ) to see what will happen if the `setuptools` pinning is dropped.