### PR TITLE
Tests for feedstock_io

### DIFF
--- a/conda_smithy/tests/test_feedstock_io.py
+++ b/conda_smithy/tests/test_feedstock_io.py
@@ -195,6 +195,41 @@ class TestFeedstockIO(unittest.TestCase):
                     self.assertEqual("", read_text)
 
 
+    def test_remove_file(self):
+        for tmp_dir, repo, pathfunc in parameterize():
+            for filename in ["test.txt", "dir1/dir2/test.txt"]:
+                dirname = os.path.dirname(filename)
+                if dirname and not os.path.exists(dirname):
+                    os.makedirs(dirname)
+
+                filename = os.path.join(tmp_dir, filename)
+
+                with io.open(filename, "w", encoding="utf-8") as fh:
+                    fh.write("")
+                if repo is not None:
+                    repo.index.add([filename])
+
+                self.assertTrue(os.path.exists(filename))
+                if dirname:
+                    self.assertTrue(os.path.exists(dirname))
+                    self.assertTrue(os.path.exists(os.path.dirname(dirname)))
+                if repo is not None:
+                    self.assertTrue(
+                        list(repo.index.iter_blobs(BlobFilter(filename)))
+                    )
+
+                fio.remove_file(pathfunc(filename))
+
+                self.assertFalse(os.path.exists(filename))
+                if dirname:
+                    self.assertFalse(os.path.exists(dirname))
+                    self.assertFalse(os.path.exists(os.path.dirname(dirname)))
+                if repo is not None:
+                    self.assertFalse(
+                        list(repo.index.iter_blobs(BlobFilter(filename)))
+                    )
+
+
     def tearDown(self):
         os.chdir(self.old_dir)
         del self.old_dir

--- a/conda_smithy/tests/test_feedstock_io.py
+++ b/conda_smithy/tests/test_feedstock_io.py
@@ -175,6 +175,26 @@ class TestFeedstockIO(unittest.TestCase):
                     self.assertEqual(write_text, read_text)
 
 
+    def test_touch_file(self):
+        for tmp_dir, repo, pathfunc in parameterize():
+            for filename in ["test.txt", "dir1/dir2/test.txt"]:
+                filename = os.path.join(tmp_dir, filename)
+
+                fio.touch_file(pathfunc(filename))
+
+                read_text = ""
+                with io.open(filename, "r", encoding="utf-8") as fh:
+                    read_text = fh.read()
+
+                self.assertEqual("", read_text)
+
+                if repo is not None:
+                    blob = next(repo.index.iter_blobs(BlobFilter(filename)))[1]
+                    read_text = blob.data_stream[3].read().decode("utf-8")
+
+                    self.assertEqual("", read_text)
+
+
     def tearDown(self):
         os.chdir(self.old_dir)
         del self.old_dir

--- a/conda_smithy/tests/test_feedstock_io.py
+++ b/conda_smithy/tests/test_feedstock_io.py
@@ -150,6 +150,31 @@ class TestFeedstockIO(unittest.TestCase):
                 self.assertEqual(blob.mode & set_mode, set_mode)
 
 
+    def test_write_file(self):
+        for tmp_dir, repo, pathfunc in parameterize():
+            for filename in ["test.txt", "dir1/dir2/test.txt"]:
+                filename = os.path.join(tmp_dir, filename)
+
+                write_text = "text"
+
+                with fio.write_file(pathfunc(filename)) as fh:
+                    fh.write(write_text)
+                if repo is not None:
+                    repo.index.add([filename])
+
+                read_text = ""
+                with io.open(filename, "r", encoding="utf-8") as fh:
+                    read_text = fh.read()
+
+                self.assertEqual(write_text, read_text)
+
+                if repo is not None:
+                    blob = next(repo.index.iter_blobs(BlobFilter(filename)))[1]
+                    read_text = blob.data_stream[3].read().decode("utf-8")
+
+                    self.assertEqual(write_text, read_text)
+
+
     def tearDown(self):
         os.chdir(self.old_dir)
         del self.old_dir

--- a/conda_smithy/tests/test_feedstock_io.py
+++ b/conda_smithy/tests/test_feedstock_io.py
@@ -6,7 +6,41 @@ import shutil
 import tempfile
 import unittest
 
+import git
+
 import conda_smithy.feedstock_io as fio
+
+
+def keep_dir(dirname):
+    keep_filename = os.path.join(dirname, ".keep")
+    with io.open(keep_filename, "w", encoding = "utf-8") as fh:
+        fh.write("")
+
+
+def parameterize():
+    for pathfunc in [
+        lambda pth, tmp_dir: os.path.relpath(pth, tmp_dir),
+        lambda pth, tmp_dir: pth
+    ]:
+        for get_repo in [
+            lambda tmp_dir: None,
+            lambda tmp_dir: git.Repo.init(tmp_dir)
+        ]:
+            try:
+                tmp_dir = tempfile.mkdtemp()
+                keep_dir(tmp_dir)
+
+                old_dir = os.getcwd()
+                os.chdir(tmp_dir)
+
+                yield (
+                    tmp_dir,
+                    get_repo(tmp_dir),
+                    lambda pth: pathfunc(pth, tmp_dir)
+                )
+            finally:
+                os.chdir(old_dir)
+                shutil.rmtree(tmp_dir)
 
 
 class TestFeedstockIO(unittest.TestCase):
@@ -18,6 +52,19 @@ class TestFeedstockIO(unittest.TestCase):
 
         with io.open(os.path.abspath(".keep"), "w", encoding="utf-8") as fh:
             fh.write("")
+
+
+    def test_repo(self):
+        for tmp_dir, repo, pathfunc in parameterize():
+            if repo is None:
+                self.assertTrue(
+                    fio.get_repo(pathfunc(tmp_dir)) is None
+                )
+            else:
+                self.assertIsInstance(
+                    fio.get_repo(pathfunc(tmp_dir)),
+                    git.Repo
+                )
 
 
     def tearDown(self):

--- a/conda_smithy/tests/test_feedstock_io.py
+++ b/conda_smithy/tests/test_feedstock_io.py
@@ -1,0 +1,32 @@
+from __future__ import unicode_literals
+
+import io
+import os
+import shutil
+import tempfile
+import unittest
+
+import conda_smithy.feedstock_io as fio
+
+
+class TestFeedstockIO(unittest.TestCase):
+    def setUp(self):
+        self.old_dir = os.getcwd()
+
+        self.tmp_dir = tempfile.mkdtemp()
+        os.chdir(self.tmp_dir)
+
+        with io.open(os.path.abspath(".keep"), "w", encoding="utf-8") as fh:
+            fh.write("")
+
+
+    def tearDown(self):
+        os.chdir(self.old_dir)
+        del self.old_dir
+
+        shutil.rmtree(self.tmp_dir)
+        del self.tmp_dir
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/conda_smithy/tests/test_feedstock_io.py
+++ b/conda_smithy/tests/test_feedstock_io.py
@@ -67,6 +67,28 @@ class TestFeedstockIO(unittest.TestCase):
                 )
 
 
+    def test_get_file_blob(self):
+        for tmp_dir, repo, pathfunc in parameterize():
+            if repo is None:
+                continue
+
+            filename = "test.txt"
+            filename = os.path.join(tmp_dir, filename)
+
+            with io.open(filename, "w", encoding = "utf-8") as fh:
+                fh.write("")
+
+            repo.index.add([filename])
+
+            blob = None
+            try:
+                blob = fio.get_file_blob(repo, filename)
+            except StopIteration:
+                self.fail("Unable to find the file we added.")
+
+            self.assertEqual(blob.name, os.path.basename(filename))
+
+
     def tearDown(self):
         os.chdir(self.old_dir)
         del self.old_dir


### PR DESCRIPTION
This is a follow-up on PR ( https://github.com/conda-forge/conda-smithy/pull/336 ).

Adds a bunch of tests for the `feedstock_io` module. Tests exist for both the presence and absence of a git repo. The combination of these should help improve test coverage of `conda-smithy` particularly on these low level aspects.

cc @nicoddemus