### PR TITLE
Use conda-build entry points

### DIFF
--- a/conda_smithy.recipe/meta.yaml
+++ b/conda_smithy.recipe/meta.yaml
@@ -10,6 +10,9 @@ source:
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
+  entry_points:
+    - feedstocks = conda_smithy.feedstocks:main
+    - conda-smithy = conda_smithy.cli:main
 
 requirements:
   build:

--- a/conda_smithy.recipe/meta.yaml
+++ b/conda_smithy.recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
   run:
     - python
     - conda-build-all
-    - setuptools
     - conda
     - conda-build >=1.21.12
     - jinja2


### PR DESCRIPTION
Changes the included development recipe to use `conda-build` entry points.