### PR TITLE
Use unicode on Python 2

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 from contextlib import contextmanager
 import os

--- a/conda_smithy/feedstock_io.py
+++ b/conda_smithy/feedstock_io.py
@@ -1,4 +1,7 @@
+from __future__ import unicode_literals
+
 from contextlib import contextmanager
+import io
 import os
 import shutil
 
@@ -62,7 +65,7 @@ def write_file(filename):
     if dirname and not os.path.exists(dirname):
         os.makedirs(dirname)
 
-    with open(filename, "w") as fh:
+    with io.open(filename, "w", encoding="utf-8") as fh:
         yield fh
 
     repo = get_repo(filename)


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-smithy/issues/364

This uses UTF-8 in all cases. Files are opened with UTF-8 encoding and unicode literals are used throughout. Fixes some issues on Python 2 in particular where metadata from the recipe included unicode characters. This should now correctly support them. Have tested against the [`pyemma` feedstock]( https://github.com/conda-forge/pyemma-feedstock ) with both Python 2 and Python 3 locally. Works fine in both cases. Should add that this ends up already being well covered in the existing test suite thanks to the use of the `touch_file` function, which had to receive a unicode literal to behave correctly.