### PR TITLE
Measure and report test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,21 @@
+[run]
+branch = True
+erase = True
+package = conda_smithy
+[report]
+exclude_lines =
+    # Ignore coverage of code that requires the module to be executed.
+    if __name__ == .__main__.:
+
+    # Ignore continue statement in code as it can't be detected as covered
+    # due to an optimization by the Python interpreter. See coverage issue
+    # ( https://bitbucket.org/ned/coveragepy/issue/198/continue-marked-as-not-covered )
+    # and Python issue ( http://bugs.python.org/issue2506 ).
+    continue
+omit =
+    */python?.?/*
+    */site-packages/*
+    *tests/*
+    */versioneer.py
+    */_version.py
+    */vendored/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.coverage
 *.token
 feedstock-repos.json
 *.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
     - rm -rf ${CONDA_INSTALL_LOCN}/pkgs && ln -s ${HOME}/cache/pkgs ${CONDA_INSTALL_LOCN}/pkgs
 
     # Now do the things we need to do to install it.
-    - conda install --file requirements.txt coverage=3 mock python=${PYTHON} setuptools=23.0.0 ${CONDA_PKGS} --yes --quiet -c conda-forge
+    - conda install --file requirements.txt coverage=3 python-coveralls mock python=${PYTHON} setuptools=23.0.0 ${CONDA_PKGS} --yes --quiet -c conda-forge
     - python setup.py install
 
 script:
@@ -32,6 +32,8 @@ script:
     - coverage run --source . setup.py test
     - coverage report
 
+after_success:
+    - coveralls
 
 # We store the files that are downloaded from continuum.io, but not the environments that are created.
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,13 @@ install:
     - rm -rf ${CONDA_INSTALL_LOCN}/pkgs && ln -s ${HOME}/cache/pkgs ${CONDA_INSTALL_LOCN}/pkgs
 
     # Now do the things we need to do to install it.
-    - conda install --file requirements.txt mock python=${PYTHON} setuptools=23.0.0 ${CONDA_PKGS} --yes --quiet -c conda-forge
+    - conda install --file requirements.txt coverage=3 mock python=${PYTHON} setuptools=23.0.0 ${CONDA_PKGS} --yes --quiet -c conda-forge
     - python setup.py install
 
 script:
-    - python setup.py test
+    - coverage erase
+    - coverage run --source . setup.py test
+    - coverage report
 
 
 # We store the files that are downloaded from continuum.io, but not the environments that are created.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Overview
 + Connect the repo to the CI services travis-ci.org, appveyor.com, circleci.com
 
 [![Build Status](https://travis-ci.org/conda-forge/conda-smithy.svg)](https://travis-ci.org/conda-forge/conda-smithy)
+[![Coverage Status](https://coveralls.io/repos/github/conda-forge/conda-smithy/badge.svg?branch=master)](https://coveralls.io/github/conda-forge/conda-smithy?branch=master)
 
 Installation
 ------------


### PR DESCRIPTION
Measure and report test coverage during CI builds. Also send the statistics to Coveralls for nicer reporting.