### PR TITLE
Set all permissions

### DIFF
--- a/conda_smithy/feedstock_io.py
+++ b/conda_smithy/feedstock_io.py
@@ -54,6 +54,8 @@ def write_file(filename):
     if repo:
         repo.index.add([filename])
 
+    set_exe_file(filename, set_exe=False)
+
 
 def touch_file(filename):
     with write_file(filename) as fh:

--- a/conda_smithy/feedstock_io.py
+++ b/conda_smithy/feedstock_io.py
@@ -83,7 +83,7 @@ def copy_file(src, dst):
     """
     try:
         with io.open(src, "r", encoding="utf-8") as fh_src:
-            with io.open(dst, "w", encoding="utf-8", newline="\n") as fh_dst:
+            with write_file(dst) as fh_dst:
                 for line in fh_src:
                     fh_dst.write(line)
     except UnicodeDecodeError:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-smithy/issues/424

Sets all file permissions whether copied or written from scratch explicitly to non-executables. As we already have to explicit set execute permissions for Windows, it is not such a burden to have everything default to non-executable permissions. This should avoid a few more odd cases with file permissions.

cc @grlee77 @CJ-Wright @nicoddemus