### PR TITLE
Add gitattributes

### DIFF
--- a/conda_smithy/feedstock_content/.gitattributes
+++ b/conda_smithy/feedstock_content/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf


### PR DESCRIPTION
Adds a `.gitattributes` file for specifying how to handle line endings with recipe content.

cc @goanpeca

xref: https://github.com/conda-forge/staged-recipes/pull/1920