### PR TITLE
Exclude `conda-build` version `2.0.9`

### DIFF
--- a/conda_smithy.recipe/meta.yaml
+++ b/conda_smithy.recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python
     - conda-build-all
     - conda
-    - conda-build >=1.21.12
+    - conda-build >=1.21.12,!=2.0.9
     - jinja2
     - requests
     - pycrypto

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 conda-build-all
 setuptools
 conda
-conda-build >=1.21.12
+conda-build >=1.21.12,!=2.0.9
 jinja2
 requests
 pycrypto


### PR DESCRIPTION
Exclude `conda-build` version `2.0.9` as it breaks compatibility with `conda` version `4.1`.