### PR TITLE
Use Pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 
 script:
     - coverage erase
-    - coverage run --source . -m pytest conda_smithy/tests
+    - coverage run --source conda_smithy -m pytest conda_smithy/tests
     - coverage report
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ install:
     - rm -rf ${CONDA_INSTALL_LOCN}/pkgs && ln -s ${HOME}/cache/pkgs ${CONDA_INSTALL_LOCN}/pkgs
 
     # Now do the things we need to do to install it.
-    - conda install --file requirements.txt coverage=3 python-coveralls mock python=${PYTHON} setuptools=23.0.0 ${CONDA_PKGS} --yes --quiet -c conda-forge
+    - conda install --file requirements.txt coverage=3 pytest python-coveralls mock python=${PYTHON} setuptools=23.0.0 ${CONDA_PKGS} --yes --quiet -c conda-forge
     - python setup.py install
 
 script:
     - coverage erase
-    - coverage run --source . setup.py test
+    - coverage run --source . -m pytest conda_smithy/tests
     - coverage report
 
 after_success:

--- a/conda_smithy.recipe/meta.yaml
+++ b/conda_smithy.recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
 
 test:
   requires:
+    - pytest
     - mock
   imports:
     - conda_smithy
@@ -39,6 +40,7 @@ test:
     - conda_smithy.configure_feedstock
   commands:
     - conda smithy --help
+    - pytest conda_smithy/tests
 
 about:
   home: https://github.com/conda-forge/conda-smithy

--- a/conda_smithy/tests/test_configure_feedstock.py
+++ b/conda_smithy/tests/test_configure_feedstock.py
@@ -36,11 +36,11 @@ class Test_fudge_subdir(unittest.TestCase):
 
             with cnfgr_fdstk.fudge_subdir('win-64', config):
                 meta.parse_again(**kwargs)
-                self.assertEqual(meta.name(), 'foo_win')
+                assert meta.name() == 'foo_win'
 
             with cnfgr_fdstk.fudge_subdir('osx-64', config):
                 meta.parse_again(**kwargs)
-                self.assertEqual(meta.name(), 'foo_osx')
+                assert meta.name() == 'foo_osx'
 
     def test_fetch_index(self):
         if hasattr(conda_build, 'api'):
@@ -53,10 +53,10 @@ class Test_fudge_subdir(unittest.TestCase):
             win_index = conda.api.get_index()
         with cnfgr_fdstk.fudge_subdir('osx-64', config):
             osx_index = conda.api.get_index()
-        self.assertNotEqual(win_index.keys(), osx_index.keys(),
+        assert win_index.keys() != osx_index.keys(), \
                             ('The keys for the Windows and OSX index were the same.'
                              ' Subdir is not working and will result in mis-rendering '
-                             '(e.g. https://github.com/SciTools/conda-build-all/issues/49).'))
+                             '(e.g. https://github.com/SciTools/conda-build-all/issues/49).')
 
 
 

--- a/conda_smithy/tests/test_configure_feedstock.py
+++ b/conda_smithy/tests/test_configure_feedstock.py
@@ -1,46 +1,31 @@
-from contextlib import contextmanager
-import os
-import shutil
-import tempfile
-import unittest
-
 import conda_build.metadata
 import conda.api
 
 import conda_smithy.configure_feedstock as cnfgr_fdstk
 
 
-@contextmanager
-def tmp_directory():
-    tmp_dir = tempfile.mkdtemp('_recipe')
-    yield tmp_dir
-    shutil.rmtree(tmp_dir)
-
-
-class Test_fudge_subdir(unittest.TestCase):
-    def test_metadata_reading(self):
-        with tmp_directory() as recipe_dir:
-            with open(os.path.join(recipe_dir, 'meta.yaml'), 'w') as fh:
-                fh.write("""
+class Test_fudge_subdir(object):
+    def test_metadata_reading(self, tmpdir):
+        tmpdir.join('meta.yaml').write("""
                         package:
                            name: foo_win  # [win]
                            name: foo_osx  # [osx]
                            name: foo_the_rest  # [not (win or osx)]
                          """)
-            meta = conda_build.metadata.MetaData(recipe_dir)
-            config = cnfgr_fdstk.meta_config(meta)
+        meta = conda_build.metadata.MetaData(str(tmpdir))
+        config = cnfgr_fdstk.meta_config(meta)
 
-            kwargs = {}
-            if hasattr(conda_build, 'api'):
-                kwargs['config'] = config
+        kwargs = {}
+        if hasattr(conda_build, 'api'):
+            kwargs['config'] = config
 
-            with cnfgr_fdstk.fudge_subdir('win-64', config):
-                meta.parse_again(**kwargs)
-                assert meta.name() == 'foo_win'
+        with cnfgr_fdstk.fudge_subdir('win-64', config):
+            meta.parse_again(**kwargs)
+            assert meta.name() == 'foo_win'
 
-            with cnfgr_fdstk.fudge_subdir('osx-64', config):
-                meta.parse_again(**kwargs)
-                assert meta.name() == 'foo_osx'
+        with cnfgr_fdstk.fudge_subdir('osx-64', config):
+            meta.parse_again(**kwargs)
+            assert meta.name() == 'foo_osx'
 
     def test_fetch_index(self):
         if hasattr(conda_build, 'api'):
@@ -57,8 +42,3 @@ class Test_fudge_subdir(unittest.TestCase):
                             ('The keys for the Windows and OSX index were the same.'
                              ' Subdir is not working and will result in mis-rendering '
                              '(e.g. https://github.com/SciTools/conda-build-all/issues/49).')
-
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/conda_smithy/tests/test_feedstock_io.py
+++ b/conda_smithy/tests/test_feedstock_io.py
@@ -61,14 +61,9 @@ class TestFeedstockIO(unittest.TestCase):
     def test_repo(self):
         for tmp_dir, repo, pathfunc in parameterize():
             if repo is None:
-                self.assertTrue(
-                    fio.get_repo(pathfunc(tmp_dir)) is None
-                )
+                assert fio.get_repo(pathfunc(tmp_dir)) is None
             else:
-                self.assertIsInstance(
-                    fio.get_repo(pathfunc(tmp_dir)),
-                    git.Repo
-                )
+                assert isinstance(fio.get_repo(pathfunc(tmp_dir)), git.Repo)
 
 
     def test_set_exe_file(self):
@@ -92,12 +87,12 @@ class TestFeedstockIO(unittest.TestCase):
                 fio.set_exe_file(pathfunc(filename), set_exe)
 
                 file_mode = os.stat(filename).st_mode
-                self.assertEqual(file_mode & set_mode,
-                                 int(set_exe) * set_mode)
+                assert file_mode & set_mode == \
+                                 int(set_exe) * set_mode
                 if repo is not None:
                     blob = next(repo.index.iter_blobs(BlobFilter(filename)))[1]
-                    self.assertEqual(blob.mode & set_mode,
-                                     int(set_exe) * set_mode)
+                    assert blob.mode & set_mode == \
+                                     int(set_exe) * set_mode
 
 
     def test_write_file(self):
@@ -116,13 +111,13 @@ class TestFeedstockIO(unittest.TestCase):
                 with io.open(filename, "r", encoding="utf-8") as fh:
                     read_text = fh.read()
 
-                self.assertEqual(write_text, read_text)
+                assert write_text == read_text
 
                 if repo is not None:
                     blob = next(repo.index.iter_blobs(BlobFilter(filename)))[1]
                     read_text = blob.data_stream[3].read().decode("utf-8")
 
-                    self.assertEqual(write_text, read_text)
+                    assert write_text == read_text
 
 
     def test_touch_file(self):
@@ -136,13 +131,13 @@ class TestFeedstockIO(unittest.TestCase):
                 with io.open(filename, "r", encoding="utf-8") as fh:
                     read_text = fh.read()
 
-                self.assertEqual("", read_text)
+                assert "" == read_text
 
                 if repo is not None:
                     blob = next(repo.index.iter_blobs(BlobFilter(filename)))[1]
                     read_text = blob.data_stream[3].read().decode("utf-8")
 
-                    self.assertEqual("", read_text)
+                    assert "" == read_text
 
 
     def test_remove_file(self):
@@ -159,25 +154,21 @@ class TestFeedstockIO(unittest.TestCase):
                 if repo is not None:
                     repo.index.add([filename])
 
-                self.assertTrue(os.path.exists(filename))
+                assert os.path.exists(filename)
                 if dirname:
-                    self.assertTrue(os.path.exists(dirname))
-                    self.assertTrue(os.path.exists(os.path.dirname(dirname)))
+                    assert os.path.exists(dirname)
+                    assert os.path.exists(os.path.dirname(dirname))
                 if repo is not None:
-                    self.assertTrue(
-                        list(repo.index.iter_blobs(BlobFilter(filename)))
-                    )
+                    assert list(repo.index.iter_blobs(BlobFilter(filename)))
 
                 fio.remove_file(pathfunc(filename))
 
-                self.assertFalse(os.path.exists(filename))
+                assert not os.path.exists(filename)
                 if dirname:
-                    self.assertFalse(os.path.exists(dirname))
-                    self.assertFalse(os.path.exists(os.path.dirname(dirname)))
+                    assert not os.path.exists(dirname)
+                    assert not os.path.exists(os.path.dirname(dirname))
                 if repo is not None:
-                    self.assertFalse(
-                        list(repo.index.iter_blobs(BlobFilter(filename)))
-                    )
+                    assert not list(repo.index.iter_blobs(BlobFilter(filename)))
 
 
     def test_copy_file(self):
@@ -192,33 +183,29 @@ class TestFeedstockIO(unittest.TestCase):
             with io.open(filename1, "w", encoding="utf-8") as fh:
                 fh.write(write_text)
 
-            self.assertTrue(os.path.exists(filename1))
-            self.assertFalse(os.path.exists(filename2))
+            assert os.path.exists(filename1)
+            assert not os.path.exists(filename2)
             if repo is not None:
-                self.assertFalse(
-                    list(repo.index.iter_blobs(BlobFilter(filename2)))
-                )
+                assert not list(repo.index.iter_blobs(BlobFilter(filename2)))
 
             fio.copy_file(pathfunc(filename1), pathfunc(filename2))
 
-            self.assertTrue(os.path.exists(filename1))
-            self.assertTrue(os.path.exists(filename2))
+            assert os.path.exists(filename1)
+            assert os.path.exists(filename2)
             if repo is not None:
-                self.assertTrue(
-                    list(repo.index.iter_blobs(BlobFilter(filename2)))
-                )
+                assert list(repo.index.iter_blobs(BlobFilter(filename2)))
 
             read_text = ""
             with io.open(filename2, "r", encoding="utf-8") as fh:
                 read_text = fh.read()
 
-            self.assertEqual(write_text, read_text)
+            assert write_text == read_text
 
             if repo is not None:
                 blob = next(repo.index.iter_blobs(BlobFilter(filename2)))[1]
                 read_text = blob.data_stream[3].read().decode("utf-8")
 
-                self.assertEqual(write_text, read_text)
+                assert write_text == read_text
 
 
     def tearDown(self):

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -29,16 +29,16 @@ class Test_linter(unittest.TestCase):
         lints = linter.lintify(meta)
         expected_msg = ("The top level meta keys are in an unexpected "
                         "order. Expecting ['package', 'source', 'build'].")
-        self.assertIn(expected_msg, lints)
+        assert expected_msg in lints
 
     def test_missing_about_license_and_summary(self):
         meta = {'about': {'home': 'a URL'}}
         lints = linter.lintify(meta)
         expected_message = "The license item is expected in the about section."
-        self.assertIn(expected_message, lints)
+        assert expected_message in lints
 
         expected_message = "The summary item is expected in the about section."
-        self.assertIn(expected_message, lints)
+        assert expected_message in lints
 
     def test_bad_about_license(self):
         meta = {'about': {'home': 'a URL',
@@ -46,7 +46,7 @@ class Test_linter(unittest.TestCase):
                           'license': 'unknown'}}
         lints = linter.lintify(meta)
         expected_message = "The recipe license cannot be unknown."
-        self.assertIn(expected_message, lints)
+        assert expected_message in lints
 
     def test_bad_about_license_family(self):
         meta = {'about': {'home': 'a URL',
@@ -55,14 +55,14 @@ class Test_linter(unittest.TestCase):
                           'license_family': 'BSD3'}}
         lints = linter.lintify(meta)
         expected = "about/license_family 'BSD3' not allowed"
-        self.assertTrue(any(lint.startswith(expected) for lint in lints))
+        assert any(lint.startswith(expected) for lint in lints)
 
     def test_missing_about_home(self):
         meta = {'about': {'license': 'BSD',
                           'summary': 'A test summary'}}
         lints = linter.lintify(meta)
         expected_message = "The home item is expected in the about section."
-        self.assertIn(expected_message, lints)
+        assert expected_message in lints
 
     def test_missing_about_home_empty(self):
         meta = {'about': {'home': '',
@@ -70,41 +70,41 @@ class Test_linter(unittest.TestCase):
                           'license': ''}}
         lints = linter.lintify(meta)
         expected_message = "The home item is expected in the about section."
-        self.assertIn(expected_message, lints)
+        assert expected_message in lints
 
         expected_message = "The license item is expected in the about section."
-        self.assertIn(expected_message, lints)
+        assert expected_message in lints
 
         expected_message = "The summary item is expected in the about section."
-        self.assertIn(expected_message, lints)
+        assert expected_message in lints
 
     def test_maintainers_section(self):
         expected_message = ('The recipe could do with some maintainers listed '
                             'in the `extra/recipe-maintainers` section.')
 
         lints = linter.lintify({'extra': {'recipe-maintainers': []}})
-        self.assertIn(expected_message, lints)
+        assert expected_message in lints
 
         # No extra section at all.
         lints = linter.lintify({})
-        self.assertIn(expected_message, lints)
+        assert expected_message in lints
 
         lints = linter.lintify({'extra': {'recipe-maintainers': ['a']}})
-        self.assertNotIn(expected_message, lints)
+        assert expected_message not in lints
 
         expected_message = ('The "extra" section was expected to be a '
                             'dictionary, but got a list.')
         lints = linter.lintify({'extra': ['recipe-maintainers']})
-        self.assertIn(expected_message, lints)
+        assert expected_message in lints
 
     def test_test_section(self):
         expected_message = 'The recipe must have some tests.'
 
         lints = linter.lintify({})
-        self.assertIn(expected_message, lints)
+        assert expected_message in lints
 
         lints = linter.lintify({'test': {'imports': 'sys'}})
-        self.assertNotIn(expected_message, lints)
+        assert expected_message not in lints
 
     def test_test_section_with_recipe(self):
         # If we have a run_test.py file, we shouldn't need to provide
@@ -114,12 +114,12 @@ class Test_linter(unittest.TestCase):
 
         with tmp_directory() as recipe_dir:
             lints = linter.lintify({}, recipe_dir)
-            self.assertIn(expected_message, lints)
+            assert expected_message in lints
 
             with io.open(os.path.join(recipe_dir, 'run_test.py'), 'w') as fh:
                 fh.write('# foo')
             lints = linter.lintify({}, recipe_dir)
-            self.assertNotIn(expected_message, lints)
+            assert expected_message not in lints
 
     def test_selectors(self):
         expected_message = ('Selectors are suggested to take a '
@@ -140,10 +140,10 @@ class Test_linter(unittest.TestCase):
                 else:
                     message = ("Expecting lints for '{}', but didn't get any."
                                "".format(selector))
-                self.assertEqual(not is_good,
+                assert (not is_good) == \
                                  any(lint.startswith(expected_message)
-                                     for lint in lints),
-                                 message)
+                                     for lint in lints), \
+                                 message
 
             assert_selector("name: foo_py3      # [py3k]")
             assert_selector("name: foo_py3  [py3k]", is_good=False)
@@ -170,12 +170,12 @@ class Test_linter(unittest.TestCase):
                           'script': 'python setup.py install',
                           'number': 0}}
         lints = linter.lintify(meta)
-        self.assertNotIn(expected_message, lints)
+        assert expected_message not in lints
 
         meta = {'build': {'skip': 'True',
                           'script': 'python setup.py install'}}
         lints = linter.lintify(meta)
-        self.assertIn(expected_message, lints)
+        assert expected_message in lints
 
     def test_bad_requirements_order(self):
         expected_message = ("The `requirements/build` section should be "
@@ -184,27 +184,27 @@ class Test_linter(unittest.TestCase):
         meta = {'requirements': OrderedDict([['run', 'a'],
                                              ['build', 'a']])}
         lints = linter.lintify(meta)
-        self.assertIn(expected_message, lints)
+        assert expected_message in lints
 
         meta = {'requirements': OrderedDict([['build', 'a'],
                                              ['run', 'a']])}
         lints = linter.lintify(meta)
-        self.assertNotIn(expected_message, lints)
+        assert expected_message not in lints
 
     def test_no_sha_with_dl(self):
         expected_message = ("When defining a source/url please add a sha256, "
                             "sha1 or md5 checksum (sha256 preferably).")
         meta = {'source': {'url': None}}
-        self.assertIn(expected_message, linter.lintify(meta))
+        assert expected_message in linter.lintify(meta)
 
         meta = {'source': {'url': None, 'sha1': None}}
-        self.assertNotIn(expected_message, linter.lintify(meta))
+        assert expected_message not in linter.lintify(meta)
 
         meta = {'source': {'url': None, 'sha256': None}}
-        self.assertNotIn(expected_message, linter.lintify(meta))
+        assert expected_message not in linter.lintify(meta)
 
         meta = {'source': {'url': None, 'md5': None}}
-        self.assertNotIn(expected_message, linter.lintify(meta))
+        assert expected_message not in linter.lintify(meta)
 
     def test_redundant_license(self):
         meta = {'about': {'home': 'a URL',
@@ -213,7 +213,7 @@ class Test_linter(unittest.TestCase):
         lints = linter.lintify(meta)
         expected_message = ('The recipe `license` should not include '
                             'the word "License".')
-        self.assertIn(expected_message, lints)
+        assert expected_message in lints
 
     def test_end_empty_line(self):
         bad_contents = [
@@ -241,9 +241,9 @@ class Test_linter(unittest.TestCase):
                 expected_message = ('There should be one empty line at the '
                                     'end of the file.')
                 if content == valid_content:
-                    self.assertNotIn(expected_message, lints)
+                    assert expected_message not in lints
                 else:
-                    self.assertIn(expected_message, lints)
+                    assert expected_message in lints
 
 
 class TestCLI_recipe_lint(unittest.TestCase):
@@ -260,7 +260,7 @@ class TestCLI_recipe_lint(unittest.TestCase):
                                       recipe_dir],
                                      stdout=subprocess.PIPE)
             out, _ = child.communicate()
-            self.assertEqual(child.returncode, 1, out)
+            assert child.returncode == 1, out
 
     def test_cli_success(self):
         with tmp_directory() as recipe_dir:
@@ -284,7 +284,7 @@ class TestCLI_recipe_lint(unittest.TestCase):
                                       recipe_dir],
                                      stdout=subprocess.PIPE)
             out, _ = child.communicate()
-            self.assertEqual(child.returncode, 0, out)
+            assert child.returncode == 0, out
 
     def test_cli_environ(self):
         with tmp_directory() as recipe_dir:
@@ -310,7 +310,7 @@ class TestCLI_recipe_lint(unittest.TestCase):
                                       recipe_dir],
                                      stdout=subprocess.PIPE)
             out, _ = child.communicate()
-            self.assertEqual(child.returncode, 0, out)
+            assert child.returncode == 0, out
 
     def test_unicode(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ def main():
         zip_safe=False,
         cmdclass=versioneer.get_cmdclass(),
         tests_require=['six'],
-        test_suite='conda_smithy',
     )
     setup(**skw)
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ def main():
         # not zip-safe.
         zip_safe=False,
         cmdclass=versioneer.get_cmdclass(),
-        tests_require=['six'],
     )
     setup(**skw)
 


### PR DESCRIPTION
As discussed in #357.

I suggest to review each commit individually to see the progress. 

Initially I just changed the runner to `pytest` and all tests pass:

```
$ coverage run --source . -m pytest conda_smithy/tests
============================= test session starts ==============================
platform linux -- Python 3.5.2, pytest-3.0.4, py-1.4.31, pluggy-0.4.0
rootdir: /home/travis/build/nicoddemus/conda-smithy, inifile: 
collected 28 items 
conda_smithy/tests/test_configure_feedstock.py ..
conda_smithy/tests/test_feedstock_io.py ......
conda_smithy/tests/test_lint_recipe.py ....................
========================== 28 passed in 6.59 seconds ===========================
```

Next I updated all `self.assert*` methods to plain asserts using [unittest2pytest](pypi.org/project/unittest2pytest).

~~Now I will work on using some of pytest features to simplify the tests.~~ 😁 

Converted all tests to use pytest's features like parametrization and fixtures. 😁 