### PR TITLE
Put conda-smithy version in first feedstock commit

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -110,7 +110,7 @@ class Init(Subcommand):
             meta = None
 
         feedstock_directory = args.feedstock_directory.format(package=argparse.Namespace(name=meta.name()))
-        msg = 'Initial commit of the {} feedstock.'.format(meta.name())
+        msg = 'Initial commit of the {} feedstock rendered with conda-smithy {}'.format(meta.name(), __version__)
 
         try:
             generate_feedstock_content(feedstock_directory, args.recipe_directory, meta)

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -110,7 +110,7 @@ class Init(Subcommand):
             meta = None
 
         feedstock_directory = args.feedstock_directory.format(package=argparse.Namespace(name=meta.name()))
-        msg = 'Initial commit of the {} feedstock rendered with conda-smithy {}'.format(meta.name(), __version__)
+        msg = 'Initial feedstock commit with conda-smithy {}.'.format(__version__)
 
         try:
             generate_feedstock_content(feedstock_directory, args.recipe_directory, meta)


### PR DESCRIPTION
So I pointed out in #374 that while re-rendered feedstock commits show the version number, the initial commit does not, but we should to help maintainers more easily determine if their feedstock is out of date when no other re-renderings have been done yet.