### PR TITLE
Move build status and version info badges near the top of the README

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -13,6 +13,35 @@ Summary: {{ package.meta.about.summary }}
 
 {% if package.meta.about.description %}{{ package.meta.about.description }}{% endif %}
 
+Current build status
+====================
+{%- set appveyor_url_name = github.repo_name.replace('_', '-').replace('.', '-') %}
+
+{%- set disabled_badge_commit = "90845bba35bec53edac7a16638aa4d77217a3713" %}
+{%- set disabled_badge_path = "conda_smithy/static/disabled.svg" %}
+{%- set disabled_badge_url = "https://cdn.rawgit.com/conda-forge/conda-smithy/%s/%s"|format(disabled_badge_commit, disabled_badge_path) %}
+{# #}
+{%- if circle.enabled %}
+Linux: [![Circle CI](https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }}.svg?style=shield)](https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }})
+{%- else %}
+Linux: ![]({{ disabled_badge_url }})
+{%- endif %}
+{%- if travis.enabled %}
+OSX: [![TravisCI](https://travis-ci.org/{{ github.user_or_org }}/{{ github.repo_name }}.svg?branch=master)](https://travis-ci.org/{{ github.user_or_org }}/{{ github.repo_name }})
+{%- else %}
+OSX: ![]({{ disabled_badge_url }})
+{%- endif %}
+{%- if appveyor.enabled %}
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/{{ github.user_or_org }}/{{ github.repo_name }}?svg=True)](https://ci.appveyor.com/project/{{ github.user_or_org }}/{{ appveyor_url_name }}/branch/master)
+{%- else %}
+Windows: ![]({{ disabled_badge_url }})
+{%- endif %}
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/{{ channel_name }}/{{ package.name() }}/badges/version.svg)](https://anaconda.org/{{ channel_name }}/{{ package.name() }})
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/{{ channel_name }}/{{ package.name() }}/badges/downloads.svg)](https://anaconda.org/{{ channel_name }}/{{ package.name() }})
+
 Installing {{ package.name() }}
 ==========={{ '=' * package.name()|length }}
 
@@ -69,35 +98,6 @@ Terminology
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
 {%- endif %}
-
-Current build status
-====================
-{%- set appveyor_url_name = github.repo_name.replace('_', '-').replace('.', '-') %}
-
-{%- set disabled_badge_commit = "90845bba35bec53edac7a16638aa4d77217a3713" %}
-{%- set disabled_badge_path = "conda_smithy/static/disabled.svg" %}
-{%- set disabled_badge_url = "https://cdn.rawgit.com/conda-forge/conda-smithy/%s/%s"|format(disabled_badge_commit, disabled_badge_path) %}
-{# #}
-{%- if circle.enabled %}
-Linux: [![Circle CI](https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }}.svg?style=shield)](https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }})
-{%- else %}
-Linux: ![]({{ disabled_badge_url }})
-{%- endif %}
-{%- if travis.enabled %}
-OSX: [![TravisCI](https://travis-ci.org/{{ github.user_or_org }}/{{ github.repo_name }}.svg?branch=master)](https://travis-ci.org/{{ github.user_or_org }}/{{ github.repo_name }})
-{%- else %}
-OSX: ![]({{ disabled_badge_url }})
-{%- endif %}
-{%- if appveyor.enabled %}
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/{{ github.user_or_org }}/{{ github.repo_name }}?svg=True)](https://ci.appveyor.com/project/{{ github.user_or_org }}/{{ appveyor_url_name }}/branch/master)
-{%- else %}
-Windows: ![]({{ disabled_badge_url }})
-{%- endif %}
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/{{ channel_name }}/{{ package.name() }}/badges/version.svg)](https://anaconda.org/{{ channel_name }}/{{ package.name() }})
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/{{ channel_name }}/{{ package.name() }}/badges/downloads.svg)](https://anaconda.org/{{ channel_name }}/{{ package.name() }})
 
 
 Updating {{ package.name() }}-feedstock


### PR DESCRIPTION
When checking if packages are available in `conda-forge`, I often look in https://conda-forge.github.io/feedstocks.html and if positive, click on the link. That lands in the feedstock page, and often I also need to check the version, in which case I have to scroll all the way down to see the version badges.

Also I check the badges of feedstocks I maintain to see if all builds passed after merging a PR to update the version as sometimes CI might fail on `master` for flaky reasons even if the builds passed during the PR.

I was going to open an issue and propose to write a PR if the response was positive, figured out easier to just open the PR and discuss it here.