### PR TITLE
bump macOS image to xcode6.4

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -9,7 +9,7 @@
 language: generic
 
 os: osx
-osx_image: beta-xcode6.1
+osx_image: xcode6.4
 
 {% block env -%}
 {% if matrix[0] or travis.secure -%}


### PR DESCRIPTION
Implementation of https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/6 , sibling of https://github.com/conda-forge/staged-recipes/pull/1094 .

Presumably shouldn't be merged until the CFEP is finalized.