### PR TITLE
Drop Obvious CI compiler activation on AppVeyor

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -4,11 +4,6 @@
 
 environment:
 
-  # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-  # /E:ON and /V:ON options are not enabled in the batch script intepreter
-  # See: http://stackoverflow.com/a/13751649/163740
-  CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
-
   {% for name, hashed_secure in (appveyor.secure or {}) | dictsort -%}
   {{ name }}:
     # The {{ name }} secure variable. This is defined canonically in conda-forge.yml.
@@ -54,7 +49,6 @@ install:
     - cmd: conda config --add channels {{ channel }}{% endfor %}
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     {% if build_setup -%}
     {{ build_setup }}{% endif %}
@@ -63,7 +57,7 @@ install:
 build: off
 
 test_script:
-    - "%CMD_IN_ENV% conda build {{ recipe_dir }} --quiet"
+    - conda build {{ recipe_dir }} --quiet
 deploy_script:
 {%- for owner, channel in channels['targets'] %}
     - cmd: {{ upload_script }} .\{{ recipe_dir }} {{ owner }} --channel={{ channel }}


### PR DESCRIPTION
It has come up several times in different discussions whether this compiler activation is still needed. There have been a few that have that state we should be able to outright drop it. Other suggestions have included moving it into the `toolchain` where it is used selectively for compilation as needed. There was a push to get much of this integrated into `conda-build`. I'm not really sure where we stand, but hopefully this can gather the discussion in one place and come to some sort of resolution. Please share your thoughts.

cc @patricksnape @jjhelmus @mwcraig @msarahan @pelson

xref: https://github.com/conda-forge/staged-recipes/pull/1142#discussion-diff-72016209R4
xref: https://github.com/conda-forge/toolchain-feedstock/issues/1
xref: https://github.com/conda/conda-build/pull/861
xref: https://github.com/conda/conda-build/pull/1189