### PR TITLE
Set CONDA_PY on AppVeyor (if undefined)

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -295,6 +295,9 @@ def render_appveyor(jinja_env, forge_config, forge_dir):
         for case in old_matrix:
             case = odict(case)
 
+            # Use Python 2.7 as a fallback when no Python version is set.
+            case["CONDA_PY"] = case.get("CONDA_PY", "27")
+
             # Set `root`'s `python` version.
             case["CONDA_INSTALL_LOCN"] = "C:\\\\Miniconda"
             if case.get("CONDA_PY") == "27":


### PR DESCRIPTION
This is done as it is used by the Obvious-CI compiler activation script for AppVeyor ( `obvci_appveyor_python_build_env.cmd` ). That script expects to get `TARGET_ARCH` and `CONDA_PY`. We already do a good job of setting `TARGET_ARCH` in the environment matrix. However, there was one case where `CONDA_PY` was not set. Namely if `python` was not a build dependency. Here we fix that to restore the old behavior of using Python 2.7 as the default, but we do this in the matrix to make it a bit clearer what it is we are doing.