### PR TITLE
Support conda 4.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,9 @@ env:
 
     matrix:
         - PYTHON=2.7
-          CONDA_PKGS='conda=4.1.*'
         - PYTHON=3.5
-          CONDA_PKGS='conda=4.1.* conda-build=1.*'
+          CONDA_PKGS='conda-build=1.*'
         - PYTHON=3.5
-          CONDA_PKGS='conda=4.1.*'
 
 install:
     - mkdir -p ${HOME}/cache/pkgs

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ env:
     matrix:
         - PYTHON=2.7
         - PYTHON=3.5
+          CONDA_PKGS='conda=4.1.* conda-env=2.5.* conda-build=1.*'
+        - PYTHON=3.5
+          CONDA_PKGS='conda=4.1.* conda-env=2.5.*'
+        - PYTHON=3.5
           CONDA_PKGS='conda-build=1.*'
         - PYTHON=3.5
 

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -501,7 +501,7 @@ def meta_of_feedstock(forge_dir, config=None):
 
 
 def compute_build_matrix(meta, existing_matrix=None):
-    index = conda.api.get_index()
+    index = conda.api.get_index(platform=meta_config(meta).subdir)
     mtx = special_case_version_matrix(meta, index)
     mtx = list(filter_cases(mtx, ['python >=2.7,<3|>=3.4', 'numpy >=1.10']))
     if existing_matrix:

--- a/conda_smithy/tests/test_configure_feedstock.py
+++ b/conda_smithy/tests/test_configure_feedstock.py
@@ -50,9 +50,9 @@ class Test_fudge_subdir(unittest.TestCase):
 
         # Get the index for OSX and Windows. They should be different.
         with cnfgr_fdstk.fudge_subdir('win-64', config):
-            win_index = conda.api.get_index()
+            win_index = conda.api.get_index(platform='win-64')
         with cnfgr_fdstk.fudge_subdir('osx-64', config):
-            osx_index = conda.api.get_index()
+            osx_index = conda.api.get_index(platform='osx-64')
         self.assertNotEqual(win_index.keys(), osx_index.keys(),
                             ('The keys for the Windows and OSX index were the same.'
                              ' Subdir is not working and will result in mis-rendering '


### PR DESCRIPTION
Appears the tests are now failing. Likely a product of `conda` version `4.2.13`, which we have recently released into the ecosystem. This PR is currently empty, but should prove fertile testing ground for a workaround and/or a fix.

Remember to revert the following pins after fixing this.
* [ ] https://github.com/conda-forge/staged-recipes/pull/2019
* [ ] https://github.com/conda-forge/conda-forge-webservices/pull/84 
* [ ] https://github.com/conda-forge/conda-forge-maintenance/pull/23
* [ ] https://github.com/conda-forge/conda-forge-webservices/pull/85
* [ ] https://github.com/conda-forge/conda-forge.github.io/pull/280