### PR TITLE
Pin `conda` to `4.1.x`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,11 @@ env:
 
     matrix:
         - PYTHON=2.7
+          CONDA_PKGS='conda=4.1.*'
         - PYTHON=3.5
-          CONDA_PKGS='conda-build=1.*'
+          CONDA_PKGS='conda=4.1.* conda-build=1.*'
         - PYTHON=3.5
+          CONDA_PKGS='conda=4.1.*'
 
 install:
     - mkdir -p ${HOME}/cache/pkgs


### PR DESCRIPTION
Temporarily pins `conda` to version `4.1.x` in CIs. This should workaround the testing failure until we have a better solution.