### PR TITLE
Fix shell variable expansion: RECIPE_ROOT and FEEDSTOCK_ROOT

### DIFF
--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -27,8 +27,8 @@ CONDARC
 )
 
 cat << EOF | docker run -i \
-                        -v ${RECIPE_ROOT}:/recipe_root \
-                        -v ${FEEDSTOCK_ROOT}:/feedstock_root \
+                        -v "${RECIPE_ROOT}":/recipe_root \
+                        -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         {{ docker.image }} \
                         {{ docker.command }} || exit $?


### PR DESCRIPTION
Wraps shell variables with double-quotes to accommodate paths with spaces. Follows up on the conversation [here](https://github.com/conda-forge/conda-forge.github.io/pull/288#issuecomment-267048286).