### PR TITLE
Fix source channel order in CIs

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -45,7 +45,7 @@ install:
     - cmd: set "OLDPATH=%PATH%"
     - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda config --set show_channel_urls true
-    {%- for channel in channels.get('sources', []) %}
+    {%- for channel in channels.get('sources', [])|reverse %}
     - cmd: conda config --add channels {{ channel }}{% endfor %}
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -13,7 +13,7 @@ docker info
 config=$(cat <<CONDARC
 
 channels:
-{%- for channel in channels.get('sources', []) | sort %}
+{%- for channel in channels.get('sources', []) %}
  - {{ channel }}
 {%- endfor %}
  - defaults # As we need conda-build

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -45,7 +45,7 @@ install:
 
       source /Users/travis/miniconda3/bin/activate root
 
-      {%- for channel in channels.get('sources', []) %}
+      {%- for channel in channels.get('sources', [])|reverse %}
       conda config --add channels {{ channel }}
       {%- endfor %}
       conda config --set show_channel_urls true


### PR DESCRIPTION
Appears the source channel order in AppVeyor and Travis CI config files was backwards. This reverses them to get the channels in the right priority order. Namely channels showing up first in `channels/sources` have highest priority and those showing up last in `channels/sources` have lowest priority. Also the CircleCI docker build was sorting the channels instead of preserving the order. This also drops that sort.