### PR TITLE
Handle defaults explicitly

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -529,7 +529,8 @@ def main(forge_file_directory):
               'travis': {},
               'circle': {},
               'appveyor': {},
-              'channels': {'sources': ['conda-forge'], 'targets': [['conda-forge', 'main']]},
+              'channels': {'sources': ['conda-forge', 'defaults'],
+                           'targets': [['conda-forge', 'main']]},
               'github': {'user_or_org': 'conda-forge', 'repo_name': ''},
               'recipe_dir': recipe_dir}
     forge_dir = os.path.abspath(forge_file_directory)

--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -41,17 +41,10 @@ install:
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
 
-    # Add our channels.
+    # Add a hack to update conda as the included copy is too old.
     - cmd: set "OLDPATH=%PATH%"
     - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
-    - cmd: conda config --set show_channel_urls true
-    {%- for channel in channels.get('sources', [])|reverse %}
-    - cmd: conda config --add channels {{ channel }}{% endfor %}
-
-    # Add a hack to switch to `conda` version `4.1.12` before activating.
-    # This is required to handle a long path activation issue.
-    # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: conda install --yes --quiet conda=4.1.12
+    - cmd: conda update --yes --quiet conda
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
@@ -59,6 +52,12 @@ install:
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
+    # Add our channels.
+    - cmd: conda config --set show_channel_urls true
+    {%- for channel in channels.get('sources', [])|reverse %}
+    - cmd: conda config --add channels {{ channel }}{% endfor %}
+
+    # Configure the VM.
     - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     {% if build_setup -%}

--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -54,6 +54,7 @@ install:
 
     # Add our channels.
     - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --remove channels defaults
     {%- for channel in channels.get('sources', [])|reverse %}
     - cmd: conda config --add channels {{ channel }}{% endfor %}
 

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -16,7 +16,6 @@ channels:
 {%- for channel in channels.get('sources', []) %}
  - {{ channel }}
 {%- endfor %}
- - defaults # As we need conda-build
 
 conda-build:
  root-dir: /feedstock_root/build_artefacts

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -44,7 +44,7 @@ install:
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root
-
+      conda config --remove channels defaults
       {%- for channel in channels.get('sources', [])|reverse %}
       conda config --add channels {{ channel }}
       {%- endfor %}


### PR DESCRIPTION
This adds `defaults` to the default set of channel sources for the feedstock. Also it makes sure that `defaults` does not get included in the CI unless it is explicitly added to channel sources for the feedstock.

Note: The constraint of requiring `defaults` to be added to channel sources explicitly (if the default setting are not used) is very important to ensure a proper interpretation of `defaults` as will be discussed in a latter PR.

Requires https://github.com/conda-forge/conda-smithy/pull/402