### PR TITLE
Config channels

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -71,7 +71,11 @@ def render_run_docker_build(jinja_env, forge_config, forge_dir):
     meta = forge_config['package']
     with fudge_subdir('linux-64', build_config=meta_config(meta)):
         meta.parse_again()
-        matrix = compute_build_matrix(meta, forge_config.get('matrix'))
+        matrix = compute_build_matrix(
+            meta,
+            forge_config.get('matrix'),
+            forge_config.get('channels', {}).get('sources', tuple())
+        )
         cases_not_skipped = []
         for case in matrix:
             pkgs, vars = split_case(case)
@@ -172,7 +176,11 @@ def render_circle(jinja_env, forge_config, forge_dir):
     meta = forge_config['package']
     with fudge_subdir('linux-64', build_config=meta_config(meta)):
         meta.parse_again()
-        matrix = compute_build_matrix(meta, forge_config.get('matrix'))
+        matrix = compute_build_matrix(
+            meta,
+            forge_config.get('matrix'),
+            forge_config.get('channels', {}).get('sources', tuple())
+        )
 
         cases_not_skipped = []
         for case in matrix:
@@ -225,7 +233,11 @@ def render_travis(jinja_env, forge_config, forge_dir):
     meta = forge_config['package']
     with fudge_subdir('osx-64', build_config=meta_config(meta)):
         meta.parse_again()
-        matrix = compute_build_matrix(meta, forge_config.get('matrix'))
+        matrix = compute_build_matrix(
+            meta,
+            forge_config.get('matrix'),
+            forge_config.get('channels', {}).get('sources', tuple())
+        )
 
         cases_not_skipped = []
         for case in matrix:
@@ -357,7 +369,11 @@ def render_appveyor(jinja_env, forge_config, forge_dir):
     for platform, arch in [['win-32', 'x86'], ['win-64', 'x64']]:
         with fudge_subdir(platform, build_config=meta_config(meta)):
             meta.parse_again()
-            matrix = compute_build_matrix(meta, forge_config.get('matrix'))
+            matrix = compute_build_matrix(
+                meta,
+                forge_config.get('matrix'),
+                forge_config.get('channels', {}).get('sources', tuple())
+            )
 
             cases_not_skipped = []
             for case in matrix:

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -500,8 +500,9 @@ def meta_of_feedstock(forge_dir, config=None):
     return meta
 
 
-def compute_build_matrix(meta, existing_matrix=None):
-    index = conda.api.get_index()
+def compute_build_matrix(meta, existing_matrix=None, channel_sources=tuple()):
+    channel_sources = tuple(channel_sources)
+    index = conda.api.get_index(channel_urls=channel_sources)
     mtx = special_case_version_matrix(meta, index)
     mtx = list(filter_cases(mtx, ['python >=2.7,<3|>=3.4', 'numpy >=1.10']))
     if existing_matrix:

--- a/conda_smithy/tests/test_configure_feedstock.py
+++ b/conda_smithy/tests/test_configure_feedstock.py
@@ -50,9 +50,11 @@ class Test_fudge_subdir(unittest.TestCase):
 
         # Get the index for OSX and Windows. They should be different.
         with cnfgr_fdstk.fudge_subdir('win-64', config):
-            win_index = conda.api.get_index(platform='win-64')
+            win_index = conda.api.get_index(channel_urls=['defaults'],
+                                            platform='win-64')
         with cnfgr_fdstk.fudge_subdir('osx-64', config):
-            osx_index = conda.api.get_index(platform='osx-64')
+            osx_index = conda.api.get_index(channel_urls=['defaults'],
+                                            platform='osx-64')
         self.assertNotEqual(win_index.keys(), osx_index.keys(),
                             ('The keys for the Windows and OSX index were the same.'
                              ' Subdir is not working and will result in mis-rendering '


### PR DESCRIPTION
This explicitly sets the channels used for generating the index. Instead of letting the index use whatever it can find, it uses the channel sources specified in `conda-forge.yml`. If the channel sources are not specified (i.e. all feedstocks in conda-forge), then this becomes `conda-forge` and `defaults`. Otherwise it uses whatever channels are specified (note `defaults` must be explicitly included if wanted). From very brief testing this seems to have the desired effect. Also includes a nifty workaround that should unblock re-rendering on Windows (*hopefully*), but this part is untested.

A test of using this can be seen with PR ( https://github.com/conda-forge/postgresql-feedstock/pull/6 ). Note that ordinarily re-rendering with the latest `conda-smithy` will not proceed correctly even with a correct `.condarc`. With these changes, the re-rendering proceeds smoothly as intended.

<br>

Fixes https://github.com/conda-forge/conda-smithy/issues/387
Fixes https://github.com/conda-forge/conda-smithy/issues/281
Fixes https://github.com/conda-forge/conda-smithy/issues/223

Closes https://github.com/conda-forge/postgresql-feedstock/pull/6
Closes https://github.com/conda-forge/py-feedstock/pull/1