### PR TITLE
Tidy up AppVeyor conda update

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -41,17 +41,10 @@ install:
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
 
-    # Add our channels.
+    # Add a hack to update conda as the included copy is too old.
     - cmd: set "OLDPATH=%PATH%"
     - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
-    - cmd: conda config --set show_channel_urls true
-    {%- for channel in channels.get('sources', [])|reverse %}
-    - cmd: conda config --add channels {{ channel }}{% endfor %}
-
-    # Add a hack to switch to `conda` version `4.1.12` before activating.
-    # This is required to handle a long path activation issue.
-    # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: conda install --yes --quiet conda=4.1.12
+    - cmd: conda update --yes --quiet conda
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
@@ -59,6 +52,12 @@ install:
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
+    # Add our channels.
+    - cmd: conda config --set show_channel_urls true
+    {%- for channel in channels.get('sources', [])|reverse %}
+    - cmd: conda config --add channels {{ channel }}{% endfor %}
+
+    # Configure the VM.
     - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     {% if build_setup -%}


### PR DESCRIPTION
Closes https://github.com/conda-forge/setuptools-feedstock/pull/47

Some of the changes included in here install a very particular version of `conda`. This was needed to fix some path manipulation bugs. ( https://github.com/conda-forge/conda-smithy/pull/329 ) Since then newer version have been released that we use successfully. So it makes sense to remove the pinning. However, the update is still needed as AppVeyor's included `conda` is so old.

Also we found ourselves in a situation where Python 2.7 jobs where running out of memory with particular configurations of the root environment when running `conda-forge-build-setup`. ( https://github.com/conda-forge/conda-smithy/issues/351 ) Some hacks were added to adjust the `root` environment to fix this. ( https://github.com/conda-forge/conda-smithy/pull/370 ) Though these appear to be no longer necessary.

These changes are tried out in PR ( https://github.com/conda-forge/setuptools-feedstock/pull/47 ).