### PR TITLE
Revert PR 404

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -41,11 +41,15 @@ install:
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
 
-    # Add path, activate `conda` and update conda.
+    # Add a hack to update conda as the included copy is too old.
+    - cmd: set "OLDPATH=%PATH%"
     - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda update --yes --quiet conda
-    - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+    - cmd: set "PATH=%OLDPATH%"
+    - cmd: set "OLDPATH="
 
+    # Actually activate `conda`.
+    - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.


### PR DESCRIPTION
Reverts PR ( https://github.com/conda-forge/conda-smithy/pull/404 ).

As mentioned in this [comment]( https://github.com/conda-forge/conda-smithy/pull/404#issuecomment-270047550 ), this path hack was found necessary in PR ( https://github.com/conda-forge/staged-recipes/pull/982 ) to update `conda` to a recent enough working version so that activation would work.

While I'm open to discussing and exploring how to do this in a cleaner in better way, it still remains necessary AFAICT. Any clean up of this should come with a demonstration of how it worked so that it can be more fully discussed.

cc @pelson @ocefpaf