### PR TITLE
Fix EOL formatting on Windows

### DIFF
--- a/conda_smithy/feedstock_io.py
+++ b/conda_smithy/feedstock_io.py
@@ -75,7 +75,12 @@ def remove_file(filename):
 
 
 def copy_file(src, dst):
-    shutil.copy2(src, dst)
+    with io.open(src, "r", encoding="utf-8") as fh_src:
+        with io.open(dst, "w", encoding="utf-8", newline="\n") as fh_dst:
+            for line in fh_src:
+                fh_dst.write(line)
+
+    shutil.copymode(src, dst)
 
     repo = get_repo(dst)
     if repo:

--- a/conda_smithy/feedstock_io.py
+++ b/conda_smithy/feedstock_io.py
@@ -47,7 +47,7 @@ def write_file(filename):
     if dirname and not os.path.exists(dirname):
         os.makedirs(dirname)
 
-    with io.open(filename, "w", encoding="utf-8") as fh:
+    with io.open(filename, "w", encoding="utf-8", newline="\n") as fh:
         yield fh
 
     repo = get_repo(filename)

--- a/conda_smithy/tests/test_feedstock_io.py
+++ b/conda_smithy/tests/test_feedstock_io.py
@@ -17,7 +17,7 @@ import conda_smithy.feedstock_io as fio
 
 def keep_dir(dirname):
     keep_filename = os.path.join(dirname, ".keep")
-    with io.open(keep_filename, "w", encoding="utf-8") as fh:
+    with io.open(keep_filename, "w", encoding="utf-8", newline="\n") as fh:
         fh.write("")
 
 
@@ -54,7 +54,7 @@ class TestFeedstockIO(unittest.TestCase):
         self.tmp_dir = tempfile.mkdtemp()
         os.chdir(self.tmp_dir)
 
-        with io.open(os.path.abspath(".keep"), "w", encoding="utf-8") as fh:
+        with io.open(os.path.abspath(".keep"), "w", encoding="utf-8", newline="\n") as fh:
             fh.write("")
 
 
@@ -84,7 +84,7 @@ class TestFeedstockIO(unittest.TestCase):
             for tmp_dir, repo, pathfunc in parameterize():
                 filename = "test.txt"
                 filename = os.path.join(tmp_dir, filename)
-                with io.open(filename, "w", encoding="utf-8") as fh:
+                with io.open(filename, "w", encoding="utf-8", newline="\n") as fh:
                     fh.write("")
                 if repo is not None:
                     repo.index.add([filename])
@@ -154,7 +154,7 @@ class TestFeedstockIO(unittest.TestCase):
 
                 filename = os.path.join(tmp_dir, filename)
 
-                with io.open(filename, "w", encoding="utf-8") as fh:
+                with io.open(filename, "w", encoding="utf-8", newline="\n") as fh:
                     fh.write("")
                 if repo is not None:
                     repo.index.add([filename])
@@ -189,7 +189,7 @@ class TestFeedstockIO(unittest.TestCase):
             filename2 = os.path.join(tmp_dir, filename2)
 
             write_text = "text"
-            with io.open(filename1, "w", encoding="utf-8") as fh:
+            with io.open(filename1, "w", encoding="utf-8", newline="\n") as fh:
                 fh.write(write_text)
 
             self.assertTrue(os.path.exists(filename1))


### PR DESCRIPTION
This configures git to normalize more line endings to avoid differences caused by a user's development environment (e.g. Windows vs. Unix). By doing this, we can be sure to get LF in all the cases we were already accustomed to having them. With Windows specific files (e.g. Batch files), we use CRLF as Windows would expect. This extends it beyond simply `bld.bat` as was the case before.