### PR TITLE
Use shell quotes for the current platform on the commit hint after re-rendering

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -229,8 +229,8 @@ class Regenerate(Subcommand):
                         print("")
                     else:
                         print(
-                            "You can commit the changes with:\n\n"
-                            "    git commit -m 'MNT: Re-rendered with conda-smithy %s'\n" % __version__
+                            'You can commit the changes with:\n\n'
+                            '    git commit -m "MNT: Re-rendered with conda-smithy %s"\n' % __version__
                         )
                     print("These changes need to be pushed to github!\n")
                 else:


### PR DESCRIPTION
As discussed in #407