### PR TITLE
Temporarily pin conda-build to 2.0.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-
 # The language in this case has no bearing - we are going to be making use of conda for a
 # python distribution for the scientific python stack.
 language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+
 # The language in this case has no bearing - we are going to be making use of conda for a
 # python distribution for the scientific python stack.
 language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 
     matrix:
         - PYTHON=2.7
-          CONDA_PKGS='conda=4.1.*'
+          CONDA_PKGS='conda=4.1.* conda-build=2.0.*'
         - PYTHON=3.5
           CONDA_PKGS='conda=4.1.* conda-build=1.*'
         - PYTHON=3.5


### PR DESCRIPTION
Encountering some strange test failures particularly on Python 2.7 since `conda-build` version 2.1.0 was released. This pins the `conda-build` 2 tests to 2.0.* to avoid these issues until we can properly address them. At present, these issues seem to only occur on the CIs and are not reproducible locally.