### PR TITLE
Bypass setup.py when testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 
 script:
     - coverage erase
-    - coverage run --source . setup.py test
+    - coverage run -m unittest discover
     - coverage report
 
 after_success:


### PR DESCRIPTION
Run the test suite through `unittest`'s `discover` option instead of using `setup.py`, which seems to be having issues.