### PR TITLE
Install enum34 in Python 2.7 CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-
 # The language in this case has no bearing - we are going to be making use of conda for a
 # python distribution for the scientific python stack.
 language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+
 # The language in this case has no bearing - we are going to be making use of conda for a
 # python distribution for the scientific python stack.
 language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 
     matrix:
         - PYTHON=2.7
-          CONDA_PKGS='conda=4.1.*'
+          CONDA_PKGS='conda=4.1.* enum34'
         - PYTHON=3.5
           CONDA_PKGS='conda=4.1.* conda-build=1.*'
         - PYTHON=3.5


### PR DESCRIPTION
Closes https://github.com/conda-forge/conda-smithy/pull/410

This is a workaround for `conda-build` 2.1.0 packages that are missing the requirement on `enum34` in their Python 2.7 packages. It can be reverted after that is fixed.

xref: https://github.com/conda/conda-build/issues/1623