### PR TITLE
Drop enum34 conda-build workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 
     matrix:
         - PYTHON=2.7
-          CONDA_PKGS='conda=4.1.* enum34'
+          CONDA_PKGS='conda=4.1.*'
         - PYTHON=3.5
           CONDA_PKGS='conda=4.1.* conda-build=1.*'
         - PYTHON=3.5


### PR DESCRIPTION
Reverts https://github.com/conda-forge/conda-smithy/pull/414

Looks like the packages in `defaults` have just been updated to include `enum34` as a requirement. So it looks like we don't need this workaround after all.