### PR TITLE
Drop NumPy 1.10.x

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -563,7 +563,7 @@ def compute_build_matrix(meta, existing_matrix=None, channel_sources=tuple()):
     index = conda.api.get_index(channel_urls=channel_sources,
                                 platform=meta_config(meta).subdir)
     mtx = special_case_version_matrix(meta, index)
-    mtx = list(filter_cases(mtx, ['python >=2.7,<3|>=3.5', 'numpy >=1.10']))
+    mtx = list(filter_cases(mtx, ['python >=2.7,<3|>=3.5', 'numpy >=1.11']))
     if existing_matrix:
         mtx = [tuple(mtx_case) + tuple(MatrixCaseEnvVar(*item) for item in case)
                for case in sorted(existing_matrix)


### PR DESCRIPTION
We are not in a hurry to merge this.  I am leaving this PR here as a remainder that we agreed to drop `numpy 1.10.x` from the build matrix soon.

https://github.com/conda-forge/staged-recipes/pull/2177