### PR TITLE
Workaround for windows file path size limit issue

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -64,7 +64,7 @@ install:
 build: off
 
 test_script:
-    - "%CMD_IN_ENV% conda build {{ recipe_dir }} --quiet --no-build-id"
+    - "%CMD_IN_ENV% conda build {{ recipe_dir }} --quiet --no-build-id --croot C:\"
 deploy_script:
 {%- for owner, channel in channels['targets'] %}
     - cmd: {{ upload_script }} .\{{ recipe_dir }} {{ owner }} --channel={{ channel }}

--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -64,7 +64,7 @@ install:
 build: off
 
 test_script:
-    - "%CMD_IN_ENV% conda build {{ recipe_dir }} --quiet"
+    - "%CMD_IN_ENV% conda build {{ recipe_dir }} --quiet --no-build-id"
 deploy_script:
 {%- for owner, channel in channels['targets'] %}
     - cmd: {{ upload_script }} .\{{ recipe_dir }} {{ owner }} --channel={{ channel }}

--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -64,7 +64,7 @@ install:
 build: off
 
 test_script:
-    - "%CMD_IN_ENV% conda build {{ recipe_dir }} --quiet --no-build-id --croot C:\"
+    - "%CMD_IN_ENV% conda build {{ recipe_dir }} --quiet --croot C:\\"
 deploy_script:
 {%- for owner, channel in channels['targets'] %}
     - cmd: {{ upload_script }} .\{{ recipe_dir }} {{ owner }} --channel={{ channel }}


### PR DESCRIPTION
Adding `--no-build-id` would shorten the file path and therefore enable
boost builds and others that have really long file paths