### PR TITLE
Drop Python 3.4 support

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -411,8 +411,6 @@ def render_appveyor(jinja_env, forge_config, forge_dir):
             case["CONDA_INSTALL_LOCN"] = "C:\\\\Miniconda"
             if case.get("CONDA_PY") == "27":
                 case["CONDA_INSTALL_LOCN"] += ""
-            elif case.get("CONDA_PY") == "34":
-                case["CONDA_INSTALL_LOCN"] += "3"
             elif case.get("CONDA_PY") in ("35", "36"):
                 case["CONDA_INSTALL_LOCN"] += "35"
 
@@ -565,7 +563,7 @@ def compute_build_matrix(meta, existing_matrix=None, channel_sources=tuple()):
     index = conda.api.get_index(channel_urls=channel_sources,
                                 platform=meta_config(meta).subdir)
     mtx = special_case_version_matrix(meta, index)
-    mtx = list(filter_cases(mtx, ['python >=2.7,<3|>=3.4', 'numpy >=1.10']))
+    mtx = list(filter_cases(mtx, ['python >=2.7,<3|>=3.5', 'numpy >=1.10']))
     if existing_matrix:
         mtx = [tuple(mtx_case) + tuple(MatrixCaseEnvVar(*item) for item in case)
                for case in sorted(existing_matrix)


### PR DESCRIPTION
Note: This does not need to be done right away. Just putting it up here for consideration.

As Python 3.6 is being included throughout feedstocks and Python 3.5 is still in use, it makes sense for us to drop our oldest Python 3 that still remains. The purpose of doing this is to cutdown on the CI burden from building so many things and maintenance burden associate with this and the older Python. So here we drop Python 3.4 from the matrix.

xref: https://github.com/conda-forge/staged-recipes/pull/2179