### PR TITLE
Add support for Python 3.6

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -370,7 +370,7 @@ def render_appveyor(jinja_env, forge_config, forge_dir):
                 case["CONDA_INSTALL_LOCN"] += ""
             elif case.get("CONDA_PY") == "34":
                 case["CONDA_INSTALL_LOCN"] += "3"
-            elif case.get("CONDA_PY") == "35":
+            elif case.get("CONDA_PY") in ("35", "36"):
                 case["CONDA_INSTALL_LOCN"] += "35"
 
             # Set architecture.


### PR DESCRIPTION
While technically re-rendering did work for Python 3.6, the Miniconda selected for Python 3.6 on AppVeyor was not the ideal choice. Namely it used the Python 2.7 one, which is built on VC9. Instead we change this so that Python 3.6 leverages the Python 3.5 Miniconda install, which uses the same VC14 runtime. Having the `root` Python version using the same VC as the one used in a build has tended to work well for us in the past and has generally been the strategy used. This returns us to that strategy for Python 3.6.