### PR TITLE
Drop Python 3.4 AppVeyor update hack remnant

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -42,9 +42,8 @@ install:
     - cmd: rmdir C:\cygwin /s /q
 
     # Add path, activate `conda` and update conda.
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
-    - cmd: conda update --yes --quiet conda
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+    - cmd: conda update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
This remnant was part of a hack to make sure AppVeyor's preincluded Miniconda for Python 3.4 had a new enough version of `conda`. The included version could not be activated properly so this was necessary to make it work. However, we have since dropped support for Python 3.4. Further the preincluded Python 3.5 Miniconda has a very recent version of `conda`. As a result, this hack is no longer necessary and can be dropped.

Edit: Please see these [builds]( https://ci.appveyor.com/project/jakirkham/setuptools-feedstock/build/1.0.57 ) for tests of this change.

xref: https://github.com/conda-forge/staged-recipes/pull/2203