### PR TITLE
Fix Homebrew uninstall step to ignore dependencies

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -32,7 +32,7 @@ env:
 
 before_install:
     # Remove homebrew.
-    - brew remove --force $(brew list)
+    - brew remove --force --ignore-dependencies $(brew list)
     - brew cleanup -s
     - rm -rf $(brew --cache)
 


### PR DESCRIPTION
Apparently `--force` is no longer sufficient when telling Homebrew to uninstall packages. If it turns out the packages are require by other packages, then `brew` will balk and issue an error message suggesting one also use `--ignore-dependencies`. Please see this [build]( https://travis-ci.org/conda-forge/conda-smithy-feedstock/jobs/191571328#L47 ) as an example. So we add `--ignore-dependencies` here in the hopes that this will get Homebrew to comply with our uninstall request.