### PR TITLE
DOC: Fix indentation in target channel example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ of organization with `--user github_user_name`.
 Optionally, you can choose a channel to upload to in `conda-forge.yml`.
   ```
   channels:
-   targets:
-     - [target_channel, target_label]
+    targets:
+      - [target_channel, target_label]
   ```
   Default is `[conda-forge, main]`.
   


### PR DESCRIPTION
Appears there was one space missing from each indented line. This appears to have resulted in a weird rendering of the code block by GitHub, which misses any of the indentation. Adding one more space to each indented line as done here should fix that.

Thanks to @guyer for [spotting this]( https://github.com/conda-forge/conda-smithy/issues/431#issuecomment-272671303 ).