### PR TITLE
Explicitly disable secrets in forked PRs

### DIFF
--- a/conda_smithy/ci_register.py
+++ b/conda_smithy/ci_register.py
@@ -96,6 +96,11 @@ def add_project_to_circle(user, project):
     # Note, here we are using a non-public part of the API and may change
     # Enable building PRs from forks
     url = url_template.format(component='{}/{}/settings'.format(user, project).lower(), token=circle_token)
+    # Disable CircleCI secrets in builds of forked PRs explicitly.
+    response = requests.put(url, headers=headers, json={'feature_flags':{'forks-receive-secret-env-vars':False}})
+    if response.status_code != 200:
+        response.raise_for_status()
+    # Enable CircleCI builds on forked PRs.
     response = requests.put(url, headers=headers, json={'feature_flags':{'build-fork-prs':True}})
     if response.status_code != 200:
         response.raise_for_status()


### PR DESCRIPTION
Seems that CircleCI was using a deploy key with forked PR builds. However, they were not exposing the secret environment variables before. Though now it appears that they are exposing secret environment variables too. This is a bit strange as the CircleCI defaults to having the setting for secret environment variables disabled by default. In other words, it appears this default is not respected by CircleCI currently.

As a workaround, we seem to be able to fix this by explicitly disabling secret environment variables as well. A little bit of testing verifies this works as intended. While it is a workaround, it is a good thing to keep should CircleCI ever change the default value of this setting. Thus we have added this change to the configuration of CircleCI on new feedstocks right after project creation in this commit.

Should note this also uses a non-public portion of the API as does enabling PRs from forks. However, we have gotten assurances from CircleCI before that this is ok to use.