### PR TITLE
verify that docker script reached its end

### DIFF
--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -58,4 +58,5 @@ EOF
 # double-check that the build got to the end
 # see https://github.com/conda-forge/conda-smithy/pull/337
 # for a possible fix
+set -x
 test -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done" || exit 1

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -25,6 +25,8 @@ show_channel_urls: true
 CONDARC
 )
 
+rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
+
 cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
@@ -50,5 +52,10 @@ conda build /recipe_root --quiet || exit 1
 {%- endfor -%}
 {%- endblock -%}
 
+touch /feedstock_root/build_artefacts/conda-forge-build-done
 EOF
 
+# double-check that the build got to the end
+# see https://github.com/conda-forge/conda-smithy/pull/337
+# for a possible fix
+test -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done" || exit 1

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -32,7 +32,7 @@ cat << EOF | docker run -i \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         {{ docker.image }} \
-                        {{ docker.command }} || exit $?
+                        {{ docker.command }} || exit 1
 
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
 export PYTHONUNBUFFERED=1


### PR DESCRIPTION
protects against early termination appearing as success.

This is one small piece of #337, but might be reviewed and merged more easily because it doesn't change anything, just adds a check that the script finished executing.

This would at least turn the cases fixed by #337 into failures, rather than mysteriously missing packages.