### PR TITLE
Fast finish old PR builds on CIs

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -45,6 +45,7 @@ def create_git_repo(target, msg):
     # Ensure shell scripts have executable permissions.
     executable_files = [
         "ci_support/checkout_merge_commit.sh",
+        "ci_support/fast_finish_ci_pr_build.sh",
         "ci_support/run_docker_build.sh",
     ]
     for each_executable_file in executable_files:

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -91,6 +91,7 @@ def render_circle(jinja_env, forge_config, forge_dir):
 
         target_fnames = [
             os.path.join(forge_dir, 'ci_support', 'checkout_merge_commit.sh'),
+            os.path.join(forge_dir, 'ci_support', 'fast_finish_ci_pr_build.sh'),
             os.path.join(forge_dir, 'ci_support', 'run_docker_build.sh'),
         ]
         for each_target_fname in target_fnames:
@@ -166,6 +167,7 @@ def render_circle(jinja_env, forge_config, forge_dir):
         # Fix permissions.
         target_fnames = [
             os.path.join(forge_dir, 'ci_support', 'checkout_merge_commit.sh'),
+            os.path.join(forge_dir, 'ci_support', 'fast_finish_ci_pr_build.sh'),
             os.path.join(forge_dir, 'ci_support', 'run_docker_build.sh'),
         ]
         for each_target_fname in target_fnames:

--- a/conda_smithy/feedstock_content/ci_support/fast_finish_ci_pr_build.sh
+++ b/conda_smithy/feedstock_content/ci_support/fast_finish_ci_pr_build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+     python - -v --ci "circle" "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BUILD_NUM}" "${CIRCLE_PR_NUMBER}"

--- a/conda_smithy/feedstock_content/ci_support/fast_finish_ci_pr_build.sh
+++ b/conda_smithy/feedstock_content/ci_support/fast_finish_ci_pr_build.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
-     python - -v --ci "circle" "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BUILD_NUM}" "${CIRCLE_PR_NUMBER}"

--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -30,9 +30,7 @@ platform:
 install:
     # If there is a newer build queued for the same PR, cancel this one.
     - cmd: |
-        curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py > ff_ci_pr_build.py
-        ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
-        del ff_ci_pr_build.py
+        {{ fast_finish }}
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q

--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -29,14 +29,10 @@ platform:
 
 install:
     # If there is a newer build queued for the same PR, cancel this one.
-    # The AppVeyor 'rollout builds' option is supposed to serve the same
-    # purpose but it is problematic because it tends to cancel builds pushed
-    # directly to master instead of just PR builds (or the converse).
-    # credits: JuliaLang developers.
-    - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-          throw "There are newer queued builds for this pull request, failing early." }
+    - cmd: |
+        curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py > ff_ci_pr_build.py
+        ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
+        del ff_ci_pr_build.py
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q

--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -11,6 +11,7 @@ general:
 {%- if matrix -%}
 checkout:
   post:
+    - ./ci_support/fast_finish_ci_pr_build.sh
     - ./ci_support/checkout_merge_commit.sh
 
 machine:

--- a/conda_smithy/templates/fast_finish_ci_pr_build.sh.tmpl
+++ b/conda_smithy/templates/fast_finish_ci_pr_build.sh.tmpl
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+{{fast_finish}}
+{##}

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -33,8 +33,7 @@ env:
 before_install:
     # Fast finish the PR.
     - |
-      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
-          python - -v --ci "travis" "${TRAVIS_REPO_SLUG}" "${TRAVIS_BUILD_NUMBER}" "${TRAVIS_PULL_REQUEST}") || exit 1
+      {{ fast_finish }}
 
     # Remove homebrew.
     - |

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -31,6 +31,11 @@ env:
 {% endblock %}
 
 before_install:
+    # Fast finish the PR.
+    - |
+      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+          python - -v --ci "travis" "${TRAVIS_REPO_SLUG}" "${TRAVIS_BUILD_NUMBER}" "${TRAVIS_PULL_REQUEST}") || exit 1
+
     # Remove homebrew.
     - |
       echo ""


### PR DESCRIPTION
Closes https://github.com/conda-forge/setuptools-feedstock/pull/59
Closes https://github.com/conda-forge/conda-forge-build-setup-feedstock/pull/55

Same thing as PR ( https://github.com/conda-forge/staged-recipes/pull/2264 ) except for the feedstocks.

Downloads the same Python script to help fast finish old PR builds on the various CIs as is used at staged-recipes. Tweaked to use the included script for `conda-forge-build-setup`.

A test of this on an ordinary feedstock can be seen in PR ( https://github.com/conda-forge/setuptools-feedstock/pull/59 ). Similarly a test for `conda-forge-build-setup` can be seen in PR ( https://github.com/conda-forge/conda-forge-build-setup-feedstock/pull/55 ).