### PR TITLE
fix typos in clone functions

### DIFF
--- a/conda_smithy/feedstocks.py
+++ b/conda_smithy/feedstocks.py
@@ -73,7 +73,7 @@ def fetch_feedstocks(feedstock_directory):
 
 
 def feedstocks_list_handle_args(args):
-   for repo in feedstock_repos(args.organization):
+    for repo in feedstock_repos(args.organization):
         print(repo.name)
 
 
@@ -83,7 +83,7 @@ def clone_feedstock(feedstock_gh_repo, feedstocks_dir):
     clone_directory = os.path.join(feedstocks_dir, repo.name)
     if not os.path.exists(clone_directory):
         print('Cloning {}'.format(repo.name))
-        new_repo = Repo.clone_from(repo.clone_url, clone_directory)
+        clone = Repo.clone_from(repo.clone_url, clone_directory)
         clone.delete_remote('origin')
     clone = Repo(clone_directory)
     if 'upstream' in [remote.name for remote in clone.remotes]:


### PR DESCRIPTION
There as a mixup in the lines. This caused the `clone_feedstock` function to fail because the clone variable doesn't exist. This also caused a silent error in `clone_all`  in the multiprocessing. Now it should work. Btw if we replace the explicit multiprocessing code with joblib the exception will always be thrown for us in the main thread.


