### PR TITLE
Add a terminal newline to `run_docker_build.sh`

### DIFF
--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -60,3 +60,4 @@ EOF
 # for a possible fix
 set -x
 test -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done" || exit 1
+


### PR DESCRIPTION
A terminal newline was dropped from `run_docker_build.sh` in PR ( https://github.com/conda-forge/conda-smithy/pull/454 ). This adds it back.