### PR TITLE
Update setting major_py_version

### DIFF
--- a/bootstrap-obvious-ci-and-miniconda.py
+++ b/bootstrap-obvious-ci-and-miniconda.py
@@ -46,7 +46,7 @@ def miniconda_url(target_system, target_arch, major_py_version, miniconda_versio
 
     if major_py_version not in ['2', '3']:
         raise ValueError('Unexpected major Python version {!r}.'.format(major_py_version))
-    template_values['major_py_version'] = major_py_version if major_py_version == '3' else ''
+    template_values['major_py_version'] = major_py_version
     
     return MINICONDA_URL_TEMPLATE.format(**template_values)
 


### PR DESCRIPTION
The download URL for miniconda2 has changed slightly. In particular, it now expects the '2' (that is, the major python version) after 'Miniconda' in the download filename, e.g.:

`https://repo.continuum.io/miniconda/Miniconda-latest-Windows-x86.exe` --> `https://repo.continuum.io/miniconda/Miniconda2-latest-Windows-x86.exe`.

Note this only affects downloading miniconda2 as the download url for miniconda3 always expected the major python version to be specified in the filename.