### PR TITLE
Allow to tweak docker executable in run_docker_build

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -645,7 +645,9 @@ def main(forge_file_directory):
     build_config.CONDA_PY = 10
 
     recipe_dir = 'recipe'
-    config = {'docker': {'image': 'condaforge/linux-anvil', 'command': 'bash'},
+    config = {'docker': {'executable': 'docker',
+                         'image': 'condaforge/linux-anvil',
+                         'command': 'bash'},
               'templates': {'run_docker_build': 'run_docker_build_matrix.tmpl'},
               'travis': {},
               'circle': {},

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -27,7 +27,7 @@ CONDARC
 
 rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
 
-cat << EOF | docker run -i \
+cat << EOF | {{ docker.executable }} run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \


### PR DESCRIPTION
This is a minimal change that adds *docker.executable* to the configurable parameters of *run_docker_build*. The goal is to be able to change the command to *nvidia-docker*, so that gpus get exposed during build, and specially test, whenever needed.