### PR TITLE
Manage teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ directory called `foo-feedstock`, populates it with CI setup skeletons, adds the
 2. **Create a github repo:** `conda smithy register-github --organization conda-forge ./foo-feedstock`.
 This requires a github token. You can try it out with a github user account
 instead of an organization by replacing the organization argument with
-`--user github_user_name`.
+`--user github_user_name`. If you are interested in adding teams for your feedstocks,
+you can provide the `--add-teams` option to create them. This can be done when creating
+the feedstock or after.
 3. **Register the feedstock with CI services:**
 `conda smithy register-ci --organization conda-forge --feedstock_directory ./foo-feedstock`.
 This requires tokens for the CI services. You can give the name of a user instead

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -111,6 +111,10 @@ class RegisterGithub(Subcommand):
         #  conda-smithy register-github ./ --organization=conda-forge
         super(RegisterGithub, self).__init__(parser, "Register a repo for a feedstock at github.")
         scp = self.subcommand_parser
+        scp.add_argument("--add-teams",
+                         action='store_true',
+                         default=False,
+                         help="Create teams and register maintainers to them.")
         scp.add_argument("feedstock_directory",
                          help="The directory of the feedstock git repository.")
         group = scp.add_mutually_exclusive_group()

--- a/conda_smithy/github.py
+++ b/conda_smithy/github.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, print_function
 
 import os
+import random
+from random import choice
 
 import git
 from git import Repo
@@ -8,6 +10,8 @@ from git import Repo
 import github
 from github import Github
 from github.GithubException import GithubException
+from github.Organization import Organization
+from github.Team import Team
 
 from . import configure_feedstock
 
@@ -21,6 +25,31 @@ def gh_token():
                'a token with repo access. Put it in ~/.conda-smithy/github.token')
         raise RuntimeError(msg)
     return token
+
+
+def create_team(org, name, description, repo_names=[]):
+    # PyGithub creates secret teams, and has no way of turning that off! :(
+    post_parameters = {
+        "name": name,
+        "description": description,
+        "privacy": "closed",
+        "permission": "push",
+        "repo_names": repo_names
+    }
+    headers, data = org._requester.requestJsonAndCheck(
+        "POST",
+        org.url + "/teams",
+        input=post_parameters
+    )
+    return Team(org._requester, headers, data, completed=True)
+
+
+def add_membership(team, member):
+    headers, data = team._requester.requestJsonAndCheck(
+        "PUT",
+        team.url + "/memberships/" + member
+    )
+    return (headers, data)
 
 
 def create_github_repo(args):
@@ -59,3 +88,80 @@ def create_github_repo(args):
                       "(it points to {}).".format(remote_name, gh_repo.ssh_url, existing_remote.url))
         else:
             repo.create_remote(remote_name, gh_repo.ssh_url)
+
+    # Add a team for this repo and add the maintainers to it.
+    if args.add_teams:
+        if isinstance(user_or_org, Organization):
+            superlative = [
+                'awesome', 'slick', 'formidable', 'awe-inspiring',
+                'breathtaking', 'magnificent', 'wonderous', 'stunning',
+                'astonishing', 'superb', 'splendid', 'impressive',
+                'unbeatable', 'excellent', 'top', 'outstanding', 'exalted',
+                'standout', 'smashing'
+            ]
+
+            maintainers = set(
+                meta.meta.get('extra', {}).get('recipe-maintainers', [])
+            )
+            teams = {team.name: team for team in user_or_org.get_teams()}
+            team_name = meta.name()
+
+            # Try to get team or create it if it doesn't exist.
+            team = teams.get(team_name)
+            current_maintainers = []
+            if not team:
+                team = create_team(
+                    user_or_org,
+                    team_name,
+                    'The {} {} contributors!'.format(
+                        choice(superlative), team_name
+                    )
+                )
+                teams[team_name] = team
+            else:
+                current_maintainers = team.get_members()
+            team.add_to_repos(gh_repo)
+
+            # Add only the new maintainers to the team.
+            current_maintainers_handles = set([
+                e.login.lower() for e in current_maintainers
+            ])
+            for new_maintainer in maintainers - current_maintainers_handles:
+                add_membership(team, new_maintainer)
+
+            # Mention any maintainers that need to be removed (unlikely here).
+            for old_maintainer in current_maintainers_handles - maintainers:
+                print(
+                    "AN OLD MEMBER ({}) NEEDS TO BE REMOVED FROM {}".format(
+                        old_maintainer, repo_name
+                    )
+                )
+
+            # Add new members to all-members team. Welcome! :)
+            team_name = 'all-members'
+            team = teams.get(team_name)
+            current_members = []
+            if not team:
+                team = create_team(
+                    user_or_org,
+                    team_name,
+                    "All of the awesome {} contributors!".format(
+                        user_or_org.name
+                    ),
+                    []
+                )
+                teams[team_name] = team
+            else:
+                current_members = team.get_members()
+
+            # Add only the new members to the team.
+            current_members_handles = set([
+                each_member.login.lower() for each_member in current_members
+            ])
+            for new_member in maintainers - current_members_handles:
+                print(
+                    "Adding a new member ({}) to {}. Welcome! :)".format(
+                        new_member, user_or_org.name
+                    )
+                )
+                add_membership(team, new_member)


### PR DESCRIPTION
The goal of this change is to handle team management at the level of `conda-smithy`. Particularly as part of GitHub registration. Currently team management is handled by two different scripts. One in staged-recipes, which populates the maintainer teams on feedstock creation. The other is part of the team and feedstocks update script. As we may need to replace the latter with something soon and there is already code duplication, it seems better to consolidate the working implementation in `conda-smithy` and have both scripts leverage it.

In addition to cutting down repeated code, this provides us the option going forward of handling team updates in a different way than we have thus far. In particular, we could use a web service to update teams as changes are made. This should provide us options that don't require scanning and updating all teams over the org in one cron job, which has been extremely problematic (subject to frequent failure, easily messed up by feedstock local changes, often running into GitHub rate limit, very rarely completing). However, these changes don't necessitate going in that particular direction, it does open the door for allowing us to explore different more viable options easily.

xref: https://github.com/conda-forge/conda-forge.github.io/issues/214
xref: https://github.com/conda-forge/conda-forge-webservices/issues/63