### PR TITLE
WIP: Cache miniconda installation on travis

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -11,6 +11,13 @@ language: generic
 os: osx
 osx_image: xcode6.4
 
+cache:
+  directories:
+  - $HOME/miniconda3
+
+before_cache:
+  - rm -rf $HOME/miniconda3/conda-bld
+
 {% block env -%}
 {% if matrix[0] or travis.secure -%}
 env:
@@ -49,11 +56,14 @@ install:
     # Install Miniconda.
     - |
       echo ""
-      echo "Installing a fresh version of Miniconda."
-      MINICONDA_URL="https://repo.continuum.io/miniconda"
-      MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
-      bash $MINICONDA_FILE -b
+      if [ ! -f $HOME/miniconda3/bin/activate ]; then
+          echo "Installing a fresh version of Miniconda."
+          MINICONDA_URL="https://repo.continuum.io/miniconda"
+          MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
+          curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+          rm -rf $HOME/miniconda3
+          bash $MINICONDA_FILE -b
+      fi
 
     # Configure conda.
     - |


### PR DESCRIPTION
This is an attempt to use travis cache to avoiding reinstalling miniconda from scratch every build.

Having to download, install miniconda and switch root packages to conda-forge versions can take a significant amount of time. Taking ```psutil-feedstock``` and https://travis-ci.org/gqmelo/psutil-feedstock/builds/210135431 as example:

- Installing miniconda takes ```~16.5s``` (15s, 18s, 17s for py27, py35, py36 respectively)
- Updating miniconda to switch to conda-forge packages takes ```~47s``` (45s, 51s, 45s for py27, py35, py36 respectively)
- Building the package takes ```~67``` (64s, 72s, 67s)

When the miniconda installation is gotten from cache (https://travis-ci.org/gqmelo/psutil-feedstock/builds/210140586):

- Installing miniconda is unecessary and is not done
- Updating miniconda to switch to conda-forge packages takes ```~25.5s``` (25s, 26s, 26s)
- Building the package takes ```~47``` (46s, 49s, 47s)

So, those are some nice improvements but the cache itself brings some overheads:

- It takes about 20s to create and upload the cache. This is done the first time and when travis detects a change on miniconda3 dir (not sure what it checks to decide that).
- It takes about  6s to download the cache on subsequent jobs.
- For some reason after a cache is found and downloaded, a homebrew update is triggered and takes a long to time to finish (more than 90s)

So if this homebrew update could be avoided we would get a 52s improvement (```16.5 + 21.5 + 20 - 6```), which I think it is quite good and an overhead of 20s on first builds (it should be better investigated when this happens).
