### PR TITLE
Add test case for configuring r related feedstocks. Fix compute_build_matrix in combination with build->skip.

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -603,6 +603,10 @@ def meta_of_feedstock(forge_dir, config=None):
 
 
 def compute_build_matrix(meta, existing_matrix=None, channel_sources=tuple()):
+    if meta.skip():
+        # return empty version matrix if build will be skipped
+        return set()
+
     channel_sources = tuple(channel_sources)
 
     # Override what `defaults` means depending on the platform used.

--- a/conda_smithy/tests/test_configure_feedstock.py
+++ b/conda_smithy/tests/test_configure_feedstock.py
@@ -90,7 +90,8 @@ class Test_fudge_subdir(unittest.TestCase):
                     self.assertEqual(meta.skip(), True)
 
                 matrix = cnfgr_fdstk.compute_build_matrix(
-                    meta
+                    meta,
+                    channel_sources=["defaults", "conda-forge"]
                 )
 
                 cases_not_skipped = []

--- a/conda_smithy/tests/test_configure_feedstock.py
+++ b/conda_smithy/tests/test_configure_feedstock.py
@@ -85,12 +85,13 @@ class Test_fudge_subdir(unittest.TestCase):
 
             def test(expect_skip=False):
                 meta.parse_again(**kwargs)
+                
+                if expect_skip:
+                    self.assertEqual(meta.skip(), True)
+
                 matrix = cnfgr_fdstk.compute_build_matrix(
                     meta
                 )
-
-                if expect_skip:
-                    self.assertEqual(meta.skip(), True)
 
                 cases_not_skipped = []
                 for case in matrix:

--- a/conda_smithy/tests/test_configure_feedstock.py
+++ b/conda_smithy/tests/test_configure_feedstock.py
@@ -85,7 +85,7 @@ class Test_fudge_subdir(unittest.TestCase):
 
             def test(expect_skip=False):
                 meta.parse_again(**kwargs)
-                
+
                 if expect_skip:
                     self.assertEqual(meta.skip(), True)
 
@@ -102,9 +102,6 @@ class Test_fudge_subdir(unittest.TestCase):
 
                 if expect_skip:
                     self.assertEqual(cases_not_skipped, [])
-
-            with cnfgr_fdstk.fudge_subdir('linux-32', config):
-                test()
 
             with cnfgr_fdstk.fudge_subdir('linux-64', config):
                 test()

--- a/conda_smithy/tests/test_configure_feedstock.py
+++ b/conda_smithy/tests/test_configure_feedstock.py
@@ -8,6 +8,7 @@ import conda_build.metadata
 import conda.api
 
 import conda_smithy.configure_feedstock as cnfgr_fdstk
+from conda_build_all.resolved_distribution import ResolvedDistribution
 
 
 @contextmanager
@@ -60,6 +61,61 @@ class Test_fudge_subdir(unittest.TestCase):
                              ' Subdir is not working and will result in mis-rendering '
                              '(e.g. https://github.com/SciTools/conda-build-all/issues/49).'))
 
+    def test_r(self):
+        with tmp_directory() as recipe_dir:
+            with open(os.path.join(recipe_dir, 'meta.yaml'), 'w') as fh:
+                fh.write("""
+                        package:
+                           name: r-test
+                           version: 1.0.0
+                        build:
+                           skip: True  # [win]
+                        requirements:
+                           build:
+                              - r-base
+                           run:
+                              - r-base
+                         """)
+            meta = conda_build.metadata.MetaData(recipe_dir)
+            config = cnfgr_fdstk.meta_config(meta)
+
+            kwargs = {}
+            if hasattr(conda_build, 'api'):
+                kwargs['config'] = config
+
+            def test(expect_skip=False):
+                meta.parse_again(**kwargs)
+                matrix = cnfgr_fdstk.compute_build_matrix(
+                    meta
+                )
+
+                if expect_skip:
+                    self.assertEqual(meta.skip(), True)
+
+                cases_not_skipped = []
+                for case in matrix:
+                    pkgs, vars = cnfgr_fdstk.split_case(case)
+                    with cnfgr_fdstk.enable_vars(vars):
+                        if not ResolvedDistribution(meta, pkgs).skip():
+                            cases_not_skipped.append(vars + sorted(pkgs))
+
+                if expect_skip:
+                    self.assertEqual(cases_not_skipped, [])
+
+            with cnfgr_fdstk.fudge_subdir('linux-32', config):
+                test()
+
+            with cnfgr_fdstk.fudge_subdir('linux-64', config):
+                test()
+
+            with cnfgr_fdstk.fudge_subdir('win-32', config):
+                test(expect_skip=True)
+
+            with cnfgr_fdstk.fudge_subdir('win-64', config):
+                test(expect_skip=True)
+
+            with cnfgr_fdstk.fudge_subdir('osx-64', config):
+                test()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This test case is able to reproduce the problems discussed in PR #453 (see [here](https://github.com/conda-forge/conda-smithy/pull/453#issuecomment-280058833)).
Further, the PR also contains the resulting fix.

@ocefpaf @jakirkham please let me know what you think.