### PR TITLE
Add condo-smithy skeleton command for easy recipe generation

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -243,6 +243,19 @@ class RecipeLint(Subcommand):
         sys.exit(int(not all_good))
 
 
+class Skeleton(Subcommand):
+    subcommand = 'skeleton'
+
+    def __init__(self, parser):
+        super(Skeleton, self).__init__(parser, "Make a conda-smithy skeleton")
+        scp = self.subcommand_parser
+        scp.add_argument("recipe_directory", default=[os.getcwd()], nargs='*')
+        scp.add_argument("source_directory", default=[os.getcwd()], nargs='*')
+
+    def __call__(self, args):
+        # All the skeleton generation code will go here
+        print('Skeleton created in folder: \n {}'.format(str(os.getcwd())))
+
 
 def main():
 


### PR DESCRIPTION
This is an intial attempt to add a `skeleton` command in conda-smithy along the lines of `conda skeleton pypy pyinstrument` which generates the .yaml files for builds. This is one of the GSoC 2017 ideas as discussed in the [ideas page](https://docs.google.com/document/d/1KSQvcP3Hxr60IhV-_dcGIb4IkmAEeAXNIqdX_2sqYoM/edit). 

This should probably be developed in way similar to the conda-build skeleton code. Specifically the [`skeletonize`](https://github.com/conda/conda-build/blob/master/conda_build/skeletons/pypi.py#L302) functions. There are skeleton generators for pypi, cran etc in the [skeleton folder](https://github.com/conda/conda-build/tree/master/conda_build/skeletons) in conda-build.