### PR TITLE
Require conda-build-all 1.0.2+

### DIFF
--- a/conda_smithy.recipe/meta.yaml
+++ b/conda_smithy.recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - setuptools
   run:
     - python
-    - conda-build-all
+    - conda-build-all >=1.0.2
     - conda
     - conda-build >=1.21.12,!=2.0.9
     - jinja2


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-smithy/issues/375
Fixes https://github.com/conda-forge/conda-smithy/issues/447

In order to correctly render R-based packages, `conda-build-all` 1.0.2 is required. Plus we need 1.0.0+ to get `conda-build` 2.x to work.