### PR TITLE
Specify channel for conda-forge-build-setup and obvious-ci installations

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -48,8 +48,8 @@ install:
     - cmd: conda config --add channels {{ channel }}{% endfor %}
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes obvious-ci -c conda-forge
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup -c conda-forge
+    - cmd: conda install -n root --quiet --yes -c conda-forge obvious-ci
+    - cmd: conda install -n root --quiet --yes -c conda-forge conda-forge-build-setup
     {% if build_setup -%}
     {{ build_setup }}{% endif %}
 

--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -48,8 +48,8 @@ install:
     - cmd: conda config --add channels {{ channel }}{% endfor %}
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes obvious-ci
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda install -n root --quiet --yes obvious-ci -c conda-forge
+    - cmd: conda install -n root --quiet --yes conda-forge-build-setup -c conda-forge
     {% if build_setup -%}
     {{ build_setup }}{% endif %}
 

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -41,7 +41,7 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artefacts.
 conda clean --lock
 
-conda install --yes --quiet conda-forge-build-setup -c conda-forge
+conda install --yes --quiet -c conda-forge conda-forge-build-setup
 {% if build_setup -%}
 {{ build_setup }}{% endif -%}
 

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -41,7 +41,7 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artefacts.
 conda clean --lock
 
-conda install --yes --quiet conda-forge-build-setup
+conda install --yes --quiet conda-forge-build-setup -c conda-forge
 {% if build_setup -%}
 {{ build_setup }}{% endif -%}
 

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -65,7 +65,7 @@ install:
       conda config --add channels {{ channel }}
       {%- endfor %}
       conda config --set show_channel_urls true
-      conda install --yes --quiet conda-forge-build-setup
+      conda install --yes --quiet conda-forge-build-setup -c conda-forge
       {% if build_setup -%}
       {{ build_setup }}{% endif %}
 

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -65,7 +65,7 @@ install:
       conda config --add channels {{ channel }}
       {%- endfor %}
       conda config --set show_channel_urls true
-      conda install --yes --quiet conda-forge-build-setup -c conda-forge
+      conda install --yes --quiet -c conda-forge conda-forge-build-setup
       {% if build_setup -%}
       {{ build_setup }}{% endif %}
 


### PR DESCRIPTION
When `conda-forge` is not listed in targets/sources, `conda-forge-build-setup` and `obvious-ci` can't be installed. This PR adds `conda-forge` channel to installation commands explicitly. These tools will always be downloaded from `conda-forge`, regardless of the channel list.