### PR TITLE
Setup path for curl on appveyor

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -28,6 +28,9 @@ platform:
     - x64
 
 install:
+    # Setup PATH for curl
+    - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+
     # If there is a newer build queued for the same PR, cancel this one.
     - cmd: |
         {{ fast_finish }}


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge.github.io/issues/357
Fixes https://github.com/conda-forge/conda-smithy/issues/487

The update of git in the latest build image of appveyor broke the windows build. Cf http://help.appveyor.com/discussions/problems/6312-curl-command-not-found