### PR TITLE
Download fast finish script with PowerShell

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -471,7 +471,7 @@ def render_appveyor(jinja_env, forge_config, forge_dir):
         if os.path.exists(cfbs_fpath):
             fast_finish_script += "{recipe_dir}\\ff_ci_pr_build".format(recipe_dir=forge_config["recipe_dir"])
         else:
-            get_fast_finish_script += "curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py > ff_ci_pr_build.py"
+            get_fast_finish_script += '''powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"'''
             fast_finish_script += "ff_ci_pr_build"
             fast_finish += "del {fast_finish_script}.py"
 


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge.github.io/issues/357
Fixes https://github.com/conda-forge/conda-smithy/issues/487
Closes https://github.com/conda-forge/conda-smithy/pull/486
Closes https://github.com/conda-forge/setuptools-feedstock/pull/62 (for testing)

It appears `curl` has moved off of the path on AppVeyor. ( https://github.com/appveyor/ci/issues/1426 ) While it is possible to move `curl` back onto the path, there are a couple of concerns. First this may result in including other things on the path that we don't intend to. Second those other things may get involved in builds corrupting packages we are trying to deploy. Third there was never any guarantee that `curl` would be included on Windows nor is there any guarantee it will still be there. So this changes the download command to make use of PowerShell to perform the download. This is something we can rely on. Therefore PowerShell should be a safe choice for long term usage.

Edit: A similar change has been proposed at staged-recipes ( https://github.com/conda-forge/staged-recipes/pull/2648 ).