### PR TITLE
[WIP] Remove skip from compute_build_matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,7 @@ env:
         - PYTHON=3.5
           CONDA_PKGS='conda=4.3.14 conda-build=2.1.7 conda-build-all=1.0.1 conda-env=2.6.0 conda-verify=2.0.0'
         - PYTHON=3.5
-          CONDA_PKGS='conda-build-all=1.0.1'
-        - PYTHON=3.5
-          CONDA_PKGS='conda-env=2.6.0'
+          CONDA_PKGS='conda-build-all=1.0.2 conda=4.3.14 conda-build=2.1.7 conda-env=2.6.0 conda-verify=2.0.0'
 
 install:
     - mkdir -p ${HOME}/cache/pkgs

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ env:
         - PYTHON=3.5
         - PYTHON=3.5
           CONDA_PKGS='conda=4.3.14 conda-build=2.1.7 conda-build-all=1.0.1 conda-env=2.6.0 conda-verify=2.0.0'
+        - PYTHON=3.5
+          CONDA_PKGS='conda=4.3.14'
 
 install:
     - mkdir -p ${HOME}/cache/pkgs

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
           CONDA_PKGS='conda-build=1.*'
         - PYTHON=3.5
         - PYTHON=3.5
-          CONDA_PKGS='conda=4.3.14 conda-build=2.1.4 conda-build-all=1.0.1 conda-env=2.6.0 conda-verify=2.0.0'
+          CONDA_PKGS='conda=4.3.14 conda-build=2.1.7 conda-build-all=1.0.1 conda-env=2.6.0 conda-verify=2.0.0'
 
 install:
     - mkdir -p ${HOME}/cache/pkgs

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
         - PYTHON=3.5
           CONDA_PKGS='conda-build=1.*'
         - PYTHON=3.5
+        - PYTHON=3.5
+          CONDA_PKGS='conda=4.3.14 conda-build=2.1.4 conda-build-all=1.0.1 conda-env=2.6.0 conda-verify=2.0.0'
 
 install:
     - mkdir -p ${HOME}/cache/pkgs

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ env:
         - PYTHON=3.5
           CONDA_PKGS='conda=4.3.14 conda-build=2.1.7 conda-build-all=1.0.1 conda-env=2.6.0 conda-verify=2.0.0'
         - PYTHON=3.5
-          CONDA_PKGS='conda=4.3.14'
+          CONDA_PKGS='conda-build-all=1.0.1'
+        - PYTHON=3.5
+          CONDA_PKGS='conda-env=2.6.0'
 
 install:
     - mkdir -p ${HOME}/cache/pkgs

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ env:
         - PYTHON=3.5
           CONDA_PKGS='conda-build=1.*'
         - PYTHON=3.5
-        - PYTHON=3.5
-          CONDA_PKGS='conda=4.3.14 conda-build=2.1.7 conda-build-all=1.0.1 conda-env=2.6.0 conda-verify=2.0.0'
-        - PYTHON=3.5
-          CONDA_PKGS='conda-build-all=1.0.2 conda=4.3.14 conda-build=2.1.7 conda-env=2.6.0 conda-verify=2.0.0'
 
 install:
     - mkdir -p ${HOME}/cache/pkgs
@@ -34,6 +30,7 @@ install:
     # Now do the things we need to do to install it.
     - conda install --file requirements.txt coverage=3 python-coveralls mock python=${PYTHON} ${CONDA_PKGS} --yes --quiet -c conda-forge
     - python setup.py install
+    - pip install git+https://github.com/johanneskoester/conda-build-all.git
 
 script:
     - coverage erase

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -603,10 +603,6 @@ def meta_of_feedstock(forge_dir, config=None):
 
 
 def compute_build_matrix(meta, existing_matrix=None, channel_sources=tuple()):
-    if meta.skip():
-        # return empty version matrix if build will be skipped
-        return set()
-
     channel_sources = tuple(channel_sources)
 
     # Override what `defaults` means depending on the platform used.


### PR DESCRIPTION
Instead, fix issue #488 by changes to conda-build-all, see SciTools/conda-build-all#82.

Currently, this PR pulls conda-build-all from my fork for demonstration. Once SciTools/conda-build-all#82 has been merged and released, we can update the dependency of conda-smithy.