### PR TITLE
Depend on conda-build-all 1.0.3. Remove previous workaround.

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -603,10 +603,6 @@ def meta_of_feedstock(forge_dir, config=None):
 
 
 def compute_build_matrix(meta, existing_matrix=None, channel_sources=tuple()):
-    if meta.skip():
-        # return empty version matrix if build will be skipped
-        return set()
-
     channel_sources = tuple(channel_sources)
 
     # Override what `defaults` means depending on the platform used.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # This list is duplicated in the conda_smithy.recipe/meta.yaml.
 
-conda-build-all
+conda-build-all >=1.0.3
 setuptools
 conda
 conda-build >=1.21.12,!=2.0.9


### PR DESCRIPTION
Use new, fixed conda-build-all. Solves issue #488, replaces pull request #492.