### PR TITLE
Mention that re-rendering does not need CI tokens set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ place them. If you need help getting tokens please ask on the
 
 You should be able to test parts of `conda-smithy` with whatever tokens you have.
 For example, you should be able to `conda smithy register-github` without the CI service tokens.
+Re-rendering an existing feedstock is also possible without CI service tokens set.
 
 Re-rendering an existing feedstock
 ----------------------------------
@@ -41,6 +42,7 @@ Re-rendering an existing feedstock
 Periodically feedstocks need to be upgraded to include new features. To do
 this we use `conda-smithy` to go through a process called re-rendering.
 Make sure you have installed `conda-smithy` before proceeding.
+Re-rendering an existing feedstock is possible without CI service tokens set.
 
 1. `cd <feedstock directory>`
 2. `conda smithy rerender [--commit]`


### PR DESCRIPTION
It seems to me that re-rendering an existing feedstock is also possible without CI service tokens set up (although the CLI will show some warnings about it).. see conda-forge/obspy-feedstock#13. I feel this should be mentioned in the README because that's probably the number one use case most people will come across..

Please correct me if I'm wrong and missing something..