### PR TITLE
Add check: package/name == recipe-dir

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -155,8 +155,8 @@ def lintify(meta, recipe_dir=None):
             os.path.basename(recipe_dir) != package_section.get('name','')):
         lints.append('The package name ("{}") does not match the recipe '
                      'directory name ("{}").'
-                     ''.format(os.path.basename(recipe_dir),
-                               package_section.get('name','')))
+                     ''.format(package_section.get('name',''),
+                               os.path.basename(recipe_dir)))
 
     return lints
 

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -47,6 +47,7 @@ def lintify(meta, recipe_dir=None):
     # find the meta.yaml within it.
     meta_fname = os.path.join(recipe_dir or '', 'meta.yaml')
 
+    package_section = get_section(meta, 'package', lints)
     source_section = get_section(meta, 'source', lints)
     build_section = get_section(meta, 'build', lints)
     requirements_section = get_section(meta, 'requirements', lints)
@@ -148,6 +149,14 @@ def lintify(meta, recipe_dir=None):
         ensure_valid_license_family(meta)
     except RuntimeError as e:
         lints.append(str(e))
+
+    # 13: The recipe directory name should be the name of the package.
+    if (recipe_dir is not None and
+            os.path.basename(recipe_dir) != package_section.get('name','')):
+        lints.append('The package name ("{}") does not match the recipe '
+                     'directory name ("{}").'
+                     ''.format(os.path.basename(recipe_dir),
+                               package_section.get('name','')))
 
     return lints
 

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -15,9 +15,11 @@ import conda_smithy.lint_recipe as linter
 
 
 @contextmanager
-def tmp_directory():
+def tmp_directory(dirname='test_package'):
     tmp_dir = tempfile.mkdtemp('recipe_')
-    yield tmp_dir
+    recipe_dir = os.path.join(tmp_dir, dirname)
+    os.mkdir(recipe_dir)
+    yield recipe_dir
     shutil.rmtree(tmp_dir)
 
 
@@ -252,6 +254,14 @@ class Test_linter(unittest.TestCase):
                     self.assertNotIn(expected_message, lints)
                 else:
                     self.assertIn(expected_message, lints)
+
+    def test_package_name_must_match_dir(self):
+        meta = { 'package': { 'name': 'wrong_package' } }
+        expected_message = ('The package name ("wrong_package") does not '
+                            'match the recipe directory name '
+                            '("test_package").')
+        self.assertIn(expected_message,
+                      linter.lintify(meta, recipe_dir='test_package'))
 
 
 class TestCLI_recipe_lint(unittest.TestCase):


### PR DESCRIPTION
Checks for mismatching `package/name:` and recipe directory as has happened in conda-forge/staged-recipes#2592 (fixed by conda-forge/staged-recipes#2718).

Also requires `package:` section to be present in `meta.yaml`

