### PR TITLE
check for conda < 4.3

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -8,6 +8,7 @@ import time
 import argparse
 
 import conda
+from distutils.version import LooseVersion
 from conda_build.metadata import MetaData
 
 from . import ci_register
@@ -274,8 +275,7 @@ def main():
         args = parser.parse_args()
 
     # Check conda version for compatibility
-    conda_version_tuple = tuple(map(int, conda.__version__.split('.')[:3]))
-    if conda_version_tuple > (4, 2):
+    if LooseVersion(conda.__version__) < LooseVersion('4.3'):
         print('You appear to be using conda {}, but conda-smithy {} is\ncurrently only compatible with conda versions < 4.3.'.format(
             conda.__version__, __version__))
         sys.exit(2)

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -7,6 +7,7 @@ import sys
 import time
 import argparse
 
+import conda
 from conda_build.metadata import MetaData
 
 from . import ci_register
@@ -271,6 +272,13 @@ def main():
         args = parser.parse_args(['--help'])
     else:
         args = parser.parse_args()
+
+    # Check conda version for compatibility
+    conda_version_tuple = tuple(map(int, conda.__version__.split('.')[:3]))
+    if conda_version_tuple > (4, 2):
+        print('You appear to be using conda {}, but conda-smithy {} is\ncurrently only compatible with conda versions < 4.3.'.format(
+            conda.__version__, __version__))
+        sys.exit(2)
 
     args.subcommand_func(args)
 

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -275,7 +275,7 @@ def main():
         args = parser.parse_args()
 
     # Check conda version for compatibility
-    if LooseVersion(conda.__version__) < LooseVersion('4.3'):
+    if LooseVersion(conda.__version__) >= LooseVersion('4.3'):
         print('You appear to be using conda {}, but conda-smithy {} is\ncurrently only compatible with conda versions < 4.3.'.format(
             conda.__version__, __version__))
         sys.exit(2)


### PR DESCRIPTION
as discussed in https://github.com/conda-forge/conda-smithy/issues/494
check for conda < 4.3, and if not found, print a message more informative than the exception which would otherwise arise (since currently we're incompatible with 4.3+)