### PR TITLE
Fix some Docker 'set [+-]x' flags

### DIFF
--- a/conda_smithy/templates/run_docker_build_matrix.tmpl
+++ b/conda_smithy/templates/run_docker_build_matrix.tmpl
@@ -9,9 +9,7 @@
   # Embarking on {{ matrix|length }} case(s).
 {%- for case in matrix %}
   {%- if case %}
-    set -x
     {{- matrix_env(case) }}
-    set +x
   {%- endif -%}
   {{- super()|indent(4) }}
 {% endfor %}{% endblock -%}


### PR DESCRIPTION
From my reading of the logs, the intention is to disable command echoing just for the stanza that sets the environment variables. The actual code was doing the opposite, however, no doubt because the bash notation is entirely counterintuitive.