### PR TITLE
Add `outputs:` to allowed meta.yaml sections

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -13,8 +13,8 @@ import ruamel.yaml
 from conda_build.metadata import ensure_valid_license_family
 
 
-EXPECTED_SECTION_ORDER = ['package', 'source', 'build', 'requirements',
-                          'outputs', 'test', 'app', 'about', 'extra']
+EXPECTED_SECTION_ORDER = ['package', 'source', 'build', 'outputs',
+                          'requirements', 'test', 'app', 'about', 'extra']
 
 REQUIREMENTS_ORDER = ['build', 'run']
 

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -14,7 +14,7 @@ from conda_build.metadata import ensure_valid_license_family
 
 
 EXPECTED_SECTION_ORDER = ['package', 'source', 'build', 'requirements',
-                          'outputs', 'test', 'app', 'about', 'extra']
+                          'test', 'app', 'outputs', 'about', 'extra']
 
 REQUIREMENTS_ORDER = ['build', 'run']
 

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -14,7 +14,7 @@ from conda_build.metadata import ensure_valid_license_family
 
 
 EXPECTED_SECTION_ORDER = ['package', 'source', 'build', 'requirements',
-                          'test', 'app', 'about', 'extra']
+                          'outputs', 'test', 'app', 'about', 'extra']
 
 REQUIREMENTS_ORDER = ['build', 'run']
 

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -13,8 +13,8 @@ import ruamel.yaml
 from conda_build.metadata import ensure_valid_license_family
 
 
-EXPECTED_SECTION_ORDER = ['package', 'source', 'build', 'outputs',
-                          'requirements', 'test', 'app', 'about', 'extra']
+EXPECTED_SECTION_ORDER = ['package', 'source', 'build', 'requirements',
+                          'outputs', 'test', 'app', 'about', 'extra']
 
 REQUIREMENTS_ORDER = ['build', 'run']
 


### PR DESCRIPTION
See #2582 for an example use-case (split hundreds of header files from main library package as they aren't needed in most scenarios).