### PR TITLE
Test conda 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ env:
         - PYTHON=3.5
           CONDA_PKGS='conda=4.2.* conda-env=2.5.* conda-build=2.1.*'
         - PYTHON=3.5
-          CONDA_PKGS='conda-build=1.*'
-        - PYTHON=3.5
 
 install:
     - mkdir -p ${HOME}/cache/pkgs

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
         - PYTHON=3.5
           CONDA_PKGS='conda=4.1.* conda-env=2.5.* conda-build=2.1.4'
         - PYTHON=3.5
+          CONDA_PKGS='conda=4.2.* conda-env=2.5.* conda-build=2.1.*'
+        - PYTHON=3.5
           CONDA_PKGS='conda-build=1.*'
         - PYTHON=3.5
 

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -275,8 +275,8 @@ def main():
         args = parser.parse_args()
 
     # Check conda version for compatibility
-    if LooseVersion(conda.__version__) >= LooseVersion('4.3'):
-        print('You appear to be using conda {}, but conda-smithy {} is\ncurrently only compatible with conda versions < 4.3.'.format(
+    if LooseVersion(conda.__version__) >= LooseVersion('4.4'):
+        print('You appear to be using conda {}, but conda-smithy {} is\ncurrently only compatible with conda versions < 4.4.'.format(
             conda.__version__, __version__))
         sys.exit(2)
 


### PR DESCRIPTION
* Adds `conda` 4.2 to the CI matrix.
* Unspecified case is now `conda` 4.3.
* Drop a `conda-build` 1.* case with `conda` 4.3 (won't work and `conda-build` 1 is old).
* Update `conda` upper bound to 4.4.