### PR TITLE
Support CircleCI 2.0

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -201,7 +201,7 @@ def render_circle(jinja_env, forge_config, forge_dir):
         for each_target_fname in target_fnames:
             set_exe_file(each_target_fname, True)
 
-    target_fname = os.path.join(forge_dir, 'circle.yml')
+    target_fname = os.path.join(forge_dir, '.circleci', 'config.yml')
     template = jinja_env.get_template('circle.yml.tmpl')
     with write_file(target_fname) as fh:
         fh.write(template.render(**forge_config))
@@ -665,6 +665,7 @@ def main(forge_file_directory):
     old_files = [
         'disabled_appveyor.yml',
         os.path.join('ci_support', 'upload_or_check_non_existence.py'),
+        'circle.yml',
     ]
     for old_file in old_files:
         remove_file(os.path.join(forge_dir, old_file))

--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -1,3 +1,5 @@
+version: 2
+
 {%- block env_branches -%}
 {%- if not matrix -%}
 general:

--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -1,11 +1,11 @@
 version: 2
 
 jobs:
+{%- block env_test -%}
+{%- if not matrix %}
   build:
     working_directory: ~/test
     machine: true
-{%- block env_test -%}
-{%- if not matrix %}
     branches:
       ignore:
         - /.*/
@@ -14,6 +14,9 @@ jobs:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.
           command: exit 0
 {%- else %}
+  build:
+    working_directory: ~/test
+    machine: true
     steps:
       - checkout
       - run:

--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -13,7 +13,7 @@ jobs:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.
           command: exit 0
-{% else %}
+{%- else %}
     steps:
       - checkout
       - run:
@@ -26,6 +26,22 @@ jobs:
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./ci_support/run_docker_build.sh
-{# #}
 {%- endif -%}
 {%- endblock %}
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+{%- block env_deps -%}
+{%- if not matrix %}
+      - build:
+          filters:
+            branches:
+              ignore:
+                - /.*/
+{%- else %}
+      - build
+{%- endif -%}
+{%- endblock %}
+{# #}

--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -5,7 +5,15 @@ jobs:
     working_directory: ~/test
     machine: true
 {%- block env_test -%}
-{%- if matrix %}
+{%- if not matrix %}
+    branches:
+      ignore:
+        - /.*/
+    steps:
+      - run:
+          # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.
+          command: exit 0
+{% else %}
     steps:
       - checkout
       - run:
@@ -18,14 +26,6 @@ jobs:
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./ci_support/run_docker_build.sh
-{% else %}
-    branches:
-      ignore:
-        - /.*/
-    steps:
-      - run:
-          # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.
-          command: exit 0
 {# #}
 {%- endif -%}
 {%- endblock %}

--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -1,41 +1,35 @@
 version: 2
 
+jobs:
+  build:
+    working_directory: ~/test
+    machine: true
 {%- block env_branches -%}
-{%- if not matrix -%}
-general:
-  branches:
-    ignore:
-      - /.*/
-
-{% endif -%}
-{% endblock -%}
-{% block env_dependencies -%}
-{%- if matrix -%}
-checkout:
-  post:
-    - ./ci_support/fast_finish_ci_pr_build.sh
-    - ./ci_support/checkout_merge_commit.sh
-
-machine:
-  services:
-    - docker
-
-dependencies:
-  # Note, we used to use the naive caching of docker images, but found that it was quicker
-  # just to pull each time. #rollondockercaching
-  override:
-    - docker pull condaforge/linux-anvil
-
-{% endif -%}
-{% endblock -%}
-test:
-  override:
-{%- block env_test %}
+{%- if not matrix %}
+    branches:
+      ignore:
+        - /.*/
+{%- endif -%}
+{%- endblock -%}
+{%- block env_test -%}
 {%- if matrix %}
-    # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-    - ./ci_support/run_docker_build.sh
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./ci_support/fast_finish_ci_pr_build.sh
+            ./ci_support/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./ci_support/run_docker_build.sh
 {% else %}
-    # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.
-    - exit 0
-{% endif -%}
+    steps:
+      - run:
+          # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.
+          command: exit 0
+{# #}
+{%- endif -%}
 {%- endblock %}

--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -4,13 +4,6 @@ jobs:
   build:
     working_directory: ~/test
     machine: true
-{%- block env_branches -%}
-{%- if not matrix %}
-    branches:
-      ignore:
-        - /.*/
-{%- endif -%}
-{%- endblock -%}
 {%- block env_test -%}
 {%- if matrix %}
     steps:
@@ -26,6 +19,9 @@ jobs:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./ci_support/run_docker_build.sh
 {% else %}
+    branches:
+      ignore:
+        - /.*/
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-smithy/issues/527

Closes https://github.com/conda-forge/pyelftools-feedstock/pull/14
Closes https://github.com/conda-forge/gnureadline-feedstock/pull/8

Upgrades to new [CircleCI 2.0]( https://circleci.com/docs/2.0/ ) by borrowing from this [migration guide]( https://circleci.com/docs/2.0/migrating-from-1-2/ ), the [reference spec]( https://circleci.com/docs/2.0/configuration-reference/ ), and a [bunch of examples]( https://github.com/CircleCI-Public ). This should make it easier to explore matrix builds in CircleCI and provide us access to all the other latest features.

Test cases for the [Linux build]( https://github.com/conda-forge/pyelftools-feedstock/pull/14 ) and [non-Linux build]( https://github.com/conda-forge/gnureadline-feedstock/pull/8 ) can be seen. Note that CircleCI still doesn't build in the non-Linux case (and if it does it just exits quietly). Also despite looking like a big overhaul, the behavior in the CircleCI 2.0 case is basically the same. Though this will change when matrix builds are considered.

In the upgrade, we make sure to clean out the old `circle.yml` file too.