### PR TITLE
Render noarch recipe to only build on Circle CI

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -76,11 +76,6 @@ def render_circle(jinja_env, forge_config, forge_dir):
             forge_config.get('matrix'),
             forge_config.get('channels', {}).get('sources', tuple())
         )
-        if meta.noarch == 'python':
-            # noarch python packages only need to be built once and do not need
-            # a python version set.
-            if matrix:
-                matrix = [(), ]
         cases_not_skipped = []
         for case in matrix:
             pkgs, vars = split_case(case)

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -76,6 +76,11 @@ def render_circle(jinja_env, forge_config, forge_dir):
             forge_config.get('matrix'),
             forge_config.get('channels', {}).get('sources', tuple())
         )
+        if meta.noarch == 'python':
+            # noarch python packages only need to be built once and do not need
+            # a python version set.
+            if matrix:
+                matrix = [(), ]
         cases_not_skipped = []
         for case in matrix:
             pkgs, vars = split_case(case)
@@ -242,11 +247,15 @@ def render_travis(jinja_env, forge_config, forge_dir):
     meta = forge_config['package']
     with fudge_subdir('osx-64', build_config=meta_config(meta)):
         meta.parse_again()
-        matrix = compute_build_matrix(
-            meta,
-            forge_config.get('matrix'),
-            forge_config.get('channels', {}).get('sources', tuple())
-        )
+        if meta.noarch:
+            # do not build noarch, including noarch: python, packages on Travis CI.
+            matrix = ()
+        else:
+            matrix = compute_build_matrix(
+                meta,
+                forge_config.get('matrix'),
+                forge_config.get('channels', {}).get('sources', tuple())
+            )
 
         cases_not_skipped = []
         for case in matrix:
@@ -402,11 +411,15 @@ def render_appveyor(jinja_env, forge_config, forge_dir):
     for platform, arch in [['win-32', 'x86'], ['win-64', 'x64']]:
         with fudge_subdir(platform, build_config=meta_config(meta)):
             meta.parse_again()
-            matrix = compute_build_matrix(
-                meta,
-                forge_config.get('matrix'),
-                forge_config.get('channels', {}).get('sources', tuple())
-            )
+            if meta.noarch:
+                # do not build noarch, include noarch: python packages on AppVeyor.
+                matrix = ()
+            else:
+                matrix = compute_build_matrix(
+                    meta,
+                    forge_config.get('matrix'),
+                    forge_config.get('channels', {}).get('sources', tuple())
+                )
 
             cases_not_skipped = []
             for case in matrix:

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -244,7 +244,7 @@ def render_travis(jinja_env, forge_config, forge_dir):
         meta.parse_again()
         if meta.noarch:
             # do not build noarch, including noarch: python, packages on Travis CI.
-            matrix = ()
+            matrix = []
         else:
             matrix = compute_build_matrix(
                 meta,
@@ -408,7 +408,7 @@ def render_appveyor(jinja_env, forge_config, forge_dir):
             meta.parse_again()
             if meta.noarch:
                 # do not build noarch, include noarch: python packages on AppVeyor.
-                matrix = ()
+                matrix = []
             else:
                 matrix = compute_build_matrix(
                     meta,

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -336,8 +336,13 @@ def render_travis(jinja_env, forge_config, forge_dir):
 
 
 def render_README(jinja_env, forge_config, forge_dir):
+    meta = forge_config['package']
     template = jinja_env.get_template('README.md.tmpl')
     target_fname = os.path.join(forge_dir, 'README.md')
+    if meta.noarch:
+        forge_config['noarch_python'] = True
+    else:
+        forge_config['noarch_python'] = False
     with write_file(target_fname) as fh:
         fh.write(template.render(**forge_config))
 

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -21,6 +21,14 @@ Current build status
 {%- set disabled_badge_path = "conda_smithy/static/disabled.svg" %}
 {%- set disabled_badge_url = "https://cdn.rawgit.com/conda-forge/conda-smithy/%s/%s"|format(disabled_badge_commit, disabled_badge_path) %}
 {# #}
+
+{%- if noarch_python %}
+{%- if circle.enabled %}
+All platforms: [![Circle CI](https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }}.svg?style=shield)](https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }})
+{%- else %}
+All platforms: ![]({{ disabled_badge_url }})
+{%- endif %}
+{%- else %}
 {%- if circle.enabled %}
 Linux: [![Circle CI](https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }}.svg?style=shield)](https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }})
 {%- else %}
@@ -35,6 +43,7 @@ OSX: ![]({{ disabled_badge_url }})
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/{{ github.user_or_org }}/{{ github.repo_name }}?svg=True)](https://ci.appveyor.com/project/{{ github.user_or_org }}/{{ appveyor_url_name }}/branch/master)
 {%- else %}
 Windows: ![]({{ disabled_badge_url }})
+{%- endif %}
 {%- endif %}
 
 Current release info

--- a/conda_smithy/tests/test_configure_feedstock.py
+++ b/conda_smithy/tests/test_configure_feedstock.py
@@ -9,6 +9,8 @@ import conda.api
 
 import conda_smithy.configure_feedstock as cnfgr_fdstk
 from conda_build_all.resolved_distribution import ResolvedDistribution
+from conda_build import __version__ as conda_build_version
+from distutils.version import LooseVersion
 
 
 @contextmanager
@@ -156,17 +158,20 @@ class Test_fudge_subdir(unittest.TestCase):
                 if expect_skip:
                     self.assertEqual(cases_not_skipped, [[]])
 
+            conda_build_supports_noarch = \
+                LooseVersion(conda_build_version) >= LooseVersion("2.1.17")
+
             with cnfgr_fdstk.fudge_subdir('linux-64', config):
                 test()
 
             with cnfgr_fdstk.fudge_subdir('win-32', config):
-                test(expect_skip=True)
+                test(expect_skip=conda_build_supports_noarch)
 
             with cnfgr_fdstk.fudge_subdir('win-64', config):
-                test(expect_skip=True)
+                test(expect_skip=conda_build_supports_noarch)
 
             with cnfgr_fdstk.fudge_subdir('osx-64', config):
-                test(expect_skip=True)
+                test(expect_skip=conda_build_supports_noarch)
 
 
 if __name__ == '__main__':

--- a/conda_smithy/tests/test_configure_feedstock.py
+++ b/conda_smithy/tests/test_configure_feedstock.py
@@ -116,6 +116,58 @@ class Test_fudge_subdir(unittest.TestCase):
             with cnfgr_fdstk.fudge_subdir('osx-64', config):
                 test()
 
+    def test_noarch(self):
+        with tmp_directory() as recipe_dir:
+            with open(os.path.join(recipe_dir, 'meta.yaml'), 'w') as fh:
+                fh.write("""
+                        package:
+                           name: python-noarch-test
+                           version: 1.0.0
+                        build:
+                           noarch: python
+                        requirements:
+                           build:
+                              - python
+                           run:
+                              - python
+                         """)
+            meta = conda_build.metadata.MetaData(recipe_dir)
+            config = cnfgr_fdstk.meta_config(meta)
+
+            kwargs = {}
+            if hasattr(conda_build, 'api'):
+                kwargs['config'] = config
+
+            def test(expect_skip=False):
+                meta.parse_again(**kwargs)
+
+                matrix = cnfgr_fdstk.compute_build_matrix(
+                    meta,
+                    channel_sources=["defaults", "conda-forge"]
+                )
+
+                cases_not_skipped = []
+                for case in matrix:
+                    pkgs, vars = cnfgr_fdstk.split_case(case)
+                    with cnfgr_fdstk.enable_vars(vars):
+                        if not ResolvedDistribution(meta, pkgs).skip():
+                            cases_not_skipped.append(vars + sorted(pkgs))
+
+                if expect_skip:
+                    self.assertEqual(cases_not_skipped, [[]])
+
+            with cnfgr_fdstk.fudge_subdir('linux-64', config):
+                test()
+
+            with cnfgr_fdstk.fudge_subdir('win-32', config):
+                test(expect_skip=True)
+
+            with cnfgr_fdstk.fudge_subdir('win-64', config):
+                test(expect_skip=True)
+
+            with cnfgr_fdstk.fudge_subdir('osx-64', config):
+                test(expect_skip=True)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
noarch, including noarch: python recipe only need to be built on a single
platform. Rendering feedstocks with noarch recipes results in only the Circle CI
logic being created.

Closes https://github.com/conda-forge/imagesize-feedstock/pull/5