### PR TITLE
Fix feedstocking with binary files

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -33,7 +33,7 @@ def generate_feedstock_content(target_directory, source_recipe_dir, meta):
         except Exception as e:
             import sys
             raise type(e)(
-                str(e) + ' while copyin file %s' % source_recipe_dir
+                str(e) + ' while copying file %s' % source_recipe_dir
                 ).with_traceback(sys.exc_info()[2])
 
     forge_yml = os.path.join(target_directory, 'conda-forge.yml')

--- a/conda_smithy/feedstock_io.py
+++ b/conda_smithy/feedstock_io.py
@@ -75,10 +75,14 @@ def remove_file(filename):
 
 
 def copy_file(src, dst):
-    with io.open(src, "r", encoding="utf-8") as fh_src:
-        with io.open(dst, "w", encoding="utf-8", newline="\n") as fh_dst:
-            for line in fh_src:
-                fh_dst.write(line)
+    try:
+        with io.open(src, "r", encoding="utf-8") as fh_src:
+            with io.open(dst, "w", encoding="utf-8", newline="\n") as fh_dst:
+                for line in fh_src:
+                    fh_dst.write(line)
+    except UnicodeDecodeError:
+        # Leave any other files alone.
+        shutil.copy(src, dst)
 
     shutil.copymode(src, dst)
 

--- a/conda_smithy/feedstock_io.py
+++ b/conda_smithy/feedstock_io.py
@@ -75,6 +75,12 @@ def remove_file(filename):
 
 
 def copy_file(src, dst):
+    """
+    Tried to copy utf-8 text files line-by-line to avoid
+    getting CRLF characters added on Windows.
+
+    If the file fails to be decoed with utf-8 we revert to a regular copy.
+    """
     try:
         with io.open(src, "r", encoding="utf-8") as fh_src:
             with io.open(dst, "w", encoding="utf-8", newline="\n") as fh_dst:


### PR DESCRIPTION
This should help with the binary file copy issue and any other file that fails the `utf-8` encoding.