### PR TITLE
Add more lints for conda recipes

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -234,12 +234,13 @@ class RecipeLint(Subcommand):
     def __init__(self, parser):
         super(RecipeLint, self).__init__(parser, "Lint a single conda recipe.")
         scp = self.subcommand_parser
+        scp.add_argument("--conda-forge", action='store_true')
         scp.add_argument("recipe_directory", default=[os.getcwd()], nargs='*')
 
     def __call__(self, args):
         all_good = True
         for recipe in args.recipe_directory:
-            lint = lint_recipe.main(os.path.join(recipe))
+            lint = lint_recipe.main(os.path.join(recipe), conda_forge=args.conda_forge)
             if lint:
                 all_good = False
                 print('{} has some lint:\n  {}'.format(recipe, '\n  '.join(lint)))

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -156,6 +156,7 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
         lints.append(str(e))
 
     # 13: Check that the recipe name is valid
+    recipe_name = package_section.get('name', '').strip()
     if re.match('^[a-z0-9_\-.]+$', recipe_name) is None:
         lints.append('Recipe name has invalid characters. only lowercase alpha, numeric, '
                      'underscores, hyphens and dots allowed')

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -73,7 +73,7 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
             lints.append('The {} item is expected in the about section.'
                          ''.format(about_item))
 
-    # 3: The recipe should have some maintainers.
+    # 3a: The recipe should have some maintainers.
     if not extra_section.get('recipe-maintainers', []):
         lints.append('The recipe could do with some maintainers listed in '
                      'the `extra/recipe-maintainers` section.')

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -155,20 +155,12 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
     except RuntimeError as e:
         lints.append(str(e))
 
-    # 13: Check that the recipe_dir has the same name as the recipe_name
-    recipe_name = package_section.get('name', '').strip()
-    if recipe_dir:
-        # Above ensures that recipe_dir is not None. It is None in tests.
-        recipe_dirname = os.path.basename(recipe_dir)
-        if recipe_dirname != 'recipe' and recipe_dirname != recipe_name:
-            lints.append('Recipe directory and the name has to be the same')
-
-    # 14: Check that the recipe name is valid
+    # 13: Check that the recipe name is valid
     if re.match('^[a-z0-9_\-.]+$', recipe_name) is None:
         lints.append('Recipe name has invalid characters. only lowercase alpha, numeric, '
                      'underscores, hyphens and dots allowed')
 
-    # 15: Run conda-forge specific lints
+    # 14: Run conda-forge specific lints
     if conda_forge:
         run_conda_forge_lints(meta, recipe_dir, lints)
 

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -177,7 +177,7 @@ def run_conda_forge_lints(meta, recipe_dir, lints):
 
     # 1: Check that the recipe does not exist in conda-forge
     if is_staged_recipes:
-        cf = gh.get_user('conda-forge')
+        cf = gh.get_user(os.getenv('GH_ORG', 'conda-forge'))
         try:
             cf.get_repo('{}-feedstock'.format(recipe_name))
             feedstock_exists = True

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -6,6 +6,7 @@ import io
 import itertools
 import os
 import re
+import github
 
 import jinja2
 import ruamel.yaml
@@ -154,7 +155,7 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
     except RuntimeError as e:
         lints.append(str(e))
 
-    # 13: Check that the recipe_dir has the same name as the recipe_name)
+    # 13: Check that the recipe_dir has the same name as the recipe_name
     recipe_name = package_section.get('name', '').strip()
     if recipe_dir:
         # Above ensures that recipe_dir is not None. It is None in tests.
@@ -175,7 +176,6 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
 
 
 def run_conda_forge_lints(meta, recipe_dir, lints):
-    import github
     gh = github.Github(os.environ['GH_TOKEN'])
     package_section = get_section(meta, 'package', lints)
     extra_section = get_section(meta, 'extra', lints)

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -99,6 +99,10 @@ class Test_linter(unittest.TestCase):
         lints = linter.lintify({'extra': ['recipe-maintainers']})
         self.assertIn(expected_message, lints)
 
+        lints = linter.lintify({'extra': {'recipe-maintainers': 'Luke'}})
+        expected_message = ('Recipe maintainers should be a json list.')
+        self.assertIn(expected_message, lints)
+
     def test_test_section(self):
         expected_message = 'The recipe must have some tests.'
 
@@ -217,16 +221,10 @@ class Test_linter(unittest.TestCase):
                             'the word "License".')
         self.assertIn(expected_message, lints)
 
-    def test_maintainer_non_list(self):
-        meta = {'extra': {'recipe-maintainers': 'Luke'}}
-        lints = linter.lintify(meta)
-        expected_message = ('recipe maintainers should be a json list.')
-        self.assertIn(expected_message, lints)
-
     def test_recipe_name(self):
         meta = {'package': {'name': 'mp++'}}
         lints = linter.lintify(meta)
-        expected_message = ('recipe name has invalid characters. only lowercase alpha, '
+        expected_message = ('Recipe name has invalid characters. only lowercase alpha, '
                             'numeric, underscores, hyphens and dots allowed')
         self.assertIn(expected_message, lints)
 

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -17,7 +17,9 @@ import conda_smithy.lint_recipe as linter
 @contextmanager
 def tmp_directory():
     tmp_dir = tempfile.mkdtemp('recipe_')
-    yield tmp_dir
+    recipe_dir = os.path.join(tmp_dir, 'recipe')
+    os.mkdir(recipe_dir)
+    yield recipe_dir
     shutil.rmtree(tmp_dir)
 
 
@@ -213,6 +215,19 @@ class Test_linter(unittest.TestCase):
         lints = linter.lintify(meta)
         expected_message = ('The recipe `license` should not include '
                             'the word "License".')
+        self.assertIn(expected_message, lints)
+
+    def test_maintainer_non_list(self):
+        meta = {'extra': {'recipe-maintainers': 'Luke'}}
+        lints = linter.lintify(meta)
+        expected_message = ('recipe maintainers should be a json list.')
+        self.assertIn(expected_message, lints)
+
+    def test_recipe_name(self):
+        meta = {'package': {'name': 'mp++'}}
+        lints = linter.lintify(meta)
+        expected_message = ('recipe name has invalid characters. only lowercase alpha, '
+                            'numeric, underscores, hyphens and dots allowed')
         self.assertIn(expected_message, lints)
 
     def test_end_empty_line(self):

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -19,11 +19,9 @@ def is_gh_token_set():
     return 'GH_TOKEN' in os.environ
 
 @contextmanager
-def tmp_directory(recipe_dir_name='recipe'):
+def tmp_directory():
     tmp_dir = tempfile.mkdtemp('recipe_')
-    recipe_dir = os.path.join(tmp_dir, recipe_dir_name)
-    os.mkdir(recipe_dir)
-    yield recipe_dir
+    yield tmp_dir
     shutil.rmtree(tmp_dir)
 
 
@@ -306,17 +304,6 @@ class Test_linter(unittest.TestCase):
         else:
             lints = linter.lintify({'package': {'name': 'python1'}}, recipe_dir="python", conda_forge=True)
             self.assertNotIn(expected_message, lints)
-
-    def test_recipe_dir(self):
-        meta = {'package': {'name': 'python'}}
-        expected_message = ('Recipe directory and the name has to be the same')
-
-        lints = linter.lintify(meta, recipe_dir="python1")
-        self.assertIn(expected_message, lints)
-        lints = linter.lintify(meta, recipe_dir="recipe")
-        self.assertNotIn(expected_message, lints)
-        lints = linter.lintify(meta, recipe_dir="python")
-        self.assertNotIn(expected_message, lints)
 
 
 class TestCLI_recipe_lint(unittest.TestCase):

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -294,7 +294,7 @@ class Test_linter(unittest.TestCase):
         gh = github.Github(os.environ['GH_TOKEN'])
         cf = gh.get_user('conda-forge')
         try:
-            cf.get_repo('python1q-feedstock')
+            cf.get_repo('python1-feedstock')
             feedstock_exists = True
         except github.UnknownObjectException as e:
             feedstock_exists = False


### PR DESCRIPTION
Fixes #520 
Fixes #469 

There are more lints when env variable, `CONDA_FORGE_LINTS` is set. It checks that the github usernames are valid and that there is no existing feedstock.