### PR TITLE
check in linter for required python run-time dependency

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -149,21 +149,13 @@ def lintify(meta, recipe_dir=None):
     except RuntimeError as e:
         lints.append(str(e))
 
-    # 13: If cython is a build-dependency then python should be a run-time
+    # 13: If cython/numpy is a build-dependency then python should be a run-time
     # dependency. This ensures that packages will be marked correctly by conda
-    if 'cython' in requirements_section.get('build', '') and 'python' not in requirements_section.get('run', ''):
-        lints.append("When using cython then python should be a run-time dependency")
-
-
-    # 14: If ``skip: True  # [py3k]`` python should be a run-time dependency
-    if recipe_dir is not None and os.path.exists(meta_fname):
-        with io.open(meta_fname, 'rt') as fh:
-            for selector_line in selector_lines(fh):
-                if 'py3k' in selector_line and 'python' not in requirements_section.get('run', ''):
-                    lints.append("When building python 2 only packages include python as a run-time "
-                                 "dependency to ensure it can't be installed on python 3.")
-                    # this will only happen once
-                    break
+    build_deps = ['cython', 'numpy x.x']
+    need_python_run_time = any([dep in requirements_section.get('build', '') for dep in build_deps])
+    if need_python_run_time and 'python' not in requirements_section.get('run', ''):
+        lints.append("Found python related compilation requirement "
+                     "please add python as a run-time dependency")
 
     return lints
 

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -149,6 +149,22 @@ def lintify(meta, recipe_dir=None):
     except RuntimeError as e:
         lints.append(str(e))
 
+    # 13: If cython is a build-dependency then python should be a run-time
+    # dependency. This ensures that packages will be marked correctly by conda
+    if 'cython' in requirements_section.get('build', '') and 'python' not in requirements_section.get('run', ''):
+        lints.append("When using cython then python should be a run-time dependency")
+
+
+    # 14: If ``skip: True  # [py3k]`` python should be a run-time dependency
+    if recipe_dir is not None and os.path.exists(meta_fname):
+        with io.open(meta_fname, 'rt') as fh:
+            for selector_line in selector_lines(fh):
+                if 'py3k' in selector_line and 'python' not in requirements_section.get('run', ''):
+                    lints.append("When building python 2 only packages include python as a run-time "
+                                 "dependency to ensure it can't be installed on python 3.")
+                    # this will only happen once
+                    break
+
     return lints
 
 

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -253,36 +253,14 @@ class Test_linter(unittest.TestCase):
                 else:
                     self.assertIn(expected_message, lints)
 
-    def test_cython_python_run_time_dependency(self):
-        meta = {'requirements': {'build': ['cython', 'python']}}
-        lints = linter.lintify(meta)
-        expected_message = "When using cython then python should be a run-time dependency"
-        self.assertIn(expected_message, lints)
-
-    def test_skip_python3_python_run_time_dependency(self):
-        metalines = """
-build:
-  number: 0
-  skip: True  # [py3k]
-  script: python setup.py install --single-version-externally-managed --record record.txt
-
-requirements:
-  build:
-    - python
-
-  run:
-    - scipy
-        """
-        with tmp_directory() as recipe_dir:
-            with io.open(os.path.join(recipe_dir, 'meta.yaml'), 'w') as fh:
-                fh.write(metalines)
-            lints = linter.lintify({}, recipe_dir=recipe_dir)
-
-        expected_message = ("When building python 2 only packages include python as a run-time "
-                            "dependency to ensure it can't be installed on python 3.")
-        self.assertIn(expected_message, lints)
-
-
+    def test_implicit_python_run_time_dependency(self):
+        build_deps = ['cython', 'numpy x.x']
+        expected_message = ("Found python related compilation requirement "
+                            "please add python as a run-time dependency")
+        for dep in build_deps:
+            meta = {'requirements': {'build': [dep, 'python']}}
+            lints = linter.lintify(meta)
+            self.assertIn(expected_message, lints)
 
 
 class TestCLI_recipe_lint(unittest.TestCase):


### PR DESCRIPTION
This will ensure that conda is forced to add a python version dependency on the
final package.

I encountered this problem for the MDAnalysis feedstock. 
https://github.com/conda-forge/mdanalysis-feedstock/issues/4

I haven't tested this locally yet because I don't know if I can go back to my a stable build or even run the tests without installing the development version.