### PR TITLE
Honor docker.image in .circle/config.yaml

### DIFF
--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -39,7 +39,7 @@ jobs:
             ./ci_support/fast_finish_ci_pr_build.sh
             ./ci_support/checkout_merge_commit.sh
       - run:
-          command: docker pull condaforge/linux-anvil
+          command: docker pull {{ docker.image }}
       {%- if case[0] %}
       - run:
           name: Print conda-build environment variables


### PR DESCRIPTION
Let's not hardcode the docker image we pull in CircleCI.