### PR TITLE
lint instead of crashing when requirements has unexpected keys

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -131,9 +131,11 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
         lints.append('The recipe must have a `build/number` section.')
 
     # 8: The build section should be before the run section in requirements.
-    requirements_order_sorted = sorted(requirements_section,
+    seen_requirements = [
+            k for k in requirements_section if k in REQUIREMENTS_ORDER]
+    requirements_order_sorted = sorted(seen_requirements,
                                        key=REQUIREMENTS_ORDER.index)
-    if list(requirements_section.keys()) != requirements_order_sorted:
+    if seen_requirements != requirements_order_sorted:
         lints.append('The `requirements/build` section should be defined '
                      'before the `requirements/run` section.')
 

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -198,6 +198,12 @@ class Test_linter(unittest.TestCase):
         lints = linter.lintify(meta)
         self.assertIn(expected_message, lints)
 
+        meta = {'requirements': OrderedDict([['run', 'a'],
+                                             ['invalid', 'a'],
+                                             ['build', 'a']])}
+        lints = linter.lintify(meta)
+        self.assertIn(expected_message, lints)
+
         meta = {'requirements': OrderedDict([['build', 'a'],
                                              ['run', 'a']])}
         lints = linter.lintify(meta)


### PR DESCRIPTION
I accidentally put a `skip` key in the `requirements` section, and got the dreaded "failed to even lint the recipe" message: https://github.com/conda-forge/staged-recipes/pull/3780#issuecomment-324723905.

This fixes the linter to not crash in this case, but instead complain about the unexpected key.