### PR TITLE
added appveyor-retry calls

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -32,7 +32,7 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: appveyor-retry conda update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
@@ -43,9 +43,9 @@ install:
     - cmd: conda config --add channels {{ channel }}{% endfor %}
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: appveyor-retry conda install -n root --quiet --yes conda-forge-build-setup
     {% if build_setup -%}
-    {{ build_setup }}{% endif %}
+    appveyor-retry {{ build_setup }}{% endif %}
 
 # Skip .NET project specific build phase.
 build: off


### PR DESCRIPTION
Added appveyor-retry calls to prevent transient network connectivity failures from manifesting as recipe build failures.  See PR #3836 for related discussions.