### PR TITLE
Import ci_register when needed

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -156,12 +156,12 @@ class RegisterCI(Subcommand):
                            help="github organisation under which to register this repo")
 
     def __call__(self, args):
+        from conda_smithy import ci_register
         owner = args.user or args.organization
         repo = os.path.basename(os.path.abspath(args.feedstock_directory))
 
         print('CI Summary for {}/{} (can take ~30s):'.format(owner, repo))
         try:
-            from conda_smithy import ci_register
             ci_register.add_project_to_travis(owner, repo)
             ci_register.travis_token_update_conda_forge_config(args.feedstock_directory, owner, repo)
             time.sleep(1)

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -11,7 +11,6 @@ import conda
 from distutils.version import LooseVersion
 from conda_build.metadata import MetaData
 
-from . import ci_register
 from . import configure_feedstock
 from . import feedstock_io
 from . import lint_recipe
@@ -162,6 +161,7 @@ class RegisterCI(Subcommand):
 
         print('CI Summary for {}/{} (can take ~30s):'.format(owner, repo))
         try:
+            from conda_smithy import ci_register
             ci_register.add_project_to_travis(owner, repo)
             ci_register.travis_token_update_conda_forge_config(args.feedstock_directory, owner, repo)
             time.sleep(1)


### PR DESCRIPTION
This stops an annoying warning about missing tokens when all you
want to do is rerender a recipe