### PR TITLE
Add feedstock hook

### DIFF
--- a/conda_smithy/ci_register.py
+++ b/conda_smithy/ci_register.py
@@ -364,6 +364,12 @@ def add_conda_forge_webservice_hooks(user, repo):
             ]
         ),
         get_conda_hook_info(
+            "http://conda-forge.herokuapp.com/conda-forge-feedstocks/hook",
+            [
+                "push"
+            ]
+        ),
+        get_conda_hook_info(
             "http://conda-forge.herokuapp.com/conda-forge-teams/hook",
             [
                 "push"


### PR DESCRIPTION
Part of issue ( https://github.com/conda-forge/conda-forge-webservices/issues/63 ).

Provides a hook to listen for push events on feedstocks. The intent being to capture these events and use them to update each feedstock in the `feedstocks` repo. The net result being that the `feedstocks` repo will stay more up-to-date with feedstock additions in the organization as well changes made to each feedstock. Since these events will only concern an individual feedstock at a time, this should cutdown on the number of calls made to the GitHub API for operations like this one.