### PR TITLE
linter check that there are actually tests

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -19,6 +19,8 @@ EXPECTED_SECTION_ORDER = ['package', 'source', 'build', 'requirements',
 
 REQUIREMENTS_ORDER = ['build', 'run']
 
+TEST_KEYS = {'imports', 'commands'}
+
 
 class NullUndefined(jinja2.Undefined):
     def __unicode__(self):
@@ -51,6 +53,7 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
     source_section = get_section(meta, 'source', lints)
     build_section = get_section(meta, 'build', lints)
     requirements_section = get_section(meta, 'requirements', lints)
+    test_section = get_section(meta, 'test', lints)
     about_section = get_section(meta, 'about', lints)
     extra_section = get_section(meta, 'extra', lints)
     package_section = get_section(meta, 'package', lints)
@@ -83,7 +86,7 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
         lints.append('Recipe maintainers should be a json list.')
 
     # 4: The recipe should have some tests.
-    if 'test' not in major_sections:
+    if not any(key in TEST_KEYS for key in test_section):
         test_files = ['run_test.py', 'run_test.sh', 'run_test.bat',
                       'run_test.pl']
         a_test_file_exists = (recipe_dir is not None and

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -333,7 +333,9 @@ class TestCLI_recipe_lint(unittest.TestCase):
                         name: 'test_package'
                     build:
                         number: 0
-                    test: []
+                    test:
+                        imports:
+                            - foo
                     about:
                         home: something
                         license: something else
@@ -360,6 +362,8 @@ class TestCLI_recipe_lint(unittest.TestCase):
                     test:
                         requires:
                             - python {{ environ['PY_VER'] + '*' }}  # [win]
+                        imports:
+                            - foo
                     about:
                         home: something
                         license: something else

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -111,6 +111,9 @@ class Test_linter(unittest.TestCase):
         lints = linter.lintify({})
         self.assertIn(expected_message, lints)
 
+        lints = linter.lintify({'test': {'files': 'foo'}})
+        self.assertIn(expected_message, lints)
+
         lints = linter.lintify({'test': {'imports': 'sys'}})
         self.assertNotIn(expected_message, lints)
 


### PR DESCRIPTION
Currently, the linter only checks that there is a `test` section (or a `run_test.*` file), not that the test section actually contains any tests. If someone makes `test/import` instead of `test/imports` by accident (https://github.com/conda-forge/staged-recipes/pull/3708), then the linter doesn't complain and it's pretty easy to miss that no tests are actually run.

Looking at [the source](https://github.com/conda/conda-build/blob/87332a198599e78ae394006b8ee87277dacfa5fa/conda_build/create_test.py), the only keys that actually cause tests to be created are `imports` and `commands`, so this checks that one of them is present for a `tests` section to count.