### PR TITLE
Revert "Add instructions to update conda"

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -60,13 +60,7 @@ Installing `{{ package.name() }}` from the `{{ channel_name }}` channel can be a
 conda config --add channels {{ channel_name }}
 ```
 
-Once the `{{ channel_name }}` channel has been enabled, update `conda` with
-
-```
-conda update conda
-```
-
-After that `{{ package.name() }}` can be installed with:
+Once the `{{ channel_name }}` channel has been enabled, `{{ package.name() }}` can be installed with:
 
 ```
 conda install {{ package.name() }}


### PR DESCRIPTION
This reverts commit 860d93ebb6edab02b1a74dd02ba7bec4f4f90c61.

Updating conda after adding the conda-forge channel is going to be problematic. (If it installs a conda-forge package that is noarch, then there's going to be problems)