### PR TITLE
Listen to repository events

### DIFF
--- a/conda_smithy/ci_register.py
+++ b/conda_smithy/ci_register.py
@@ -366,13 +366,13 @@ def add_conda_forge_webservice_hooks(user, repo):
         get_conda_hook_info(
             "http://conda-forge.herokuapp.com/conda-forge-feedstocks/hook",
             [
-                "push"
+                "push", "repository"
             ]
         ),
         get_conda_hook_info(
             "http://conda-forge.herokuapp.com/conda-forge-teams/hook",
             [
-                "push"
+                "push", "repository"
             ]
         ),
         get_conda_hook_info(


### PR DESCRIPTION
The repository event notifies when a repo has been deleted (amongst other things). This is important for the team and feedstocks services as they will also need to handle this event. The team service will need to remove the associated team and the feedstocks service will need to remove it from the feedstocks repo.