### PR TITLE
Add feedstock PR/issue templates and contribution guidance

### DIFF
--- a/conda_smithy/feedstock_content/.github/CONTRIBUTING.md
+++ b/conda_smithy/feedstock_content/.github/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+Thanks for your interest in helping out conda-forge.
+
+Whether you are brand new or a seasoned maintainer, we always appreciate
+feedback from the community about how we can improve conda-forge. If you
+are submitting a PR or issue, please fill out the respective template. Should
+any questions arise please feel free to ask the maintainer team of the
+respective feedstock or reach out to `@conda-forge/core` for more complex
+issues.
+
+In the case of any issues reported, please be sure to demonstrate the relevant
+issue (even if it is an absence of a feature). Providing this information will
+help busy maintainers understand what it is you hope to accomplish. Also this
+will help provide them clues as to what might be going wrong. These examples
+can also be reused as tests in the build to ensure further packages meet these
+criteria. This is requested to help you get timely and relevant feedback. :)

--- a/conda_smithy/feedstock_content/.github/ISSUE_TEMPLATE.md
+++ b/conda_smithy/feedstock_content/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,46 @@
+Thanks for reporting your issue.
+
+
+Please fill out the sections below.
+
+
+Example (code snippet, shell command, or screenshot):
+
+<details>
+
+
+
+</details>
+
+<br>
+Environment (`conda env export`):
+<br>
+<br>
+
+<details>
+
+```yaml
+name: test
+channels:
+- conda-forge
+- defaults
+dependencies:
+# Please fill these in. :)
+-
+```
+
+</details>
+
+<br>
+Details about `conda` and system (`conda info`):
+<br>
+<br>
+
+<details>
+
+```
+$ conda info
+
+```
+
+</details>

--- a/conda_smithy/feedstock_content/.github/PULL_REQUEST_TEMPLATE.md
+++ b/conda_smithy/feedstock_content/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+Thank you for pull request.
+
+Below are a few things we ask you kindly to self-check before getting a review.
+
+* [ ] Bump the build number (if the version is unchanged)
+* [ ] Reset the build number to `0` (if the version changed)
+* [ ] [Re-render]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
+* [ ] Updating pinnings based on the [current list]( https://github.com/conda-forge/conda-forge.github.io/blob/master/scripts/pin_the_slow_way.py#L39 )
+* [ ] Ensure the license file is being packaged.
+
+Please note and issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
+
+
+
+Please add any other relevant info below:
+
+

--- a/conda_smithy/feedstock_content/.github/PULL_REQUEST_TEMPLATE.md
+++ b/conda_smithy/feedstock_content/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ Below are a few things we ask you kindly to self-check before getting a review.
 * [ ] Updating pinnings based on the [current list]( https://github.com/conda-forge/conda-forge.github.io/blob/master/scripts/pin_the_slow_way.py#L39 )
 * [ ] Ensure the license file is being packaged.
 
-Please note and issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
+Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
 
 
 

--- a/conda_smithy/feedstock_content/.github/PULL_REQUEST_TEMPLATE.md
+++ b/conda_smithy/feedstock_content/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,7 @@ Thank you for pull request.
 
 Below are a few things we ask you kindly to self-check before getting a review.
 
+* [ ] Used a fork of the feedstock to propose changes
 * [ ] Bump the build number (if the version is unchanged)
 * [ ] Reset the build number to `0` (if the version changed)
 * [ ] [Re-render]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-smithy/issues/509

Provides GitHub templates for [issues]( https://help.github.com/articles/creating-an-issue-template-for-your-repository/ ) and [PRs]( https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/ ) to each feedstock. Also provides some [contribution guidance]( https://help.github.com/articles/setting-guidelines-for-repository-contributors/ ) when either issues or PRs are opened. Should help streamline some common interactions on feedstocks and make it easier on maintainers trying to resolve users' problems and/or review proposed changes.