### PR TITLE
add test that noarch packages don't have selectors

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -196,6 +196,14 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
                              'subsection name. {} is not a valid subsection'
                              ' name.'.format(section, subsection))
 
+    # 17: noarch doesn't work with selectors
+    if build_section.get('noarch') is not None:
+        with io.open(meta_fname, 'rt') as fh:
+            if any(True for l in selector_lines(fh)):
+                lints.append("Selectors don't work for `noarch` packages. If "
+                             "the selectors are necessary, please remove "
+                             "`noarch: {}`.".format(build_section['noarch']))
+
     return lints
 
 

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -200,7 +200,7 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
     if build_section.get('noarch') is not None:
         with io.open(meta_fname, 'rt') as fh:
             if any(True for l in selector_lines(fh)):
-                lints.append("Selectors don't work for `noarch` packages. If "
+                lints.append("`noarch` packages can't have selectors. If "
                              "the selectors are necessary, please remove "
                              "`noarch: {}`.".format(build_section['noarch']))
 

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -163,7 +163,7 @@ class Test_linter(unittest.TestCase):
             assert_selector("name: foo_py3 # [py3k]", is_good=False)
 
     def test_noarch_selectors(self):
-        expected_start = "Selectors don't work for `noarch` packages."
+        expected_start = "`noarch` packages can't have selectors."
 
         with tmp_directory() as recipe_dir:
             def assert_noarch_selector(noarch, selector, is_good=False):

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -162,7 +162,7 @@ class Test_linter(unittest.TestCase):
             assert_selector("name: foo_py3  #[py3k]", is_good=False)
             assert_selector("name: foo_py3 # [py3k]", is_good=False)
 
-    def test_noarch_selector(self):
+    def test_noarch_selectors(self):
         expected_start = "Selectors don't work for `noarch` packages."
 
         with tmp_directory() as recipe_dir:
@@ -173,7 +173,7 @@ class Test_linter(unittest.TestCase):
                               noarch: {}
                               skip: true  # {}
                             """.format(noarch, selector))
-                lints = linter.lintify({}, recipe_dir)
+                lints = linter.main(recipe_dir)
                 if is_good:
                     message = ("Found lints when there shouldn't have "
                                "been a lint for '{}', '{}'."

--- a/conda_smithy/tests/test_lint_recipe.py
+++ b/conda_smithy/tests/test_lint_recipe.py
@@ -162,6 +162,34 @@ class Test_linter(unittest.TestCase):
             assert_selector("name: foo_py3  #[py3k]", is_good=False)
             assert_selector("name: foo_py3 # [py3k]", is_good=False)
 
+    def test_noarch_selector(self):
+        expected_start = "Selectors don't work for `noarch` packages."
+
+        with tmp_directory() as recipe_dir:
+            def assert_noarch_selector(noarch, selector, is_good=False):
+                with io.open(os.path.join(recipe_dir, 'meta.yaml'), 'w') as fh:
+                    fh.write("""
+                            build:
+                              noarch: {}
+                              skip: true  # {}
+                            """.format(noarch, selector))
+                lints = linter.lintify({}, recipe_dir)
+                if is_good:
+                    message = ("Found lints when there shouldn't have "
+                               "been a lint for '{}', '{}'."
+                              ).format(noarch, selector)
+                else:
+                    message = ("Expected lints for '{}', '{}', but didn't "
+                               "get any.").format(noarch, selector)
+                self.assertEqual(not is_good,
+                                 any(lint.startswith(expected_start)
+                                     for lint in lints),
+                                 message)
+
+            assert_noarch_selector('python', '[py2k]')
+            assert_noarch_selector('generic', '[win]')
+            assert_noarch_selector('python', '', is_good=True)
+
     def test_jinja_os_environ(self):
         # Test that we can use os.environ in a recipe. We don't care about
         # the results here.


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-smithy/issues/578.

Since this has been happening more often now that the example recipe includes a `noarch: python` instruction, add a linter check that `noarch` packages don't have any selectors in them.