### PR TITLE
Only include r-base versions provided by conda-forge.

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -637,7 +637,7 @@ def compute_build_matrix(meta, existing_matrix=None, channel_sources=tuple()):
     index = conda.api.get_index(channel_urls=channel_sources,
                                 platform=meta_config(meta).subdir)
     mtx = special_case_version_matrix(meta, index)
-    mtx = list(filter_cases(mtx, ['python >=2.7,<3|>=3.5', 'numpy >=1.11', 'r-base >=3.3.2']))
+    mtx = list(filter_cases(mtx, ['python >=2.7,<3|>=3.5', 'numpy >=1.11', 'r-base ==3.3.2|==3.4.1']))
     if existing_matrix:
         mtx = [tuple(mtx_case) + tuple(MatrixCaseEnvVar(*item) for item in case)
                for case in sorted(existing_matrix)


### PR DESCRIPTION
conda smithy has started including R 3.4.2 in the build matrix for R packages because it is available in defaults. This is causing problems for recipes added to staged-recipes and also for existing feedstocks when being rerendered.

The current plan as I understand it is for conda-forge to support only one version per minor release, i.e. 3.3.2 for the 3.3.* series and 3.4.1 for the 3.4.* series. When R 3.5 is released, this script can be updated by changing it to, e.g. `'r-base ==3.3.2|==3.4.1|==3.5.1'`.