### PR TITLE
[appveyor] update to the new VS2017 image for py3

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -458,6 +458,7 @@ def render_appveyor(jinja_env, forge_config, forge_dir):
                 case["CONDA_INSTALL_LOCN"] += "35"
             elif case.get("CONDA_PY") == "36":
                 case["CONDA_INSTALL_LOCN"] += "36"
+                case["APPVEYOR_BUILD_WORKER_IMAGE"] = "Visual Studio 2017"
 
             # Set architecture.
             if case.get("TARGET_ARCH") == "x86":


### PR DESCRIPTION
/cc @isuruf 

This updates the build image to VS2017 for Python 3. VS2017 is ABI compatible with VS2015, and the new image has VS2015 as well, so there shouldn't be any problems. 

That said, I am sure that there is something that I haven't considered.