### PR TITLE
WIP: Test against conda-build 3 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     matrix:
         - PYTHON=2.7
         - PYTHON=3.5
+          CONDA_PKGS='conda=4.3.* conda-build=2.1.*'
 
 install:
     - mkdir -p ${HOME}/cache/pkgs

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ env:
         - PYTHON=3.5
           CONDA_PKGS='conda=4.3.* conda-build=3.0.*'
 
+matrix:
+    allow_failures:
+        - env: PYTHON=3.5 CONDA_PKGS='conda=4.3.* conda-build=3.0.*'
+
 install:
     - mkdir -p ${HOME}/cache/pkgs
     - "[ ! -f ${HOME}/cache/miniconda.sh ] && wget https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh -O ${HOME}/cache/miniconda.sh || :"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
         - PYTHON=2.7
         - PYTHON=3.5
           CONDA_PKGS='conda=4.3.* conda-build=2.1.*'
+        - PYTHON=3.5
+          CONDA_PKGS='conda=4.3.* conda-build=3.0.*'
 
 install:
     - mkdir -p ${HOME}/cache/pkgs


### PR DESCRIPTION
Includes a `conda-build` 3 matrix item in the Travis CI tests. Marks it as a known failure as it is already known this doesn't work with `conda-smithy`. However run the test anyways so that this can be seen in Travis CI's builds and improved incrementally.