### PR TITLE
Hide AppVeyor config file in feedstocks

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -431,7 +431,7 @@ def render_appveyor(jinja_env, forge_config, forge_dir):
                                    for case in cases_not_skipped)
     matrix = sorted(full_matrix, key=sort_without_target_arch)
 
-    target_fname = os.path.join(forge_dir, 'appveyor.yml')
+    target_fname = os.path.join(forge_dir, '.appveyor.yml')
 
     if not matrix:
         # There are no cases to build (not even a case without any special
@@ -677,6 +677,7 @@ def main(forge_file_directory):
         'disabled_appveyor.yml',
         os.path.join('ci_support', 'upload_or_check_non_existence.py'),
         'circle.yml',
+        'appveyor.yml',
     ]
     for old_file in old_files:
         remove_file(os.path.join(forge_dir, old_file))


### PR DESCRIPTION
As AppVeyor recognizes `appveyor.yml` and `.appveyor.yml` by default, switch to `.appveyor.yml`. This matches how we handle other CI configuration files for Travis CI and CircleCI. Should also remove noise for anyone just looking at the feedstock locally.

Edit: Testing in PR ( https://github.com/conda-forge/click-feedstock/pull/8 ). Have also tested on a `noarch: python` recipe, but there is no visible change to the feedstock.