### PR TITLE
[wip] detect selinux and mount with Z, readonly feedstock

### DIFF
--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -19,7 +19,7 @@
 # benefit from the improvement.
 
 FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
-RECIPE_ROOT=$FEEDSTOCK_ROOT/{{ recipe_dir }}
+ARTIFACTS_ROOT=$FEEDSTOCK_ROOT/build_artifacts
 
 docker info
 
@@ -31,7 +31,7 @@ channels:
 {%- endfor %}
 
 conda-build:
- root-dir: /home/conda/feedstock_root/build_artifacts
+ root-dir: /home/conda/build_artifacts
 
 show_channel_urls: true
 
@@ -48,15 +48,23 @@ if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
     HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
 fi
 
-rm -f "$FEEDSTOCK_ROOT/build_artifacts/conda-forge-build-done"
+# If the docker host has SELinux enabled, it is neccessary to add some
+# additional options to the volume
+VOLUME_OPTIONS=""
+if hash getenforce 2> /dev/null && getenforce | grep 'Enforcing' > /dev/null
+then
+  VOLUME_OPTIONS=",Z"
+fi
+
+rm -f "$ARTIFACTS_ROOT/conda-forge-build-done"
 
 cat << EOF | {{ docker.executable }} run -i \
-                        -v "${RECIPE_ROOT}":/home/conda/recipe_root \
-                        -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root \
-                        {{ matrix_env_vars(matrix) }}
-                        -a stdin -a stdout -a stderr \
-                        {{ docker.image }} \
-                        {{ docker.command }} || exit 1
+  -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:ro${VOLUME_OPTIONS} \
+  -v "${ARTIFACTS_ROOT}":/home/conda/build_artifacts:rw${VOLUME_OPTIONS} \
+  {{ matrix_env_vars(matrix) }}
+  -a stdin -a stdout -a stderr \
+  {{ docker.image }} \
+  {{ docker.command }} || exit 1
 
 set -e
 set +x
@@ -72,17 +80,16 @@ conda install --yes --quiet conda-forge-build-setup
 {% if build_setup -%}
 {{ build_setup }}{% endif -%}
 
-conda build /home/conda/recipe_root --quiet || exit 1
+conda build /home/conda/feedstock_root/recipe --quiet || exit 1
 {%- for owner, channel in channels['targets'] %}
 {{ upload_script }} /home/conda/recipe_root {{ owner }} --channel={{ channel }} || exit 1
 {%- endfor %}
 
-touch /home/conda/feedstock_root/build_artifacts/conda-forge-build-done
+touch /home/conda/build_artifacts/conda-forge-build-done
 EOF
 
 # double-check that the build got to the end
 # see https://github.com/conda-forge/conda-smithy/pull/337
 # for a possible fix
 set -x
-test -f "$FEEDSTOCK_ROOT/build_artifacts/conda-forge-build-done" || exit 1
-
+test -f "$ARTIFACTS_ROOT/conda-forge-build-done" || exit 1

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -82,7 +82,7 @@ conda install --yes --quiet conda-forge-build-setup
 
 conda build /home/conda/feedstock_root/recipe --quiet || exit 1
 {%- for owner, channel in channels['targets'] %}
-{{ upload_script }} /home/conda/recipe_root {{ owner }} --channel={{ channel }} || exit 1
+{{ upload_script }} /home/conda/feedstock_root/recipe {{ owner }} --channel={{ channel }} || exit 1
 {%- endfor %}
 
 touch /home/conda/build_artifacts/conda-forge-build-done

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -21,7 +21,7 @@
 FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
 ARTIFACTS_ROOT=$FEEDSTOCK_ROOT/build_artifacts
 
-mkdir -p $ARTEFACTS_ROOT
+mkdir -p $ARTIFACTS_ROOT
 
 docker info
 

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -61,12 +61,12 @@ fi
 rm -f "$ARTIFACTS_ROOT/conda-forge-build-done"
 
 cat << EOF | {{ docker.executable }} run -i \
-  -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:ro${VOLUME_OPTIONS} \
-  -v "${ARTIFACTS_ROOT}":/home/conda/build_artifacts:rw${VOLUME_OPTIONS} \
-  {{ matrix_env_vars(matrix) }}
-  -a stdin -a stdout -a stderr \
-  {{ docker.image }} \
-  {{ docker.command }} || exit 1
+                        -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:ro${VOLUME_OPTIONS} \
+                        -v "${ARTIFACTS_ROOT}":/home/conda/build_artifacts:rw${VOLUME_OPTIONS} \
+                        {{ matrix_env_vars(matrix) }}
+                        -a stdin -a stdout -a stderr \
+                        {{ docker.image }} \
+                        {{ docker.command }} || exit 1
 
 set -e
 set +x

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -21,6 +21,8 @@
 FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
 ARTIFACTS_ROOT=$FEEDSTOCK_ROOT/build_artifacts
 
+mkdir -p $ARTEFACTS_ROOT
+
 docker info
 
 config=$(cat <<CONDARC


### PR DESCRIPTION
This PR:
- mounts the `feedstock_root` as read-only
  - while not strictly necessary, it has a nice _least privilege_ feel to it, though as @jakirkham points out, it _can_ be handy to hack the recipe in-place for a tighter debugging loop, but this can be accomplished by doing your own docker thing. If `ro` is the default, perhaps this could also be parameterized.
- removes the (apparently) extraneous `$RECIPE_ROOT`... 
  - might be ignorance on my part, can certainly be convinced this is still needed
- creates(outside) and mounts the `build_artifacts` as read-write
  - though honestly, I've often wanted different containers to share the _same_ `build_artifacts`, but that's another story, and maybe a recipe (ha) for un-reproducible builds... would save some steps with orchestrating multiple feedstock updates...
- for #637, detects `Enforcing` selinux hosts and adds `Z`
  - This helps people running SELinux from getting mysterious `permission denied` errors, using a similar mechanism to the `docker-machine` check and config.
  - An alternative would be to _not_ detect selinux, and offer local runners of the docker-based scripts to provide additional volume options, which are numerous.
    - In this case, to help folks like myself, it could preflight whether `build_artifacts` is writeable and `feedstock_root` is readable, and perhaps suggest use of the escape hatch.

```
Checking if /home/conda/feedstock_root is readable.... FAIL
Checking if /home/conda/build_artifacts is writeable... FAIL

   It looks like the feedstock is not writeable. If you are running with SELinux 
  (check with `getenforcing`), you can try running:
   
       VOLUME_OPTIONS=Z ./.circle_ci/run_docker_build.sh

   Note that this changes SELinux labels ON YOUR HOST SYSTEM, and can lead to 
   instability if used too broadly, like $HOME or /. This script will only change:

      /home/weg/projects/conda-forge/feedstocks/gawk-feedstock
      /home/weg/projects/conda-forge/feedstocks/gawk-feedstock/build_artifacts

Aborting!
```

This was tested with `gawk-feedstock`, which exhibited a number of exciting permission denied errors before some patches were made to the non-root anvil (which is a very good thing!).