### PR TITLE
Drop the `--no-git-repo` option

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -94,8 +94,6 @@ class Init(Subcommand):
         scp.add_argument("--feedstock-directory", default='./{package.name}-feedstock',
                          help="Target directory, where the new feedstock git repository should be "
                          "created. (Default: './<packagename>-feedstock')")
-        scp.add_argument("--no-git-repo", action='store_true', default=False,
-                         help="Do not init the feedstock as a git repository.")
         scp.add_argument("-m", "--variant-config-files", action="append",
                          help="path to conda_build_config.yaml defining your base matrix")
 
@@ -117,12 +115,10 @@ class Init(Subcommand):
 
         try:
             os.makedirs(feedstock_directory)
-            if not args.no_git_repo:
-                subprocess.check_call(['git', 'init'], cwd=feedstock_directory)
+            subprocess.check_call(['git', 'init'], cwd=feedstock_directory)
             generate_feedstock_content(feedstock_directory, args.recipe_directory, meta,
                                        args.variant_config_files)
-            if not args.no_git_repo:
-                subprocess.check_call(['git', 'commit', '-m', msg], cwd=feedstock_directory)
+            subprocess.check_call(['git', 'commit', '-m', msg], cwd=feedstock_directory)
 
             print("\nRepository created, please edit conda-forge.yml to configure the upload channels\n"
                   "and afterwards call 'conda smithy register-github'")


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-smithy/issues/333

The `--no-git-repo` option is unused in `conda-forge`. Also it doesn't sound like it is being used outside of `conda-forge`. Most of the content that `conda-smithy` generates ends up being only useful for GitHub repos with CI configured anyways. In an effort to help simplify the codebase, this drops the `--no-git-repo` option. Hopefully things like `feedstock_io` can be simplified in the process.