### PR TITLE
Use backslashes on AppVeyor

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -56,8 +56,8 @@ install:
 build: off
 
 test_script:
-    - conda.exe build {{ recipe_dir }} -m ci_support/matrix/%CONFIG%.yaml --quiet
+    - conda.exe build {{ recipe_dir }} -m ci_support\matrix\%CONFIG%.yaml --quiet
 deploy_script:
 {%- for owner, channel in channels['targets'] %}
-    - cmd: {{ upload_script }} .\{{ recipe_dir }} {{ owner }} --channel={{ channel }} -m ci_support/matrix/%CONFIG%.yaml
+    - cmd: {{ upload_script }} .\{{ recipe_dir }} {{ owner }} --channel={{ channel }} -m ci_support\matrix\%CONFIG%.yaml
 {% endfor %}

--- a/tests/recipes/click-test-feedstock/.appveyor.yml
+++ b/tests/recipes/click-test-feedstock/.appveyor.yml
@@ -52,6 +52,6 @@ install:
 build: off
 
 test_script:
-    - conda build recipe -m ci_support/matrix/appveyor_%CONFIG%.yaml --quiet
+    - conda build recipe -m ci_support\matrix\appveyor_%CONFIG%.yaml --quiet
 deploy_script:
-    - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main -m ci_support/matrix/appveyor_%CONFIG%.yaml
+    - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main -m ci_support\matrix\appveyor_%CONFIG%.yaml


### PR DESCRIPTION
Some of the paths in the AppVeyor configuration files were using forward slashes. This fixes them to use backslashes as is typical on Windows.