### PR TITLE
No need to manually update pins

### DIFF
--- a/conda_smithy/feedstock_content/.github/PULL_REQUEST_TEMPLATE.md
+++ b/conda_smithy/feedstock_content/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,6 @@ Below are a few things we ask you kindly to self-check before getting a review.
 * [ ] Bump the build number (if the version is unchanged)
 * [ ] Reset the build number to `0` (if the version changed)
 * [ ] [Re-render]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
-* [ ] Updating pinnings based on the [current list]( https://github.com/conda-forge/conda-forge.github.io/blob/master/scripts/pin_the_slow_way.py#L39 )
 * [ ] Ensure the license file is being packaged.
 
 Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):


### PR DESCRIPTION
As we no longer need to manually update pins in `conda-build` 3, drop the line suggesting we do.

cc @isuruf