### PR TITLE
Add `--yes --quiet` to conda update

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -34,7 +34,7 @@ install:
     - cmd: call C:\Miniconda3-x64\Scripts\activate.bat
 
     # workaround for https://github.com/conda/conda/issues/6057
-    - cmd: conda.exe update conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
We need to tell `conda` it is ok to update. So this fixes that. The quiet portion merely deals with the fact that CIs are not the same as interactive terminals.