### PR TITLE
Add load_file_regex as an allowed jinja2 command

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -13,7 +13,11 @@ import ruamel.yaml
 
 from conda_build.metadata import (ensure_valid_license_family,
                                   FIELDS as cbfields)
+from conda_build.jinja_context import load_file_regex
 import conda_build.conda_interface
+
+from collections import namedtuple
+
 import copy
 
 FIELDS = copy.deepcopy(cbfields)
@@ -341,10 +345,14 @@ def main(recipe_dir, conda_forge=False):
     # stub out cb3 jinja2 functions - they are not important for linting
     #    if we don't stub them out, the ruamel.yaml load fails to interpret them
     #    we can't just use conda-build's api.render functionality, because it would apply selectors
+    CondaBuildConfig = namedtuple('CondaBuildConfig', 'work_dir')
     env.globals.update(dict(compiler=lambda x: x + '_compiler_stub',
                             pin_subpackage=lambda *args, **kwargs: 'subpackage_stub',
                             pin_compatible=lambda *args, **kwargs: 'compatible_pin_stub',
                             cdt=lambda *args, **kwargs: 'cdt_stub',
+                            load_file_regex=lambda *args, **kwargs: \
+                                    load_file_regex(CondaBuildConfig(recipe_dir), \
+                                                    *args, **kwargs),
                             ))
 
     with io.open(recipe_meta, 'rt') as fh:

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -13,10 +13,9 @@ import ruamel.yaml
 
 from conda_build.metadata import (ensure_valid_license_family,
                                   FIELDS as cbfields)
-from conda_build.jinja_context import load_file_regex
 import conda_build.conda_interface
 
-from collections import namedtuple
+from collections import defaultdict
 
 import copy
 
@@ -345,14 +344,12 @@ def main(recipe_dir, conda_forge=False):
     # stub out cb3 jinja2 functions - they are not important for linting
     #    if we don't stub them out, the ruamel.yaml load fails to interpret them
     #    we can't just use conda-build's api.render functionality, because it would apply selectors
-    CondaBuildConfig = namedtuple('CondaBuildConfig', 'work_dir')
     env.globals.update(dict(compiler=lambda x: x + '_compiler_stub',
                             pin_subpackage=lambda *args, **kwargs: 'subpackage_stub',
                             pin_compatible=lambda *args, **kwargs: 'compatible_pin_stub',
                             cdt=lambda *args, **kwargs: 'cdt_stub',
                             load_file_regex=lambda *args, **kwargs: \
-                                    load_file_regex(CondaBuildConfig(recipe_dir), \
-                                                    *args, **kwargs),
+                                    defaultdict(lambda : ''),
                             ))
 
     with io.open(recipe_meta, 'rt') as fh:

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -266,6 +266,23 @@ class Test_linter(unittest.TestCase):
                          """)
             lints = linter.main(recipe_dir)
 
+    def test_jinja_load_file_regex(self):
+        # Test that we can use load_file_regex in a recipe. We don't care about
+        # the results here.
+        with tmp_directory() as recipe_dir:
+            with io.open(os.path.join(recipe_dir, 'sha256'), 'w') as fh:
+                fh.write("""
+                        fake  fakefile.txt
+                        """)
+            with io.open(os.path.join(recipe_dir, 'meta.yaml'), 'w') as fh:
+                fh.write("""
+                        {% set sha256 = load_file_regex('shasum', '.*') %}
+                        package:
+                          name: foo
+                          version: {{ version }}
+                        """)
+            lints = linter.main(recipe_dir)
+
     def test_missing_build_number(self):
         expected_message = "The recipe must have a `build/number` section."
 

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -272,11 +272,14 @@ class Test_linter(unittest.TestCase):
         with tmp_directory() as recipe_dir:
             with io.open(os.path.join(recipe_dir, 'sha256'), 'w') as fh:
                 fh.write("""
-                        fake  fakefile.txt
+                        d0e46ea5fca7d4c077245fe0b4195a828d9d4d69be8a0bd46233b2c12abd2098  iwftc_osx.zip
+                        8ce4dc535b21484f65027be56263d8b0d9f58e57532614e1a8f6881f3b8fe260  iwftc_win.zip
                         """)
             with io.open(os.path.join(recipe_dir, 'meta.yaml'), 'w') as fh:
                 fh.write("""
-                        {% set sha256 = load_file_regex('shasum', '.*') %}
+                        {% set sha256_osx = load_file_regex(load_file="sha256",
+                                                        regex_pattern="(?m)^(?P<sha256>[0-9a-f]+)\\s+iwftc_osx.zip$",
+                                                        from_recipe_dir=True)["sha256"] %}
                         package:
                           name: foo
                           version: {{ version }}


### PR DESCRIPTION
This PR is to fix the issues raised by the recipes here:

 - Terraform conda-forge/terraform-feedstock#11
 - Terraform-Providers conda-forge/staged-recipes#5328
 - Vault conda-forge/vault-feedstock#6
 - Consul conda-forge/consul-feedstock#13
 - Consul-template conda-forge/consul-template-feedstock#4
