### PR TITLE
fix zip_keys getting trimmed too much due to type check error

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -124,7 +124,7 @@ def _trim_unused_zip_keys(all_used_vars):
     """Remove unused keys in zip_keys sets, so that they don't cause unnecessary missing value
     errors"""
     groups = all_used_vars.get('zip_keys', [])
-    if groups and not isinstance(groups[0], list):
+    if groups and not any(isinstance(groups[0], obj) for obj in (list, tuple)):
         groups = [groups]
     used_groups = []
     for group in groups:
@@ -187,8 +187,9 @@ def _collapse_subpackage_variants(list_of_metas):
     preserve_top_level_loops = set(top_level_loop_vars) - set(all_used_vars)
 
     # Add in some variables that should always be preserved
-    all_used_vars.update(set(('zip_keys', 'pin_run_as_build', 'MACOSX_DEPLOYMENT_TARGET',
-                              'macos_min_version', 'macos_machine')))
+    always_keep_keys = set(('zip_keys', 'pin_run_as_build', 'MACOSX_DEPLOYMENT_TARGET',
+                            'macos_min_version', 'macos_machine'))
+    all_used_vars.update(always_keep_keys)
     all_used_vars.update(top_level_vars)
 
     used_key_values = {key: squished_input_variants[key]
@@ -623,7 +624,8 @@ def check_version_uptodate(resolve, name, installed_version, error_on_warn):
     if installed_version is None:
         msg = "{} is not installed in root env.".format(name)
     elif VersionOrder(installed_version) < VersionOrder(most_recent_version):
-        msg = "{} version in root env is out-of-date.".format(name)
+        msg = "{} version in root env ({}) is out-of-date ({}).".format(
+            name, installed_version, most_recent_version)
     else:
         return
     if error_on_warn:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,12 @@ def config_yaml(testing_workdir):
         f.write('target_platform:\n')
         f.write('- win-64   # [win]\n')
         f.write('- win-32   # [win]\n')
+        f.write('c_compiler:\n  # [win]')
+        f.write('- vs2008\n  # [win]')
+        f.write('- vs2015\n  # [win]')
+        f.write('zip_keys:\n  # [win]')
+        f.write('- c_compiler\n   # [win]')
+        f.write('- python\n   # [win]')
     # dummy file that needs to be present for circle ci.  This is created by the init function
     os.makedirs(os.path.join(testing_workdir, '.circleci'))
     with open(os.path.join(testing_workdir, '.circleci', 'checkout_merge_commit.sh'), 'w') as f:
@@ -123,7 +129,9 @@ package:
     name: py-test
     version: 1.0.0
 requirements:
-    build:
+    build:                      # [win]
+        - {{ compiler('c') }}   # [win]
+    host:
         - python
     run:
         - python
@@ -158,6 +166,7 @@ about:
                             _load_forge_config(config_yaml,
                                                exclusive_config_file=os.path.join(config_yaml,
                                                                                   'config.yaml')))
+
 
 @pytest.fixture(scope='function')
 def python_skipped_recipe(config_yaml, request):

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -87,7 +87,8 @@ def test_py_matrix_appveyor(py_recipe, jinja_env):
     assert py_recipe.config['appveyor']['enabled']
     matrix_dir = os.path.join(py_recipe.recipe, '.ci_support')
     assert os.path.isdir(matrix_dir)
-    # 2 python versions, 2 target_platforms
+    # 2 python versions, 2 target_platforms.  Recipe uses c_compiler, but this is a zipped key
+    #     and shouldn't add extra configurations
     assert len(os.listdir(matrix_dir)) == 4
 
 


### PR DESCRIPTION
fixes #711 

I tried to get the tests to break without the fix, but couldn't.  I don't know exactly what I'm missing.  I do know that line 127 in configure_feedstock here fixes it, but it would be nice to understand how the types were coming out differently.

They were coming in as a list of tuples, which made this code wrap the list in another list, which then caused zip_keys to be trimmed completely down the line, which caused us to lose our association between python version and vs version.