### PR TITLE
Bump conda upper bound to 4.5.x

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -242,9 +242,10 @@ def main():
         args = parser.parse_args()
 
     # Check conda version for compatibility
-    if LooseVersion(conda.__version__) >= LooseVersion('4.4'):
-        print('You appear to be using conda {}, but conda-smithy {} is\ncurrently only compatible with conda versions < 4.4.'.format(
-            conda.__version__, __version__))
+    CONDA_VERSION_MAX = '4.4'
+    if LooseVersion(conda.__version__) >= LooseVersion(CONDA_VERSION_MAX):
+        print('You appear to be using conda {}, but conda-smithy {} is\ncurrently only compatible with conda versions < {}.'.format(
+            conda.__version__, __version__, CONDA_VERSION_MAX))
         sys.exit(2)
 
     args.subcommand_func(args)

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -242,7 +242,7 @@ def main():
         args = parser.parse_args()
 
     # Check conda version for compatibility
-    CONDA_VERSION_MAX = '4.4'
+    CONDA_VERSION_MAX = '4.6'
     if LooseVersion(conda.__version__) >= LooseVersion(CONDA_VERSION_MAX):
         print('You appear to be using conda {}, but conda-smithy {} is\ncurrently only compatible with conda versions < {}.'.format(
             conda.__version__, __version__, CONDA_VERSION_MAX))


### PR DESCRIPTION
Thus far `conda` version `4.5` works ok for `conda-smithy`. Maybe even all versions of `conda` now that we use `conda-build`'s API exclusively (given `conda-build` supports them). Though just bump to anything below `4.6` as a cautionary move.