### PR TITLE
Optionally use CircleCI OSX builds

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -626,7 +626,7 @@ def _load_forge_config(forge_dir, exclusive_config_file):
               'circle': {},
               'appveyor': {},
               'osx_provider': 'travis',
-              'windows': {'enabled': False},
+              'win': {'enabled': False},
               'osx': {'enabled': False},
               'linux': {'enabled': False},
               'channels': {'sources': ['conda-forge', 'defaults'],

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -358,6 +358,11 @@ def _render_ci_provider(provider_name, jinja_env, forge_config, forge_dir, platf
                     for each_target_fname in extra_platform_files[platform]:
                         remove_file(each_target_fname)
 
+        for key in extra_platform_files.keys():
+            if key != 'common' and key not in platforms:
+                for each_target_fname in extra_platform_files[key]:
+                    remove_file(each_target_fname)
+
         forge_config[provider_name]["platforms"] = ','.join(fancy_platforms)
 
         forge_config['configs'] = configs

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -28,18 +28,21 @@ All platforms: ![noarch disabled]({{ shield }}badge/noarch-disabled-lightgrey.sv
 {%- endif %}
 {%- else %}
 {%- if circle.enabled %}
-[![Linux]({{ shield }}circleci/project/github/{{ github.user_or_org }}/{{ github.repo_name }}/master.svg?label=Linux)](https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }})
-{%- else %}
-![Linux disabled]({{ shield }}badge/linux-disabled-lightgrey.svg)
+[![{{ circle.platforms }}]({{ shield }}circleci/project/github/{{ github.user_or_org }}/{{ github.repo_name }}/master.svg?label={{ circle.platforms }})](https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }})
 {%- endif %}
 {%- if travis.enabled %}
 [![OSX]({{ shield }}travis/{{ github.user_or_org }}/{{ github.repo_name }}/master.svg?label=macOS)](https://travis-ci.org/{{ github.user_or_org }}/{{ github.repo_name }})
-{%- else %}
-![OSX disabled]({{ shield }}badge/OSX-disabled-lightgrey.svg)
 {%- endif %}
 {%- if appveyor.enabled %}
 [![Windows]({{ shield }}appveyor/ci/{{ github.user_or_org }}/{{ github.repo_name }}/master.svg?label=Windows)](https://ci.appveyor.com/project/{{ github.user_or_org }}/{{ appveyor_url_name }}/branch/master)
-{%- else %}
+{%- endif %}
+{%- if not linux.enabled %}
+![Linux disabled]({{ shield }}badge/linux-disabled-lightgrey.svg)
+{%- endif %}
+{%- if not osx.enabled %}
+![OSX disabled]({{ shield }}badge/OSX-disabled-lightgrey.svg)
+{%- endif %}
+{%- if not windows.enabled %}
 ![Windows disabled]({{ shield }}badge/Windows-disabled-lightgrey.svg)
 {%- endif %}
 {%- endif %}

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -42,7 +42,7 @@ All platforms: ![noarch disabled]({{ shield }}badge/noarch-disabled-lightgrey.sv
 {%- if not osx.enabled %}
 ![OSX disabled]({{ shield }}badge/OSX-disabled-lightgrey.svg)
 {%- endif %}
-{%- if not windows.enabled %}
+{%- if not win.enabled %}
 ![Windows disabled]({{ shield }}badge/Windows-disabled-lightgrey.svg)
 {%- endif %}
 {%- endif %}

--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -14,10 +14,15 @@ jobs:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.
           command: exit 0
 {%- else %}
-{%- for config, _ in configs %}
+{%- for config, platform in configs %}
   build_{{ config }}:
     working_directory: ~/test
+{%- if platform == 'linux' %}
     machine: true
+{%- else %}
+    macos:
+      xcode: "9.0"
+{%- endif %}
     environment:
       - CONFIG: "{{ config }}"
     steps:
@@ -27,11 +32,17 @@ jobs:
           command: |
             ./.circleci/fast_finish_ci_pr_build.sh
             ./.circleci/checkout_merge_commit.sh
+{%- if platform == 'linux' %}
       - run:
           command: docker pull {{ docker.image }}
+{%- endif %}
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+{%- if platform == 'linux' %}
           command: ./.circleci/run_docker_build.sh
+{%- else %}
+          command: ./.circleci/run_osx_build.sh
+{%- endif %}
 {%- endfor -%}
 {%- endif -%}
 {%- endblock %}

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -x
+
+echo "Removing homebrew from Circle CI to avoid conflicts."
+curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+chmod +x ~/uninstall_homebrew
+~/uninstall_homebrew -fq
+rm ~/uninstall_homebrew
+
+echo "Installing a fresh version of Miniconda."
+MINICONDA_URL="https://repo.continuum.io/miniconda"
+MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
+curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+bash $MINICONDA_FILE -b
+
+echo "Downloading sdk"
+curl -L -O https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.9.sdk.tar.xz
+tar -xvf $(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/
+sed -i '' "s|<string>10.11</string>|<string>10.9</string>|g" /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Info.plist
+
+echo "Configuring conda."
+source ~/miniconda3/bin/activate root
+conda config --remove channels defaults
+{%- for channel in channels.get('sources', [])|reverse %}
+conda config --add channels {{ channel }}
+{%- endfor %}
+conda config --set show_channel_urls true
+conda install --yes --quiet conda-forge-ci-setup=1
+{% if build_setup -%}
+{{ build_setup }}{% endif %}
+
+set -e
+conda build ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml
+{% for owner, channel in channels['targets'] %}
+{{ upload_script }} ./{{ recipe_dir }} {{ owner }} --channel={{ channel }} -m ./.ci_support/${CONFIG}.yaml
+{% endfor %}
+

--- a/conda_smithy/templates/run_osx_build.tmpl
+++ b/conda_smithy/templates/run_osx_build.tmpl
@@ -14,11 +14,6 @@ MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
 curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
 bash $MINICONDA_FILE -b
 
-echo "Downloading sdk"
-curl -L -O https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.9.sdk.tar.xz
-tar -xf MacOSX10.9.sdk.tar.xz -C $(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/
-sed -i '' "s|<string>10.11</string>|<string>10.9</string>|g" $(xcode-select -p)/Platforms/MacOSX.platform/Info.plist
-
 echo "Configuring conda."
 source ~/miniconda3/bin/activate root
 conda config --remove channels defaults
@@ -35,4 +30,3 @@ conda build ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml
 {% for owner, channel in channels['targets'] %}
 {{ upload_script }} ./{{ recipe_dir }} {{ owner }} --channel={{ channel }} -m ./.ci_support/${CONFIG}.yaml
 {% endfor %}
-

--- a/conda_smithy/templates/run_osx_build.tmpl
+++ b/conda_smithy/templates/run_osx_build.tmpl
@@ -16,8 +16,8 @@ bash $MINICONDA_FILE -b
 
 echo "Downloading sdk"
 curl -L -O https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.9.sdk.tar.xz
-tar -xvf $(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/
-sed -i '' "s|<string>10.11</string>|<string>10.9</string>|g" /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Info.plist
+tar -xf MacOSX10.9.sdk.tar.xz -C $(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/
+sed -i '' "s|<string>10.11</string>|<string>10.9</string>|g" $(xcode-select -p)/Platforms/MacOSX.platform/Info.plist
 
 echo "Configuring conda."
 source ~/miniconda3/bin/activate root
@@ -28,8 +28,8 @@ conda config --add channels {{ channel }}
 conda config --set show_channel_urls true
 conda install --yes --quiet conda-forge-ci-setup=1
 {% if build_setup -%}
-{{ build_setup }}{% endif %}
-
+{{ build_setup }}
+{%- endif %}
 set -e
 conda build ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml
 {% for owner, channel in channels['targets'] %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,6 +191,27 @@ about:
                                                exclusive_config_file=os.path.join(config_yaml,
                                                                                   'config.yaml')))
 
+@pytest.fixture(scope='function')
+def linux_skipped_recipe(config_yaml, request):
+    os.makedirs(os.path.join(config_yaml, 'recipe'))
+    with open(os.path.join(config_yaml, 'recipe', 'meta.yaml'), 'w') as fh:
+        fh.write("""
+package:
+    name: py-test
+    version: 1.0.0
+build:
+    skip: True   # [linux]
+requirements:
+    build:
+        - zlib
+about:
+    home: home
+    """)
+    return RecipeConfigPair(str(config_yaml),
+                            _load_forge_config(config_yaml,
+                                               exclusive_config_file=os.path.join(config_yaml,
+                                                                                  'config.yaml')))
+
 
 @pytest.fixture(scope='function')
 def jinja_env(request):

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -137,40 +137,42 @@ def test_circle_with_empty_yum_reqs_raises(py_recipe, jinja_env):
 
 
 def test_circle_osx(py_recipe, jinja_env):
-    travis_yml_file = os.path.join(py_recipe.recipe, '.travis.yml')
-    circle_osx_file = os.path.join(py_recipe.recipe, '.circleci', 'run_osx_build.sh')
-    circle_linux_file = os.path.join(py_recipe.recipe, '.circleci', 'run_docker_build.sh')
-    circle_config_file = os.path.join(py_recipe.recipe, '.circleci', 'config.yml')
+    forge_dir = py_recipe.recipe
+    travis_yml_file = os.path.join(forge_dir, '.travis.yml')
+    circle_osx_file = os.path.join(forge_dir, '.circleci', 'run_osx_build.sh')
+    circle_linux_file = os.path.join(forge_dir, '.circleci', 'run_docker_build.sh')
+    circle_config_file = os.path.join(forge_dir, '.circleci', 'config.yml')
 
     cnfgr_fdstk.render_circle(jinja_env=jinja_env,
                               forge_config=py_recipe.config,
-                              forge_dir=py_recipe.recipe)
+                              forge_dir=forge_dir)
     assert not os.path.exists(circle_osx_file)
     assert os.path.exists(circle_linux_file)
     assert os.path.exists(circle_config_file)
     cnfgr_fdstk.render_travis(jinja_env=jinja_env,
                               forge_config=py_recipe.config,
-                              forge_dir=py_recipe.recipe)
+                              forge_dir=forge_dir)
     assert os.path.exists(travis_yml_file)
 
     config = copy.deepcopy(py_recipe.config)
     config['provider']['osx'] = 'circle'
     cnfgr_fdstk.render_circle(jinja_env=jinja_env,
                               forge_config=config,
-                              forge_dir=config)
+                              forge_dir=forge_dir)
     assert os.path.exists(circle_osx_file)
     assert os.path.exists(circle_linux_file)
     assert os.path.exists(circle_config_file)
     cnfgr_fdstk.render_travis(jinja_env=jinja_env,
                               forge_config=config,
-                              forge_dir=py_recipe.recipe)
+                              forge_dir=forge_dir)
     assert not os.path.exists(travis_yml_file)
 
     config = copy.deepcopy(py_recipe.config)
     config['provider']['linux'] = 'dummy'
+    config['provider']['osx'] = 'circle'
     cnfgr_fdstk.render_circle(jinja_env=jinja_env,
                               forge_config=config,
-                              forge_dir=config)
+                              forge_dir=forge_dir)
     assert os.path.exists(circle_osx_file)
     assert not os.path.exists(circle_linux_file)
     assert os.path.exists(circle_config_file)


### PR DESCRIPTION
```yaml
provider:
  osx: circle
```
in `conda-forge.yml` changes the rerendering to skip travis and use circleci for osx.