### PR TITLE
Place package badges in markdown table

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -50,12 +50,12 @@ All platforms: ![noarch disabled]({{ shield }}badge/noarch-disabled-lightgrey.sv
 Current release info
 ====================
 
+| Name | Downloads | Version | Platforms |
+| --- | --- | --- | --- |
 {%- for output in outputs %}
-[![Conda Recipe]({{ shield }}badge/recipe-{{ output.replace('-','--') }}-green.svg)](https://anaconda.org/{{ channel_name }}/{{ output }})
-[![Conda Downloads]({{ shield }}conda/dn/{{ channel_name }}/{{ output }}.svg)](https://anaconda.org/{{ channel_name }}/{{ output }})
-[![Conda Version]({{ shield }}conda/vn/{{ channel_name }}/{{ output }}.svg)](https://anaconda.org/{{ channel_name }}/{{ output }})
-[![Conda Platforms]({{ shield }}conda/pn/{{ channel_name }}/{{ output }}.svg)](https://anaconda.org/{{ channel_name }}/{{ output }})
-{% endfor %}
+| [![Conda Recipe]({{ shield }}badge/recipe-{{ output.replace('-','--') }}-green.svg)](https://anaconda.org/{{ channel_name }}/{{ output }}) | [![Conda Downloads]({{ shield }}conda/dn/{{ channel_name }}/{{ output }}.svg)](https://anaconda.org/{{ channel_name }}/{{ output }}) | [![Conda Version]({{ shield }}conda/vn/{{ channel_name }}/{{ output }}.svg)](https://anaconda.org/{{ channel_name }}/{{ output }}) | [![Conda Platforms]({{ shield }}conda/pn/{{ channel_name }}/{{ output }}.svg)](https://anaconda.org/{{ channel_name }}/{{ output }}) |
+{%- endfor %}
+
 Installing {{ package_name }}
 ==========={{ '=' * package_name|length }}
 


### PR DESCRIPTION
To aid readability, format the badges in a Markdown table. This should make it clearer what they represent and easier to look at several split packages from one recipe build.

<img width="627" alt="screen shot 2018-04-18 at 13 52 10" src="https://user-images.githubusercontent.com/3019665/38949213-bcc2a300-430f-11e8-8204-32ed11612f52.png">

Side note: Making the text pretty would be pretty painful (and it is autogenerated). So skipped that. However the table it generates is still nice.

xref: https://github.com/conda-forge/conda-smithy/pull/744#issuecomment-382464743

cc @isuruf