### PR TITLE
Generate the changelog first

### DIFF
--- a/rever.xsh
+++ b/rever.xsh
@@ -3,7 +3,7 @@ import os
 $PROJECT = $GITHUB_REPO = 'conda-smithy'
 $GITHUB_ORG = 'conda-forge'
 
-$ACTIVITIES = ['tag', 'push_tag', 'changelog', 'ghrelease', 'conda_forge']
+$ACTIVITIES = ['changelog', 'tag', 'push_tag', 'ghrelease', 'conda_forge']
 
 $CHANGELOG_FILENAME = 'CHANGELOG.rst'
 $CHANGELOG_TEMPLATE = 'TEMPLATE.rst'


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-smithy/issues/752

As we need to generate the changelog before we tag.

@CJ-Wright, is this correct?