### PR TITLE
Update conda-build for Linux builds

### DIFF
--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -56,7 +56,8 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artifacts.
 conda clean --lock
 
-conda install --yes --quiet conda-forge-ci-setup=1 conda-build
+# Make sure we pull in the latest pinnimgs and conda-build versions too
+conda install --yes --quiet conda-forge-ci-setup=1 conda-build conda-forge-pinning
 {% if build_setup -%}
 {{ build_setup }}{% endif -%}
 

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -56,7 +56,7 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artifacts.
 conda clean --lock
 
-# Make sure we pull in the latest pconda-build version too
+# Make sure we pull in the latest conda-build version too
 conda install --yes --quiet conda-forge-ci-setup=1 conda-build
 {% if build_setup -%}
 {{ build_setup }}{% endif -%}

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -56,7 +56,7 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artifacts.
 conda clean --lock
 
-conda install --yes --quiet conda-forge-ci-setup=1
+conda install --yes --quiet conda-forge-ci-setup=1 conda-build
 {% if build_setup -%}
 {{ build_setup }}{% endif -%}
 

--- a/conda_smithy/templates/run_docker_build.tmpl
+++ b/conda_smithy/templates/run_docker_build.tmpl
@@ -56,8 +56,8 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artifacts.
 conda clean --lock
 
-# Make sure we pull in the latest pinnimgs and conda-build versions too
-conda install --yes --quiet conda-forge-ci-setup=1 conda-build conda-forge-pinning
+# Make sure we pull in the latest pconda-build version too
+conda install --yes --quiet conda-forge-ci-setup=1 conda-build
 {% if build_setup -%}
 {{ build_setup }}{% endif -%}
 

--- a/news/update-conda-build.rst
+++ b/news/update-conda-build.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+* Update conda-build in the docker build script
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
https://github.com/conda-forge/pdal-feedstock/issues/1#issuecomment-382729121

Currently `run_docker` doesn't update to the latest conda-build, because `conda-forge-ci-setup` only requires 3.*, and the Docker container already has 3.something. This <s>should (I think?)</s>will update it appropriately when it's out of date.