### PR TITLE
Fix inclusion of yum requirements

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -471,7 +471,6 @@ def _circle_specific_setup(jinja_env, forge_config, forge_dir, platform):
 
     # TODO: Conda has a convenience for accessing nested yaml content.
     template_files = [
-        'build_steps.sh.tmpl',
         '{}.sh.tmpl'.format(run_file_name),
         'fast_finish_ci_pr_build.sh.tmpl',
     ]

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -455,7 +455,7 @@ def _circle_specific_setup(jinja_env, forge_config, forge_dir, platform):
 
                 # Install the yum requirements defined canonically in the
                 # "recipe/yum_requirements.txt" file. After updating that file,
-                # run "conda smithy rerender" and this line be updated
+                # run "conda smithy rerender" and this line will be updated
                 # automatically.
                 /usr/bin/sudo -n yum install -y {}
 


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-smithy/issues/775
Fixes https://github.com/conda-forge/conda-smithy/issues/776

Previously `yum_requirements.txt` was being ignored on Linux. As @isuruf correctly deduced, this was due to the unconditional inclusion of `build_steps.sh.tmpl`, which was also being done below. This corrects that issue by dropping `build_steps.sh.tmpl` from general inclusion in the template files when it is not needed. Also fixes a small typo in a comment about `yum_requirements.txt`.

cc @looooo