### PR TITLE
Add requirements specifier lint

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -38,6 +38,7 @@ TEST_KEYS = {'imports', 'commands'}
 
 sel_pat = re.compile(r'(.+?)\s*(#.*)?\[([^\[\]]+)\](?(2).*)$')
 jinja_pat = re.compile(r'\s*\{%\s*(set)\s+[^\s]+\s*=\s*[^\s]+\s*%\}')
+req_pat = re.compile(r'(.+?)(\s+([><=]+\w+)(,[><=]+\w+)*)')
 
 
 class NullUndefined(jinja2.Undefined):
@@ -314,6 +315,12 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
                          '<variable name><one space>=<one space>'
                          '<expression><one space>%}}`` form. See lines '
                          '{}'.format(bad_lines))
+
+    # 21: Verify requirements format
+    for subsection in requirements_section.values():
+        for req in subsection:
+            if not req_pat.match(req):
+                lints.append('Invalid requirements specification {}'.format(req))
 
     # hints
     # 1: Legacy usage of compilers

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -38,7 +38,7 @@ TEST_KEYS = {'imports', 'commands'}
 
 sel_pat = re.compile(r'(.+?)\s*(#.*)?\[([^\[\]]+)\](?(2).*)$')
 jinja_pat = re.compile(r'\s*\{%\s*(set)\s+[^\s]+\s*=\s*[^\s]+\s*%\}')
-req_pat = re.compile(r'(.+?)(\s+([><=]+\w+)(,[><=]+\w+)*)')
+req_pat = re.compile(r'(.+?)(\s+([><=]+\w+)(,[><=]+\w+)*)?')
 
 
 class NullUndefined(jinja2.Undefined):

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -38,7 +38,7 @@ TEST_KEYS = {'imports', 'commands'}
 
 sel_pat = re.compile(r'(.+?)\s*(#.*)?\[([^\[\]]+)\](?(2).*)$')
 jinja_pat = re.compile(r'\s*\{%\s*(set)\s+[^\s]+\s*=\s*[^\s]+\s*%\}')
-req_pat = re.compile(r'(.+?)(\s+([><=]+\w+)(,[><=]+\w+)*)?')
+req_pat = re.compile(r'((?:.+?)[^><!,|]?)(?:(?<![=!|,<>])(?:[ =])([^-=,|<>]+?))?$')
 
 
 class NullUndefined(jinja2.Undefined):

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -21,6 +21,9 @@ from collections import defaultdict
 
 import copy
 
+from conda.models.match_spec import MatchSpec
+from conda.exceptions import CondaValueError, InvalidVersionSpecError
+
 FIELDS = copy.deepcopy(cbfields)
 
 # Just in case 'extra' moves into conda_build
@@ -38,7 +41,6 @@ TEST_KEYS = {'imports', 'commands'}
 
 sel_pat = re.compile(r'(.+?)\s*(#.*)?\[([^\[\]]+)\](?(2).*)$')
 jinja_pat = re.compile(r'\s*\{%\s*(set)\s+[^\s]+\s*=\s*[^\s]+\s*%\}')
-req_pat = re.compile(r'((?:.+?)[^><!,|]?)(?:(?<![=!|,<>])(?:[ =])([^-=,|<>]+?))?$')
 
 
 class NullUndefined(jinja2.Undefined):
@@ -319,7 +321,9 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
     # 21: Verify requirements format
     for subsection in requirements_section.values():
         for req in subsection:
-            if not req_pat.match(req):
+            try:
+                spec = MatchSpec(req)
+            except (CondaValueError, InvalidVersionSpecError) as e:
                 lints.append('Invalid requirements specification {}'.format(req))
 
     # hints


### PR DESCRIPTION
Adds a regexp based lint of a requirement specifier. Note: The current regexp is not rigorously defined yet, but is a first-guess implementation for a proof of concept.

TODO:
- [ ] Ensure requirements regexp matches the spec that is accepted.
- [ ] Write tests.

Fixes #794.