### PR TITLE
fix pin_run_as_build trimming for packages with -

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -139,6 +139,9 @@ def break_up_top_level_values(top_level_keys, squished_variants):
 
     return configs
 
+def _package_var_name(pkg):
+    return pkg.replace('-', '_')
+
 
 def _trim_unused_zip_keys(all_used_vars):
     """Remove unused keys in zip_keys sets, so that they don't cause unnecessary missing value
@@ -163,7 +166,7 @@ def _trim_unused_pin_run_as_build(all_used_vars):
     used_pkgs = {}
     if pkgs:
         for key in pkgs.keys():
-            if key in all_used_vars:
+            if _package_var_name(key) in all_used_vars:
                 used_pkgs[key] = pkgs[key]
     if used_pkgs:
         all_used_vars['pin_run_as_build'] = used_pkgs

--- a/news/fix-trim-pinnings.rst
+++ b/news/fix-trim-pinnings.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+- Fix `pin_run_as_build` inclusion for packages with `-` in their names (#796)
+
+**Security:** None


### PR DESCRIPTION
I noticed that rerendering was removing `json_c` from `pin_run_as_build`, after https://github.com/conda-forge/conda-forge-pinning-feedstock/commit/0098fad4493f5ecad1a0d90b8664dd19566c2170, but not adding the correct `json-c`. The current check for whether packages are used doesn't work for packages with `-` in their name.

Things I don't know, and haven't checked:

- Are there any other changes to the names that might be made?
- If so, is there a better way to make this check?
- Do we need to do a similar thing in `_trim_unused_zip_keys` or `_collapse_subpackage_variants`?