### PR TITLE
Allow custom branch in repo for badges

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -685,7 +685,9 @@ def _load_forge_config(forge_dir, exclusive_config_file):
               'linux': {'enabled': False},
               'channels': {'sources': ['conda-forge', 'defaults'],
                            'targets': [['conda-forge', 'main']]},
-              'github': {'user_or_org': 'conda-forge', 'repo_name': ''},
+              'github': {'user_or_org': 'conda-forge',
+                         'repo_name': '',
+                         'branch_name': 'master'},
               'recipe_dir': 'recipe'}
 
     # An older conda-smithy used to have some files which should no longer exist,

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -22,19 +22,19 @@ Current build status
 {%- if noarch_python %}
 {%- if circle.enabled %}
 All platforms:
-[![noarch]({{ shield }}circleci/project/github/{{ github.user_or_org }}/{{ github.repo_name }}/master.svg?label=noarch)](https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }})
+[![noarch]({{ shield }}circleci/project/github/{{ github.user_or_org }}/{{ github.repo_name }}/{{ github.branch_name }}.svg?label=noarch)](https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }})
 {%- else %}
 All platforms: ![noarch disabled]({{ shield }}badge/noarch-disabled-lightgrey.svg)
 {%- endif %}
 {%- else %}
 {%- if circle.enabled %}
-[![{{ circle.platforms }}]({{ shield }}circleci/project/github/{{ github.user_or_org }}/{{ github.repo_name }}/master.svg?label={{ circle.platforms }})](https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }})
+[![{{ circle.platforms }}]({{ shield }}circleci/project/github/{{ github.user_or_org }}/{{ github.repo_name }}/{{ github.branch_name }}.svg?label={{ circle.platforms }})](https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }})
 {%- endif %}
 {%- if travis.enabled %}
-[![OSX]({{ shield }}travis/{{ github.user_or_org }}/{{ github.repo_name }}/master.svg?label=macOS)](https://travis-ci.org/{{ github.user_or_org }}/{{ github.repo_name }})
+[![OSX]({{ shield }}travis/{{ github.user_or_org }}/{{ github.repo_name }}/{{ github.branch_name }}.svg?label=macOS)](https://travis-ci.org/{{ github.user_or_org }}/{{ github.repo_name }})
 {%- endif %}
 {%- if appveyor.enabled %}
-[![Windows]({{ shield }}appveyor/ci/{{ github.user_or_org }}/{{ github.repo_name }}/master.svg?label=Windows)](https://ci.appveyor.com/project/{{ github.user_or_org }}/{{ appveyor_url_name }}/branch/master)
+[![Windows]({{ shield }}appveyor/ci/{{ github.user_or_org }}/{{ github.repo_name }}/{{ github.branch_name }}.svg?label=Windows)](https://ci.appveyor.com/project/{{ github.user_or_org }}/{{ appveyor_url_name }}/branch/{{ github.branch_name }})
 {%- endif %}
 {%- if not linux.enabled %}
 ![Linux disabled]({{ shield }}badge/linux-disabled-lightgrey.svg)


### PR DESCRIPTION
For a project of mine, I'm trying to stay close to the upstream conda-forge-feedstock, but would prefer to have the badges generated for my own branch.

Does this do what I want it to do?

Do I need to add something around these lines of code:
https://github.com/conda-forge/conda-smithy/blob/master/conda_smithy/github.py#L99