### PR TITLE
Allow setting appveyor.image in conda-forge.yml

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -2,6 +2,10 @@
 # file, make changes to conda-forge.yml and/or recipe/meta.yaml, and run
 # "conda smithy rerender".
 
+{% if appveyor.image -%}
+image: {{ appveyor.image }}
+{% endif -%}
+
 environment:
 
   {% for name, hashed_secure in (appveyor.secure or {}) | dictsort -%}

--- a/news/appveyor_image.rst
+++ b/news/appveyor_image.rst
@@ -1,0 +1,1 @@
+**Added:** allow appveyor.image in conda-forge.yml to set the `appveyor image <https://www.appveyor.com/docs/build-environment/#choosing-image-for-your-builds>`_.


### PR DESCRIPTION
I need this to get Visual Studio 2017 for nodejs 10.

Testing a build rendered from this branch now: https://github.com/conda-forge/nodejs-feedstock/pull/41

At some point, the default image may want to be bumped, but the VS 2017 image doesn't appear to have the old-timey Python 2.7 compilers, so I think it would have to be conditional for a while.

closes #605