### PR TITLE
Fix travis-ci API permission error

### DIFF
--- a/news/fix_travis_error.rst
+++ b/news/fix_travis_error.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+- Fix travis-ci API permission error (#812)
+
+**Security:** None


### PR DESCRIPTION
Travis sometimes knows about github repos, but doesn't know that the bot
has admin access to it. (Maybe because travis accounts of cf admins are
synced, travis knows about the repo)

In that case, sync account and wait till travis knows that the bot has
admin access