### PR TITLE
track conda-smithy, etc versions in the feedstock

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -718,7 +718,13 @@ def render_version(jinja_env, forge_config, forge_dir):
                             ["conda-forge-pinning", "conda-build", "python"])
     installed_vers['conda-smithy'] = __version__
     with write_file(os.path.join(forge_dir, '.smithy-version.json')) as fh:
-        fh.write(json.dumps(installed_vers, fh, sort_keys=True, indent=2))
+        # json.dumps has inconsistent text vs binary behavior on py2/3
+        s = json.dumps(installed_vers, sort_keys=True, indent=2)
+        try:
+            s = s.decode('utf-8')
+        except AttributeError:  # on python 3 and s is already text
+            pass
+        fh.write(s)
         fh.write('\n')
 
 

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -718,7 +718,8 @@ def render_version(jinja_env, forge_config, forge_dir):
                             ["conda-forge-pinning", "conda-build", "python"])
     installed_vers['conda-smithy'] = __version__
     with write_file(os.path.join(forge_dir, '.smithy-version.json')) as fh:
-        json.dump(installed_vers, fh, sort_keys=True, indent=2)
+        fh.write(json.dumps(installed_vers, fh, sort_keys=True, indent=2))
+        fh.write('\n')
 
 
 def copy_feedstock_content(forge_dir):

--- a/news/track_versions.rst
+++ b/news/track_versions.rst
@@ -1,0 +1,3 @@
+**Added:**
+
+* Keep track of `conda-smithy` and related versions in `.smithy-version.json` (#822)


### PR DESCRIPTION
There's been discussion about this before, but not finding it right now.

Currently tracks `conda-smithy`, `conda-forge-pinning`, `conda-build`, and `python` versions in `.smithy-version.json`. Also adds `[skip ci]` to the commit message if only that file (and/or the README; any other files like that?) changed in a re-rendering.