### PR TITLE
remove xcode

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -4,7 +4,6 @@
 language: generic
 
 os: osx
-osx_image: xcode6.4
 
 {% block env -%}
 {% if configs[0] or travis.secure -%}


### PR DESCRIPTION
This is just to get the conversation going. Since Travis-CI single out `conda-forge` on their error message today I guess this is a good time to just move to the new compilers, at least for OS X.

@conda-forge/core 