### PR TITLE
Fix OrderedDict order not being kept

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -299,10 +299,10 @@ def _collapse_subpackage_variants(list_of_metas):
     return break_up_top_level_values(top_level_loop_vars, used_key_values), top_level_loop_vars
 
 
-def _yaml_represent_ordereddict(self, data):
+def _yaml_represent_ordereddict(yaml_representer, data):
     # represent_dict processes dict-likes with a .sort() method or plain iterables of key-value
     #     pairs. Only for the latter it never sorts and retains the order of the OrderedDict.
-    return yaml.representer.SafeRepresenter.represent_dict(self, data.items())
+    return yaml.representer.SafeRepresenter.represent_dict(yaml_representer, data.items())
 
 
 def dump_subspace_config_files(metas, root_path, output_name):

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -299,6 +299,12 @@ def _collapse_subpackage_variants(list_of_metas):
     return break_up_top_level_values(top_level_loop_vars, used_key_values), top_level_loop_vars
 
 
+def _yaml_represent_ordereddict(self, data):
+    # represent_dict processes dict-likes with a .sort() method or plain iterables of key-value
+    #     pairs. Only for the latter it never sorts and retains the order of the OrderedDict.
+    return yaml.representer.SafeRepresenter.represent_dict(self, data.items())
+
+
 def dump_subspace_config_files(metas, root_path, output_name):
     """With conda-build 3, it handles the build matrix.  We take what it spits out, and write a
     config.yaml file for each matrix entry that it spits out.  References to a specific file
@@ -312,7 +318,7 @@ def dump_subspace_config_files(metas, root_path, output_name):
     # get rid of the special object notation in the yaml file for objects that we dump
     yaml.add_representer(set, yaml.representer.SafeRepresenter.represent_list)
     yaml.add_representer(tuple, yaml.representer.SafeRepresenter.represent_list)
-    yaml.add_representer(OrderedDict, yaml.representer.SafeRepresenter.represent_dict)
+    yaml.add_representer(OrderedDict, _yaml_represent_ordereddict)
 
     result = []
     for config in configs:

--- a/news/fix_ordereddict_order.rst
+++ b/news/fix_ordereddict_order.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+- Fix OrderedDict order not being kept (#854)
+
+**Security:** None


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-smithy/pull/820#issuecomment-408478535.
Avoids sorting of `OrderedDict` entries at https://bitbucket.org/ruamel/yaml/src/default/representer.py?at=0.15.46#representer.py-201.
cc @isuruf 