### PR TITLE
Upgrade links to HTTPS and update link targets where necessary

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -19,5 +19,5 @@ exclude_lines =
     # Ignore continue statement in code as it can't be detected as covered
     # due to an optimization by the Python interpreter. See coverage issue
     # ( https://bitbucket.org/ned/coveragepy/issue/198/continue-marked-as-not-covered )
-    # and Python issue ( http://bugs.python.org/issue2506 ).
+    # and Python issue ( https://bugs.python.org/issue2506 ).
     continue

--- a/README.md
+++ b/README.md
@@ -102,4 +102,9 @@ $ rever 0.1.2
 Conda-smithy in a nutshell
 --------------------------
 
-![tools](http://imgs.xkcd.com/comics/tools.png)
+xkcd 1629: Tools
+~~~~~~~~~~~~~~~~
+
+[![xkcd 1629: Tools](https://imgs.xkcd.com/comics/tools.png)](https://xkcd.com/1629/)
+**Titletext**: *I make tools for managing job-hunting sites for people who make*
+*tools for managing job-hunting sites for people who make tools for ...*

--- a/conda_smithy/ci_register.py
+++ b/conda_smithy/ci_register.py
@@ -317,7 +317,7 @@ def travis_encrypt_binstar_token(repo, string_to_encrypt):
     #    not use this file except in compliance with the License. You may obtain
     #    a copy of the License at
     #
-    #         http://www.apache.org/licenses/LICENSE-2.0
+    #         https://www.apache.org/licenses/LICENSE-2.0
     #
     #    Unless required by applicable law or agreed to in writing, software
     #    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/conda_smithy/ci_register.py
+++ b/conda_smithy/ci_register.py
@@ -398,25 +398,25 @@ def add_conda_forge_webservice_hooks(user, repo):
 
     hooks = [
         get_conda_hook_info(
-            "http://conda-forge.herokuapp.com/conda-linting/hook",
+            "https://conda-forge.herokuapp.com/conda-linting/hook",
             [
                 "pull_request"
             ]
         ),
         get_conda_hook_info(
-            "http://conda-forge.herokuapp.com/conda-forge-feedstocks/hook",
+            "https://conda-forge.herokuapp.com/conda-forge-feedstocks/hook",
             [
                 "push", "repository"
             ]
         ),
         get_conda_hook_info(
-            "http://conda-forge.herokuapp.com/conda-forge-teams/hook",
+            "https://conda-forge.herokuapp.com/conda-forge-teams/hook",
             [
                 "push", "repository"
             ]
         ),
         get_conda_hook_info(
-            "http://conda-forge.herokuapp.com/conda-forge-command/hook",
+            "https://conda-forge.herokuapp.com/conda-forge-command/hook",
             [
                 "pull_request_review", "pull_request",
                 "pull_request_review_comment", "issue_comment", "issues",

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -249,7 +249,7 @@ def main():
     parser = argparse.ArgumentParser("a tool to help create, administer and manage feedstocks.")
     subparser = parser.add_subparsers()
     # TODO: Consider allowing plugins/extensions using entry_points.
-    # http://reinout.vanrees.org/weblog/2010/01/06/zest-releaser-entry-points.html
+    # https://reinout.vanrees.org/weblog/2010/01/06/zest-releaser-entry-points.html
     for subcommand in Subcommand.__subclasses__():
         subcommand(subparser)
     # And the alias for rerender

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -89,13 +89,13 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](http://www.appveyor.com/)
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
 and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](http://docs.anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
-[conda-smithy](http://github.com/conda-forge/conda-smithy) has been developed.
+[conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
@@ -132,7 +132,7 @@ build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string).
+   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string)
+   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
    back to 0.

--- a/tests/recipes/click-test-feedstock/README.md
+++ b/tests/recipes/click-test-feedstock/README.md
@@ -58,13 +58,13 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](http://www.appveyor.com/)
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
 and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](http://docs.anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
-[conda-smithy](http://github.com/conda-forge/conda-smithy) has been developed.
+[conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
@@ -100,7 +100,7 @@ build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string).
+   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string)
+   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
    back to 0.

--- a/versioneer.py
+++ b/versioneer.py
@@ -1905,7 +1905,7 @@ def do_setup():
     except EnvironmentError:
         pass
     # That doesn't cover everything MANIFEST.in can do
-    # (http://docs.python.org/2/distutils/sourcedist.html#commands), so
+    # (https://docs.python.org/3/distutils/sourcedist.html#commands), so
     # it might give some false negatives. Appending redundant 'include'
     # lines is safe, though.
     if "versioneer.py" not in simple_includes:


### PR DESCRIPTION
To conform to modern best practices, this PR upgrades all public-facing links to HTTPS where available, and update link targets if broken. redirected or otherwise clearly out of date. All links were carefully checked by hand to confirm whether they were fully functional both before and after (attempted) HTTPS conversion. HTTP links that were present for example or testing purposes, or that were XML namespace URNs were not altered, as were any links that did not fully function when tested over HTTPS. 

The ``get_conda_hook_info()`` URLs *were* updated in a separate commit as they did automatically redirect on trying them, but please double-check this. Also, in addition to updating the URL for the xkcd webcomic, it was properly named, linked and attributed (as is legally and ethically *required* by its CC-BY-SA 2.5 license), and  the title-text was included for completeness.