### PR TITLE
get_section: check ABCs instead of list/dict subclass

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -4,8 +4,10 @@ from __future__ import unicode_literals
 
 try:
     from collections.abc import Sequence, Mapping
+    str_type = str
 except ImportError:  # python 2
     from collections import Sequence, Mapping
+    str_type = basestring
 import copy
 import io
 import itertools
@@ -60,7 +62,7 @@ def get_list_section(parent, name, lints, allow_single=False):
     section = parent.get(name, [])
     if allow_single and isinstance(section, Mapping):
         return [section]
-    elif isinstance(section, Sequence):
+    elif isinstance(section, Sequence) and not isinstance(section, str_type):
         return section
     else:
         msg = ('The "{}" section was expected to be a {}list, but got a {}.{}.'

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -2,26 +2,25 @@
 
 from __future__ import unicode_literals
 
-import datetime
+try:
+    from collections.abc import Sequence, Mapping
+except ImportError:  # python 2
+    from collections import Sequence, Mapping
+import copy
 import io
 import itertools
 import os
 import re
-import time
 
 import github
-import jinja2
 import ruamel.yaml
 
 from conda_build.metadata import (ensure_valid_license_family,
                                   FIELDS as cbfields)
 import conda_build.conda_interface
 
-from collections import defaultdict
-
-import copy
-
 from .utils import render_meta_yaml
+
 
 FIELDS = copy.deepcopy(cbfields)
 
@@ -50,7 +49,7 @@ def get_section(parent, name, lints):
         return get_list_section(parent, name, lints)
 
     section = parent.get(name, {})
-    if not isinstance(section, dict):
+    if not isinstance(section, Mapping):
         lints.append('The "{}" section was expected to be a dictionary, but '
                      'got a {}.'.format(name, type(section).__name__))
         section = {}
@@ -59,9 +58,9 @@ def get_section(parent, name, lints):
 
 def get_list_section(parent, name, lints, allow_single=False):
     section = parent.get(name, [])
-    if allow_single and isinstance(section, dict):
+    if allow_single and isinstance(section, Mapping):
         return [section]
-    elif isinstance(section, list):
+    elif isinstance(section, Sequence):
         return section
     else:
         msg = ('The "{}" section was expected to be a {}list, but got a {}.{}.'

--- a/news/check-abcs.rst
+++ b/news/check-abcs.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+- Linter: handle new versions of `ruamel.yaml` appropriately instead of complaining about `expected to be a dictionary, but got a CommentedMap`. (#871)

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -538,6 +538,14 @@ class Test_linter(unittest.TestCase):
         lints = linter.main(os.path.join(_thisdir, 'recipes', 'multiple_sources'))
         assert not lints
 
+    def test_string_source(self):
+        url = "http://mistake.com/v1.0.tar.gz"
+        lints, hints = linter.lintify({'source': url})
+        msg = ('The "source" section was expected to be a dictionary or a '
+               'list, but got a {}.{}.').format(
+                    type(url).__module__, type(url).__name__)
+        self.assertIn(msg, lints)
+
 class TestCLI_recipe_lint(unittest.TestCase):
     def test_cli_fail(self):
         with tmp_directory() as recipe_dir:


### PR DESCRIPTION
`ruamel.yaml` version 0.15.52 [changed `CommentedMap` to no longer subclass from `dict`](https://bitbucket.org/ruamel/yaml/commits/ace40a6a40270b75320971d1c9ff7625fbf6e081#Lcomments.pyF594). This is breaking `get_section` / `get_list_section` and causing all kinds of spurious errors / breaking real checks: [example](https://github.com/conda-forge/conda-forge-webservices/pull/54#issuecomment-412106931). Checking based on ABCs instead should still work.

I also removed a few no-longer-used imports from the top of this file while I was at it.