### PR TITLE
don't complain about bioconda for packages with no name

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -344,8 +344,8 @@ def run_conda_forge_specific(meta, recipe_dir, lints, hints):
     recipe_name = package_section.get('name', '').strip()
     is_staged_recipes = recipe_dirname != 'recipe'
 
-    # 1: Check that the recipe does not exist in conda-forge
-    if is_staged_recipes:
+    # 1: Check that the recipe does not exist in conda-forge or bioconda
+    if is_staged_recipes and recipe_name:
         cf = gh.get_user(os.getenv('GH_ORG', 'conda-forge'))
         try:
             cf.get_repo('{}-feedstock'.format(recipe_name))

--- a/news/bioconda-no-name.rst
+++ b/news/bioconda-no-name.rst
@@ -1,0 +1,3 @@
+**Fixed:** None
+
+* Linter: packages without a `name` aren't actually in bioconda. (#872)

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -467,6 +467,9 @@ class Test_linter(unittest.TestCase):
             self.assertNotIn(expected_message, lints)
             lints = linter.lintify({'package': {'name': r}}, recipe_dir='recipe', conda_forge=False)
             self.assertNotIn(expected_message, lints)
+            # No lint if the name isn't specified
+            lints = linter.lintify({}, recipe_dir=r, conda_forge=True)
+            self.assertNotIn(expected_message, lints)
 
         r = 'this-will-never-exist'
         try:


### PR DESCRIPTION
Currently, if a recipe doesn't have a `name`, it'll ping `bioconda-recipes` ([example](https://github.com/conda-forge/conda-forge-webservices/pull/54#issuecomment-412106931)). That seems not ideal. :)