### PR TITLE
Enable Travis build for ppc64le

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -478,7 +478,7 @@ def _render_ci_provider(provider_name, jinja_env, forge_config, forge_dir, platf
         fancy_platforms = []
 
         configs = []
-        for metas, platform, enable in zip(metas_list_of_lists, platforms, archs, enable_platform):
+        for metas, platform, arch, enable in zip(metas_list_of_lists, platforms, archs, enable_platform):
             plat_arch = platform if arch == "64" else "{}_{}".format(platform, arch)
             if enable:
                 configs.extend(dump_subspace_config_files(metas, forge_dir, platform, arch))

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -624,7 +624,7 @@ def _get_platforms_of_provider(provider, forge_config):
     platforms = []
     keep_noarchs = []
     archs = []
-    for platform, arch in zip['linux', 'osx', 'win', 'linux'],
+    for platform, arch in zip(['linux', 'osx', 'win', 'linux'],
                              ['64',    '64',  '64',  'ppc64le']):
         plat_arch = platform if arch == "64" else "{}_{}".format(platform, arch)
         if forge_config['provider'][plat_arch] == provider:

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -45,6 +45,9 @@ All platforms: ![noarch disabled]({{ shield }}badge/noarch-disabled-lightgrey.sv
 {%- if not win.enabled %}
 ![Windows disabled]({{ shield }}badge/Windows-disabled-lightgrey.svg)
 {%- endif %}
+{%- if not linux_ppc64le.enabled %}
+![ppc64le disabled]({{ shield }}badge/ppc64le-disabled-lightgrey.svg)
+{%- endif %}
 {%- endif %}
 
 Current release info

--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -30,7 +30,11 @@ if [ -z "$CONFIG" ]; then
 fi
 
 pip install shyaml
-DOCKER_IMAGE=$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 {{ docker.image }} )
+if [ "$(uname -m)" = "x86_64" ]; then
+    DOCKER_IMAGE=$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 {{ docker.image }} )
+else
+    DOCKER_IMAGE=$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 {{ docker.image_ppc64le }} )
+fi
 
 mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -12,7 +12,7 @@ env:
     {%- endfor %}
 {%- endif %}
 
-(% if configs[0] -%}
+{% if configs[0] -%}
 matrix:
   include:
     (%- for config, plat in configs %}

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -17,7 +17,7 @@ matrix:
   include:
     (%- for config, plat in configs %}
     - env: CONFIG={{ config }}
-    {%- if plat.startswith={{"osx") %}
+    {%- if plat.startswith("osx") %}
       os: osx
       osx_image: xcode6.4
     {%- elif plat.startswith("linux-ppc64le") %}

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -15,7 +15,7 @@ env:
 {% if configs[0] -%}
 matrix:
   include:
-    (%- for config, plat in configs %}
+    {%- for config, plat in configs %}
     - env: CONFIG={{ config }}
     {%- if plat.startswith("osx") %}
       os: osx

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -76,6 +76,7 @@ install:
       if [ "$TRAVIS_OS_NAME" == "osx" ]; then
         mangle_compiler ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
       fi
+    {%- endif %}
 
 script:
   {%- if osx.enabled %}

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -3,73 +3,102 @@
 
 language: generic
 
-os: osx
-osx_image: xcode6.4
-
-{% block env -%}
-{% if configs[0] or travis.secure -%}
+{% if travis.secure -%}
 env:
-  {%- if configs[0] %}
-  matrix:
-    {%- for config, _ in configs %}
-    - CONFIG={{ config }}
-    {%- endfor %}
-  {%- endif %}
-{##}
-  {%- if travis.secure %}
   global:
     {%- for name, hashed_secure in travis.secure | dictsort %}
     # The {{ name }} secure variable. This is defined canonically in conda-forge.yml.
     - secure: "{{ hashed_secure }}"
     {%- endfor %}
-  {%- endif %}
 {%- endif %}
-{% endblock %}
+
+(% if configs[0] -%}
+matrix:
+  include:
+    (%- for config, plat in configs %}
+    - env: CONFIG={{ config }}
+    {%- if plat.startswith={{"osx") %}
+      os: osx
+      osx_image: xcode6.4
+    {%- elif plat.startswith("linux-ppc64le") %}
+      os: linux-ppc64le
+    {%- endif %}
+
+    {%- endfor %}
+{%- endif %}
 
 before_install:
     # Fast finish the PR.
-    - |
-      {{ fast_finish }}
+    - {{ fast_finish }}
+{%- if osx.enabled %}
 
-    # Remove homebrew.
+    # Remove homebrew in osx
     - |
-      echo ""
-      echo "Removing homebrew from Travis CI to avoid conflicts."
-      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
-      chmod +x ~/uninstall_homebrew
-      ~/uninstall_homebrew -fq
-      rm ~/uninstall_homebrew
-
+      if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+        echo ""
+        echo "Removing homebrew from Travis CI to avoid conflicts."
+        curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+        chmod +x ~/uninstall_homebrew
+        ~/uninstall_homebrew -fq
+        rm ~/uninstall_homebrew
+      fi
+{%- endif %}
 
 install:
+    {%- if osx.enabled %}
     # Install Miniconda.
     - |
-      echo ""
-      echo "Installing a fresh version of Miniconda."
-      MINICONDA_URL="https://repo.continuum.io/miniconda"
-      MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
-      bash $MINICONDA_FILE -b
+      if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+        echo ""
+        echo "Installing a fresh version of Miniconda."
+        MINICONDA_URL="https://repo.continuum.io/miniconda"
+        MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
+        curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+        bash $MINICONDA_FILE -b
+      fi
 
     # Configure conda.
     - |
-      echo ""
-      echo "Configuring conda."
-      source /Users/travis/miniconda3/bin/activate root
+      if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+        echo ""
+        echo "Configuring conda."
+        source /Users/travis/miniconda3/bin/activate root
 
-      conda install --yes --quiet conda-forge::conda-forge-ci-setup=2
-      setup_conda_rc ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
+        conda install --yes --quiet conda-forge::conda-forge-ci-setup=2
+        setup_conda_rc ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
 
-      {% if build_setup -%}
-      {{ build_setup }}{% endif %}
+        {% if build_setup -%}
+        {{ build_setup }}{% endif %}
+      fi
 
     # compiler cleanup
     - |
-      mangle_compiler ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
+      if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+        mangle_compiler ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
+      fi
 
 script:
-  # generate the build number clobber
-  - make_build_number ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
-  - conda build ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
-  - upload_package ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
+  {%- if osx.enabled %}
+  - |
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      # generate the build number clobber
+      make_build_number ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
+    fi
+
+  - |
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      conda build ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+    fi
+
+  - |
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      upload_package ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
+    fi
+  {%- endif %}
+{% if linux_ppc64le.enabled %}
+  - |
+    if [ "$TRAVIS_OS_NAME" == "linux*" ]; then
+      ./.circleci/run_docker_build.sh
+    fi
+{%- endif %}
 

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -63,7 +63,7 @@ def test_r_matrix_travis(r_recipe, jinja_env):
     matrix_dir = os.path.join(r_recipe.recipe, '.ci_support')
     assert os.path.isdir(matrix_dir)
     # single matrix entry - readme is generated later in main function
-    assert len(os.listdir(matrix_dir)) == 2
+    assert len(os.listdir(matrix_dir)) == 4
 
 
 def test_r_matrix_on_circle(r_recipe, jinja_env):
@@ -102,7 +102,7 @@ def test_py_matrix_travis(py_recipe, jinja_env):
     matrix_dir = os.path.join(py_recipe.recipe, '.ci_support')
     assert os.path.isdir(matrix_dir)
     # two matrix enties - one per py ver
-    assert len(os.listdir(matrix_dir)) == 2
+    assert len(os.listdir(matrix_dir)) == 4
 
 
 def test_py_matrix_on_circle(py_recipe, jinja_env):


### PR DESCRIPTION
This PR is a continuation of: https://github.com/conda-forge/conda-smithy/pull/763  by @kamasubb

I've not seen activity on that PR, so I figured we should start fresh. I've resolved the merge conflicts that have popped up since 763 was opened, but have not yet tested it. I'll try and lead this work now and would like some feedback on where this one left off. Thanks!

=======
Added New Build Queue for PowerPC builds
Added changes to download and Install miniconda for PPC
Added changes to build conda-forge-build-setup

TODO:

- [x]    Build su-exec locally and copy
- [x]    Build tini locally and copy
- [x]    Build conda-forge-ci-setup locally and copy
- [x]    Merge conda-forge/conda-forge-pinning-feedstock#78 and release
- [x]    Merge conda-forge/docker-images#67 and upload to dockerhub
- [x]    Fix this PR to use docker.
- [ ]    Create a help-ppc64le team
- [ ]    Build su-exec using this PR
- [ ]    Build tini using this PR
- [ ]    Build conda-forge-ci-setup using this PR
