### PR TITLE
Fix Windows badge in feedstocks' README

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -34,7 +34,7 @@ All platforms: ![noarch disabled]({{ shield }}badge/noarch-disabled-lightgrey.sv
 [![OSX]({{ shield }}travis/{{ github.user_or_org }}/{{ github.repo_name }}/{{ github.branch_name }}.svg?label=macOS)](https://travis-ci.org/{{ github.user_or_org }}/{{ github.repo_name }})
 {%- endif %}
 {%- if appveyor.enabled %}
-[![Windows]({{ shield }}appveyor/ci/{{ github.user_or_org }}/{{ github.repo_name }}/{{ github.branch_name }}.svg?label=Windows)](https://ci.appveyor.com/project/{{ github.user_or_org }}/{{ appveyor_url_name }}/branch/{{ github.branch_name }})
+[![Windows]({{ shield }}appveyor/ci/{{ github.user_or_org }}/{{ appveyor_url_name }}/{{ github.branch_name }}.svg?label=Windows)](https://ci.appveyor.com/project/{{ github.user_or_org }}/{{ appveyor_url_name }}/branch/{{ github.branch_name }})
 {%- endif %}
 {%- if not linux.enabled %}
 ![Linux disabled]({{ shield }}badge/linux-disabled-lightgrey.svg)


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-smithy/issues/777

There are some tweaks needed for the repo name for the AppVeyor/Windows badge. While these were included in the link, it seems they need to be included in the Shields.io badge as well for the badge to render. Should fix some issues with the rendering of AppVeyor/Windows badges on feedstocks that have `_`s or `.`s in their names.

cc @isuruf @epruesse