### PR TITLE
conda_smithy/templates/run_docker_build.sh.tmpl: add SELinux flags to Docker volumes

### DIFF
--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -37,8 +37,8 @@ DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
 
 {{ docker.executable }} run -it \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:ro,z \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
            -e CONFIG \
            -e BINSTAR_TOKEN \
            -e HOST_USER_ID \


### PR DESCRIPTION
If you're running Docker builds on an SELinux-enabled Linux system, the mounted volumes need to have the appropriate SELinux flags set if they are to be used by their containers. Here we add the magic `z` option to make this happen. We also mount the recipe directory read-only since the container shouldn't need to write to it.

Full disclosure: not tested locally but it *should* work ...