### PR TITLE
Simplify collection of current maintainers

### DIFF
--- a/conda_smithy/github.py
+++ b/conda_smithy/github.py
@@ -208,7 +208,7 @@ def configure_github_team(meta, gh_repo, org, feedstock_name):
     # Get the all-members team
     description = "All of the awesome {} contributors!".format(org.name)
     all_members_team = get_cached_team(org, 'all-members', description)
-    new_conda_forge_members = set()
+    new_org_members = set()
 
     # Add new members to all-members
     for new_member in maintainers - current_maintainers_handles:
@@ -219,6 +219,6 @@ def configure_github_team(meta, gh_repo, org, feedstock_name):
                 )
             )
             add_membership(all_members_team, new_member)
-            new_conda_forge_members.add(new_member)
+            new_org_members.add(new_member)
 
-    return maintainers, current_maintainers_handles, new_conda_forge_members
+    return maintainers, current_maintainers_handles, new_org_members

--- a/conda_smithy/github.py
+++ b/conda_smithy/github.py
@@ -192,9 +192,24 @@ def configure_github_team(meta, gh_repo, org, feedstock_name):
             e.login.lower() for e in team.get_members()
         ])
 
+    # Get the all-members team
+    description = "All of the awesome {} contributors!".format(org.name)
+    all_members_team = get_cached_team(org, 'all-members', description)
+    new_org_members = set()
+
     # Add only the new maintainers to the team.
+    # Also add the new maintainers to all-members if not already included.
     for new_maintainer in maintainers - current_maintainers:
         add_membership(team, new_maintainer)
+
+        if not has_in_members(all_members_team, new_maintainer):
+            print(
+                "Adding a new member ({}) to {}. Welcome! :)".format(
+                    new_maintainer, org.name
+                )
+            )
+            add_membership(all_members_team, new_maintainer)
+            new_org_members.add(new_maintainer)
 
     # Mention any maintainers that need to be removed (unlikely here).
     for old_maintainer in current_maintainers - maintainers:
@@ -203,21 +218,5 @@ def configure_github_team(meta, gh_repo, org, feedstock_name):
                 old_maintainer, gh_repo
             )
         )
-
-    # Get the all-members team
-    description = "All of the awesome {} contributors!".format(org.name)
-    all_members_team = get_cached_team(org, 'all-members', description)
-    new_org_members = set()
-
-    # Add new members to all-members
-    for new_member in maintainers - current_maintainers:
-        if not has_in_members(all_members_team, new_member):
-            print(
-                "Adding a new member ({}) to {}. Welcome! :)".format(
-                    new_member, org.name
-                )
-            )
-            add_membership(all_members_team, new_member)
-            new_org_members.add(new_member)
 
     return maintainers, current_maintainers, new_org_members

--- a/conda_smithy/github.py
+++ b/conda_smithy/github.py
@@ -206,9 +206,8 @@ def configure_github_team(meta, gh_repo, org, feedstock_name):
         )
 
     # Get the all-members team
-    team_name = 'all-members'
     description = "All of the awesome {} contributors!".format(org.name)
-    all_members_team = get_cached_team(org, team_name, description)
+    all_members_team = get_cached_team(org, 'all-members', description)
     new_conda_forge_members = set()
 
     # Add new members to all-members


### PR DESCRIPTION
Only iterate over the current maintainers of a feedstock listed on the GitHub team when the team exists. Otherwise we know there are no maintainers and this iteration is unneeded.

Also handle additions to the feedstock team and the all-members team in the same loop to avoid performing the same checks twice.