### PR TITLE
CI: run CI also against gcc7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ env:
        - CONDA_INSTALL_LOCN="${HOME}/conda"
 
     matrix:
-        - PYTHON=2
-        - PYTHON=3
+        - PYTHON=2 CHANNEL=conda-forge
+        - PYTHON=3 CHANNEL=conda-forge
+        - PYTHON=2 CHANNEL=conda-forge/label/gcc7
+        - PYTHON=3 CHANNEL=conda-forge/label/gcc7
 
 install:
     - mkdir -p ${HOME}/cache/pkgs


### PR DESCRIPTION
This might fix our symbol error (at least on the gcc7 label builds)