### PR TITLE
Drop duplicative comments

### DIFF
--- a/conda_smithy/azure_ci_utils.py
+++ b/conda_smithy/azure_ci_utils.py
@@ -10,7 +10,6 @@ AZURE_PROJECT_ID = os.getenv("AZURE_PROJECT_ID", "feedstock-builds")
 AZURE_SERVICE_ENDPOINT_NAME = os.getenv("AZURE_SERVICE_ENDPOINT", "conda-forge")
 
 try:
-    # Create a token at https://circleci.com/account/api. Put it in circle.token
     with open(os.path.expanduser("~/.conda-smithy/azure.token"), "r") as fh:
         AZURE_TOKEN = fh.read().strip()
     if not AZURE_TOKEN:

--- a/conda_smithy/ci_register.py
+++ b/conda_smithy/ci_register.py
@@ -16,7 +16,6 @@ from . import github
 # https://circleci.com/api/v1/project/:username/:project/envvar?circle-token=:token
 
 try:
-    # Create a token at https://circleci.com/account/api. Put it in circle.token
     with open(os.path.expanduser('~/.conda-smithy/circle.token'), 'r') as fh:
         circle_token = fh.read().strip()
     if not circle_token:


### PR DESCRIPTION
The error messages already explain what to do and at this point do a better job than the comments. So just drop the comments.

cc @willsmythe

xref: https://github.com/conda-forge/conda-smithy/pull/901#discussion_r226675817