### PR TITLE
Fix copy-paste issue in Azure script

### DIFF
--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -19,7 +19,7 @@ jobs:
       {{ fast_finish }}
 
   - script: |
-      echo "Removing homebrew from Travis CI to avoid conflicts."
+      echo "Removing homebrew from Azure to avoid conflicts."
       curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
       chmod +x ~/uninstall_homebrew
       ~/uninstall_homebrew -fq


### PR DESCRIPTION
This is removing Homebrew on Azure (instead of Travis CI previously).

cc @willsmythe

xref: https://github.com/conda-forge/conda-smithy/pull/901#discussion_r228593277