### PR TITLE
Readd the `-it` flags for `docker run`

### DIFF
--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -39,7 +39,7 @@ mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
 
-{{ docker.executable }} run \
+{{ docker.executable }} run -it \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:ro,z \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
            -e CONFIG \


### PR DESCRIPTION
This is handy when building locally as it allows the user to quickly terminate a job use `^C`. Also has the nice added effect of showing color coded text as it was intended to appear.

xref: https://github.com/conda-forge/conda-smithy/pull/901#discussion_r229541251