### PR TITLE
install conda-forge deps from conda-forge

### DIFF
--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -19,7 +19,7 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge::conda-forge-ci-setup=2 conda-build
+conda install --yes --quiet conda-forge-ci-setup=2 conda-build -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"


### PR DESCRIPTION
somehow the channel-priority doesn't work with this explicit specification of channels. Using the -c instead seems to solve this.

No idea why this has changed.