### PR TITLE
add setup_conda_rc in appveyor config

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -51,6 +51,7 @@ install:
 
     # Configure the VM.
     - cmd: conda.exe install -n root --quiet --yes conda-forge-ci-setup=2
+    - cmd: setup_conda_rc .\ .\recipe .\.ci_support\%CONFIG%.yaml
     {% if build_setup -%}
     {{ build_setup }}{% endif %}
 


### PR DESCRIPTION
This is needed to enable the use of custom labels in AppVeyor builds, which did not have this feature at variance with the other CIs.

An example of a failing AppVeyor build can be seen [here](https://github.com/conda-forge/responder-feedstock/pull/1/commits) at this commit: https://github.com/conda-forge/responder-feedstock/pull/1/commits/f7ad3a93ec5cbd89b543e30931a3493af877d70f

Fixes #931