### PR TITLE
bump default travis image to xcode9.4

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -4,7 +4,8 @@
 language: generic
 
 os: osx
-osx_image: xcode6.4
+osx_image: {{ travis.get('osx_image', 'xcode9.4') }}
+
 
 {% block env -%}
 {% if configs[0] or travis.secure -%}


### PR DESCRIPTION
and allow override via travis.osx_image

The current xcode6.4 has had a warning about its impending removal for a long time, and it's coming up pretty soon, in January 2019.

With the current state of tooling including [fetching the sdk](https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/31) and [setting the sysroot](https://github.com/conda-forge/toolchain-feedstock/pull/46), we should be able to be less conservative about the base xcode version from now on. The few mac builds on CircleCI have been using xcode 9 since they started. Having [faced a build from Circle that didn't work](https://travis-ci.org/conda-forge/parmetis-feedstock/jobs/428047190#L945) (openmpi) and fixed it by [ensuring sysroot was properly set](https://github.com/conda-forge/toolchain-feedstock/pull/46), I am now relatively confident that this is a safe transition to make, so long as builds ensure that:

1. sysroot is properly set (ci-setup + compiler activation scripts should cover this for at least most cases now), and
2. MACOSX_DEPLOYMENT_TARGET is set

There should be nothing for most builds to do, as the tooling is already doing the right thing at this point. If there is anything else to do for conda-forge before making this transition (which needs to be finished within two months), it might be some additional testing of packages to verify that they used the right sysroot post-build. I'm not sure how feasible that is, though.

The biggest downside is the fact that we run tests on the same image as the build, we won't know about packages that haven't been built correctly until users start being affected.

The reason I didn't bump to the current lowest-supported version by default is that doing so would inevitably run into the same image-removal process again, likely in a year's time, and we would still need to be manually fetching the 10.9 SDK, anyway. So bumping only to the next-lowest version wouldn't make things any more likely to be correct, but it would shrink the affected version range when things were *not* done correctly.

closes conda-forge/conda-forge.github.io#641