### PR TITLE
Increase timeout for commands with no output on CircleCI and Travis

### DIFF
--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -43,6 +43,7 @@ jobs:
 {%- else %}
           command: ./.circleci/run_osx_build.sh
 {%- endif %}
+          no_output_timeout: 30m
 {%- endfor -%}
 {%- endif -%}
 {%- endblock %}

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -70,6 +70,5 @@ install:
 script:
   # generate the build number clobber
   - make_build_number ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
-  - conda build ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+  - travis_wait 30 conda build ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
   - upload_package ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
-


### PR DESCRIPTION
This increases the timeout for commands with no output from the default (10 minutes) to 30 minutes on CircleCI and Travis, during the build phase. I've started to see some packages where conda is so slow at solving/downloading dependencies that the build times out.

I'm not sure how this is tested, but hopefully the CI will already warn if something is seriously broken.

Fixes https://github.com/conda-forge/conda-smithy/issues/940