### PR TITLE
Adds maintainers list to README

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, unicode_literals
 
 import glob
-from itertools import product
+from itertools import product, chain
 import os
 import subprocess
 import textwrap
@@ -841,6 +841,7 @@ def render_README(jinja_env, forge_config, forge_dir):
     forge_config['package'] = metas[0][0]
     forge_config['package_name'] = metas[0][0].meta['extra']['parent_recipe']['name']
     forge_config['outputs'] = sorted(list(OrderedDict((meta[0].name(), None) for meta in metas)))
+    forge_config['maintainers'] = sorted(set(chain.from_iterable(meta[0].meta['extra']['recipe-maintainers'] for meta in metas)))
     with write_file(target_fname) as fh:
         fh.write(template.render(**forge_config))
 

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -139,3 +139,10 @@ In order to produce a uniquely identifiable distribution:
    the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
    back to 0.
 {# this comment ensures a trailing newline #}
+
+Feedstock Maintainers
+=====================
+
+{% for maintainer in maintainers -%}
+* [@{{maintainer}}](https://github.com/{{maintainer}}/)
+{% endfor %}

--- a/news/readme-maint.rst
+++ b/news/readme-maint.rst
@@ -1,0 +1,13 @@
+**Added:**
+
+* Feedstock maintainers are now listed in the README file.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry


This is something that I have wanted for a very long time, because it sucks to have to go into the meta.yaml just to check if I am a maintainer.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
