### PR TITLE
remove --quiet from conda-build on linux

### DIFF
--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -34,7 +34,7 @@ conda clean --lock
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"  --quiet
+    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
 {% if upload_packages %}
 upload_package "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"


### PR DESCRIPTION
conda-build 3.17 doesn’t show host and build envs when built with `--quiet` which are important for debugging. Mac builds are already not using --quiet.