### PR TITLE
Only fail noarch lint if selectors in runtime dependencies.

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -273,7 +273,7 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
             in_runreqs = False
             for line in fh:
                 line_s = line.strip()
-                if (line_s == "run:"):
+                if (line_s == "host:" or line_s == "run:"):
                     in_runreqs = True
                     runreqs_spacing = line[:-len(line.lstrip())]
                     continue

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -267,24 +267,24 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
                                      ' name.'.format(section, source_subsection))
 
 
-    # 17: noarch doesn't work with selectors
+    # 17: noarch doesn't work with selectors for runtime dependencies
     if build_section.get('noarch') is not None and os.path.exists(meta_fname):
         with io.open(meta_fname, 'rt') as fh:
-            in_requirements = False
+            in_runreqs = False
             for line in fh:
                 line_s = line.strip()
-                if (line_s == "requirements:"):
-                    in_requirements = True
-                    requirements_spacing = line[:-len(line.lstrip())]
+                if (line_s == "run:"):
+                    in_runreqs = True
+                    runreqs_spacing = line[:-len(line.lstrip())]
                     continue
                 if line_s.startswith("skip:") and is_selector_line(line):
                     lints.append("`noarch` packages can't have selectors. If "
                                  "the selectors are necessary, please remove "
                                  "`noarch: {}`.".format(build_section['noarch']))
                     break
-                if in_requirements:
-                    if requirements_spacing == line[:-len(line.lstrip())]:
-                        in_requirements = False
+                if in_runreqs:
+                    if runreqs_spacing == line[:-len(line.lstrip())]:
+                        in_runreqs = False
                         continue
                     if is_selector_line(line):
                         lints.append("`noarch` packages can't have selectors. If "

--- a/news/noarch_selectors_runtime.rst
+++ b/news/noarch_selectors_runtime.rst
@@ -8,6 +8,6 @@
 
 **Fixed:**
 
-* Linting only fails noarch recipes with selectors for runtime dependencies.
+* Linting only fails noarch recipes with selectors for host and runtime dependencies.
 
 **Security:** None

--- a/news/noarch_selectors_runtime.rst
+++ b/news/noarch_selectors_runtime.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Linting only fails noarch recipes with selectors for runtime dependencies.
+
+**Security:** None

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -267,6 +267,23 @@ class Test_linter(unittest.TestCase):
                               tests:
                                 commands:
                                   - cp asd qwe  # [unix]
+                            """, is_good=True)
+            assert_noarch_selector("""
+                            build:
+                              noarch: python
+                              script:
+                                - echo "hello" # [unix]
+                                - echo "hello" # [win]
+                              requirements:
+                                build:
+                                  - python
+                                  - enum34     # [py2k]
+                                run:
+                                  - python
+                                  - enum34     # [py2k]
+                              tests:
+                                commands:
+                                  - cp asd qwe  # [unix]
                             """)
 
     def test_jinja_os_environ(self):

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -271,19 +271,36 @@ class Test_linter(unittest.TestCase):
             assert_noarch_selector("""
                             build:
                               noarch: python
-                              script:
-                                - echo "hello" # [unix]
-                                - echo "hello" # [win]
                               requirements:
-                                build:
-                                  - python
-                                  - enum34     # [py2k]
                                 run:
                                   - python
                                   - enum34     # [py2k]
-                              tests:
-                                commands:
-                                  - cp asd qwe  # [unix]
+                            """)
+            assert_noarch_selector("""
+                            build:
+                              noarch: python
+                              requirements:
+                                host:
+                                  - python
+                                  - enum34     # [py2k]
+                            """)
+            assert_noarch_selector("""
+                            build:
+                              noarch: python
+                              requirements:
+                                host:
+                                  - enum34     # [py2k]
+                                run:
+                                  - python
+                            """)
+            assert_noarch_selector("""
+                            build:
+                              noarch: python
+                              requirements:
+                                host:
+                                  - python
+                                run:
+                                  - enum34     # [py2k]
                             """)
 
     def test_jinja_os_environ(self):


### PR DESCRIPTION
Checklist
* [x] Added a ``news`` entry

PR #622 didn't include a news entry. Since this PR is similar in scope, I assume it also does not warrant a news entry. Please let me know otherwise.

This PR address https://github.com/conda-forge/conda-forge.github.io/issues/683, in which the linter is failing recipes that have selectors in the build requirements. staged-recipes builds noarch packages on all 3 platforms purposefully, in case others want to build the recipe on other platforms.

cc: @CJ-Wright @isuruf @bgruening 