### PR TITLE
Minor simplification to fix azure builds

### DIFF
--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -27,8 +27,8 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artifacts.
 conda clean --lock
 
-{% if build_setup -%}
-{{ build_setup }}{% endif -%}
+{% if build_setup %}
+{{ build_setup }}{% endif %}
 
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"


### PR DESCRIPTION
The current version strips whitespace until it hits the make_build_number clobber portion.  this causes weird breakage

See say https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1049 for an example
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
