### PR TITLE
Add options to disable CIs

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -143,10 +143,6 @@ class RegisterCI(Subcommand):
                            help="github organisation under which to register this repo")
         for ci in ['Azure', 'Travis', 'Circle', 'Appveyor']:
             scp.add_argument(
-                '--with-{}'.format(ci.lower()), dest=ci.lower(),
-                action='store_true',
-                help="If set, {} will be registered".format(ci))
-            scp.add_argument(
                 '--without-{}'.format(ci.lower()), dest=ci.lower(),
                 action='store_false',
                 help="If set, {} will be not registered".format(ci))

--- a/news/per_ci_disable_registration_options.rst
+++ b/news/per_ci_disable_registration_options.rst
@@ -1,0 +1,16 @@
+**Added:**
+
+Command line options are now available for the command `conda smithy register-ci`
+to disable registration on a per-ci level. `--without-azure`, `--without-circle`,
+`--without-travis`, and `--without-appveyor` can now be used to disable
+CI registsration on each respective CI.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/news/per_ci_disable_registration_options.rst
+++ b/news/per_ci_disable_registration_options.rst
@@ -2,8 +2,8 @@
 
 Command line options are now available for the command `conda smithy register-ci`
 to disable registration on a per-ci level. `--without-azure`, `--without-circle`,
-`--without-travis`, and `--without-appveyor` can now be used to disable
-CI registsration on each respective CI.
+`--without-travis`, and `--without-appveyor` can now be used in conjunction with
+`conda smithy register-ci`.
 
 **Changed:** None
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

you can use

````
$ conda-smithy register-ci --help                                                                                                                             
usage: a tool to help create, administer and manage feedstocks. register-ci
       [-h] [--feedstock_directory FEEDSTOCK_DIRECTORY]
       [--user USER | --organization ORGANIZATION] [--without-azure]
       [--without-travis] [--without-circle] [--without-appveyor]

optional arguments:
  -h, --help            show this help message and exit
  --feedstock_directory FEEDSTOCK_DIRECTORY
                        The directory of the feedstock git repository.
  --user USER           github username under which to register this repo
  --organization ORGANIZATION
                        github organisation under which to register this repo
  --without-azure       If set, Azure will be not registered
  --without-travis      If set, Travis will be not registered
  --without-circle      If set, Circle will be not registered
  --without-appveyor    If set, Appveyor will be not registered

```
