### PR TITLE
Fix linter error on missing target_platform

### DIFF
--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -44,6 +44,7 @@ def render_meta_yaml(text):
                                     defaultdict(lambda : ''),
                             datetime=datetime,
                             time=time,
+                            target_platform="linux-64",
                             ))
     mockos = MockOS()
     content = env.from_string(text).render(os=mockos, environ=mockos.environ)

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -302,6 +302,19 @@ class Test_linter(unittest.TestCase):
                         """)
             lints = linter.main(recipe_dir)
 
+    def test_target_platform(self):
+        # Test that we can use target_platform in a recipe. We don't care about
+        # the results here.
+        with tmp_directory() as recipe_dir:
+            with io.open(os.path.join(recipe_dir, 'meta.yaml'), 'w') as fh:
+                fh.write("""
+                        package:
+                           name: foo_{{ target_platform }}
+                           version: 1.0
+                         """)
+            lints = linter.main(recipe_dir)
+
+
     def test_missing_build_number(self):
         expected_message = "The recipe must have a `build/number` section."
 


### PR DESCRIPTION
Invoking `conda smithy recipe-lint` on the [conda-forge/go1.4-feedstock/meta.yaml](
https://github.com/conda-forge/go1.4-bootstrap-feedstock/blob/master/recipe/meta.yaml) file yields the following exception:

```
± conda smithy recipe-lint
Traceback (most recent call last):
  File "/opt/conda/bin/conda-smithy", line 10, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.6/site-packages/conda_smithy/cli.py", line 279, in main
    args.subcommand_func(args)
  File "/opt/conda/lib/python3.6/site-packages/conda_smithy/cli.py", line 203, in __call__
    return_hints=True)
  File "/opt/conda/lib/python3.6/site-packages/conda_smithy/lint_recipe.py", line 428, in main
    content = render_meta_yaml(''.join(fh))
  File "/opt/conda/lib/python3.6/site-packages/conda_smithy/utils.py", line 49, in render_meta_yaml
    content = env.from_string(text).render(os=mockos, environ=mockos.environ)
  File "/opt/conda/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/opt/conda/lib/python3.6/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/opt/conda/lib/python3.6/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/opt/conda/lib/python3.6/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 29, in top-level template code
jinja2.exceptions.UndefinedError: 'target_platform' is undefined
```