### PR TITLE
Move the NumFOCUS badge to "About conda-forge"

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -3,8 +3,6 @@
 About {{ package_name }}
 ======{{ '=' * package_name|length }}
 
-[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
-
 Home: {{ package.meta.about.home }}
 
 Package license: {{ package.meta.about.license }}
@@ -82,6 +80,8 @@ conda search {{ outputs[0] }} --channel {{ channel_name }}
 {% if channel_name == 'conda-forge' %}
 About conda-forge
 =================
+
+[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the

--- a/news/relocate-numfocus-badge-readme.rst
+++ b/news/relocate-numfocus-badge-readme.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* Moved NumFOCUS badge to "About conda-forge" section in the feedstock README.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-smithy/issues/972

As there was some concern raised that having the NumFOCUS badge where it was would confuse users as to what was NumFOCUS sponsored (i.e. that their library is NumFOCUS sponsored) as opposed to the fact that conda-forge is NumFOCUS sponsored, this relocates the NumFOCUS badge to the "About conda-forge" section where this should hopefully make it clear that conda-forge is NumFOCUS sponsored.

cc @moorepants @scopatz

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
