### PR TITLE
Drop old CHANGELOG file linking to GitHub releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,0 @@
-Please consult the [GitHub releases page](https://github.com/conda-forge/conda-smithy/releases) for release notes.


### PR DESCRIPTION
As we now use rever to cut releases and that makes a `CHANGELOG.rst` in the top-level directory, there is no need to point users to GitHub releases using this `CHANGELOG.md` as well. So go ahead and drop it for simplicity.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
