### PR TITLE
specify conda-build>=3.17 for window

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -44,7 +44,10 @@ install:
     - cmd: set PYTHONUNBUFFERED=1
 
     # Configure the VM.
-    - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2
+    # conda-build 3.17 and crytography seem to pull in different versions of openssl
+    # this causes problems in the build system
+    # therefore, specify that the higher conda-build version should take precedence
+    - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2 "conda-build>=3.17"
     - cmd: setup_conda_rc .\ .\{{ recipe_dir }} .\.ci_support\%CONFIG%.yaml
     {% if build_setup -%}
     {{ build_setup }}{% endif %}

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -56,7 +56,10 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=2' # Optional
+        # conda-build 3.17 and crytography seem to pull in different versions of openssl
+        # this causes problems in the build system
+        # therefore, specify that the higher conda-build version should take precedence
+        packageSpecs: 'python=3.6 conda-build>=3.17 conda conda-forge::conda-forge-ci-setup=2' # Optional
         installOptions: "-c conda-forge"
         updateConda: false
       displayName: Install conda-build and activate environment

--- a/news/TEMPLATE.rst
+++ b/news/TEMPLATE.rst
@@ -1,6 +1,6 @@
 **Added:** None
 
-**Changed:** None
+**Changed:** Appveyor and Azure builds on Windows now specify the need to install conda-build>=3.17 for better build stability.
 
 **Deprecated:** None
 

--- a/news/appveyor_conda_build_version.rst
+++ b/news/appveyor_conda_build_version.rst
@@ -1,0 +1,11 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
@jakirkham it seems that there is some issue with cryptography and conda-build 3.17 in terms of which version of openssl they want to pull in.

See my green builds:
https://ci.appveyor.com/project/conda-forge/scikit-image-feedstock/builds/21372670

But more importantly, see how they downgrade cryptography and openssl
https://ci.appveyor.com/project/conda-forge/scikit-image-feedstock/builds/21372670/job/n45cx54g0scn0kw4?fullLog=true#L154

I'll probably cut a new release of scikit-image with this "mod" when the other CIs pass
https://github.com/conda-forge/scikit-image-feedstock/pull/39

FYI: @jni 

Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
