### PR TITLE
README: Fix markdown for xkcd inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ $ rever 0.1.2
 Conda-smithy in a nutshell
 --------------------------
 
-xkcd 1629: Tools
-~~~~~~~~~~~~~~~~
+#### xkcd 1629: Tools
 
 [![xkcd 1629: Tools](https://imgs.xkcd.com/comics/tools.png)](https://xkcd.com/1629/)
+
 **Titletext**: *I make tools for managing job-hunting sites for people who make*
 *tools for managing job-hunting sites for people who make tools for ...*


### PR DESCRIPTION
rst headings don't do the same things in markdown, so the image was just a literal block
