### PR TITLE
[WIP][azure,mac] set CONDA_BUILD_SYSROOT env during build

### DIFF
--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -77,6 +77,10 @@ jobs:
   - script: |
       export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
       set -x -e
+      # set CONDA_BUILD_SYSROOT env which conda-forge-ci-setup stored
+      # in .ci_support/{config}.yaml in a previous stage.
+      # Without doing this, conda-build omits this env from the test stage
+      export CONDA_BUILD_SYSROOT=$(cat .ci_support/${CONFIG}.yaml  | shyaml get-value CONDA_BUILD_SYSROOT.0)
       conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
     displayName: Build recipe
 

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -45,7 +45,7 @@ jobs:
   - script: |
       export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
       set -x -e
-      conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
+      conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build shyaml
     displayName: 'Add conda-forge-ci-setup=2'
 
   - script: |


### PR DESCRIPTION
adding this to the conda build config file appears to only affect the build env, in which case compilation during the test phase can still fail. This *seems* like a conda-build bug, though because I'm using multiple outputs [where I ran into this](https://github.com/conda-forge/mpich-feedstock/pull/32) I'm ready to believe this is something peculiar in my recipe.

WIP, pending testing in https://github.com/conda-forge/mpich-feedstock/pull/32

This implementation relies on [this bit](https://github.com/conda-forge/conda-forge-ci-setup-feedstock/blob/276c13013f674fab262fc3e02bf2e90396334468/recipe/run_conda_forge_build_setup_osx#L33-L39) where conda-forge-ci-setup stores the CONDA_BUILD_SYSROOT in the current build config file. That level of coupling implementation details of the two repos doesn't seem the best to me, but I didn't see a more obvious solution.

Given azure's pattern of resetting the env from one stage to the next, perhaps we should be populating an `env` file to source, rather than the same export lines in each step?

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->