### PR TITLE
rework yum-requirements

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -708,11 +708,6 @@ def _circle_specific_setup(jinja_env, forge_config, forge_dir, platform):
         """
         )
 
-    if platform == "linux":
-        yum_build_setup = generate_yum_requirements(forge_dir)
-        if yum_build_setup:
-            forge_config["yum_build_setup"] = yum_build_setup
-
     forge_config["build_setup"] = build_setup
 
     if platform == "linux":
@@ -742,42 +737,6 @@ def _circle_specific_setup(jinja_env, forge_config, forge_dir, platform):
     ]
     for target_fname in target_fnames:
         set_exe_file(target_fname, True)
-
-
-def generate_yum_requirements(forge_dir):
-    # If there is a "yum_requirements.txt" file in the recipe, we honour it.
-    yum_requirements_fpath = os.path.join(
-        forge_dir, "recipe", "yum_requirements.txt"
-    )
-    yum_build_setup = ''
-    if os.path.exists(yum_requirements_fpath):
-        with open(yum_requirements_fpath) as fh:
-            requirements = [
-                line.strip()
-                for line in fh
-                if line.strip() and not line.strip().startswith("#")
-            ]
-        if not requirements:
-            raise ValueError(
-                "No yum requirements enabled in the "
-                "yum_requirements.txt, please remove the file "
-                "or add some."
-            )
-        yum_build_setup = textwrap.dedent(
-            """\
-
-            # Install the yum requirements defined canonically in the
-            # "recipe/yum_requirements.txt" file. After updating that file,
-            # run "conda smithy rerender" and this line will be updated
-            # automatically.
-            /usr/bin/sudo -n yum install -y {}
-
-
-        """.format(
-                " ".join(requirements)
-            )
-        )
-    return yum_build_setup
 
 
 def _get_platforms_of_provider(provider, forge_config):
@@ -1013,11 +972,6 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
 
     # Explicitly add in a newline character to ensure that jinja templating doesn't do something stupid
     build_setup = "run_conda_forge_build_setup\n"
-
-    if platform == "linux":
-        yum_build_setup = generate_yum_requirements(forge_dir)
-        if yum_build_setup:
-            forge_config['yum_build_setup'] = yum_build_setup
 
     forge_config["build_setup"] = build_setup
 

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -26,7 +26,7 @@ jobs:
   # configure qemu binfmt-misc running.  This allows us to run docker containers 
   # embedded qemu-static
   - script: |
-      docker run --rm --privileged multiarch/qemu-user-static:register
+      docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
       ls /proc/sys/fs/binfmt_misc/
     condition: not(startsWith(variables['CONFIG'], 'linux_64'))
     displayName: Configure binfmt_misc

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -27,6 +27,13 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 {% if build_setup -%}
 {{ build_setup }}{% endif -%}
 
+# If we have yum requirements build a new specialized image that we will use to run our build in that includes
+# those dependencies.
+if [ -f ${RECIPE_ROOT}/yum_requirements.txt ]; then
+  sudo yum -y install $(cat ${RECIPE_ROOT}/yum_requirements.txt)
+fi
+
+
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -15,7 +15,7 @@ export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
 cat >~/.condarc <<CONDARC
 
 conda-build:
- root-dir: /home/conda/feedstock_root/build_artifacts
+  root-dir: /home/conda/feedstock_root/build_artifacts
 
 CONDARC
 
@@ -26,8 +26,6 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 {% if build_setup -%}
 {{ build_setup }}{% endif -%}
-{% if yum_build_setup is defined -%}
-{{ yum_build_setup }}{% endif -%}
 
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -39,26 +39,8 @@ mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
 
-# Set up the docker image that we are going to use.  This is used to install yum requirements at build time if needed
+# Set up the docker image that we are going to use.
 {{ docker.executable }} pull $DOCKER_IMAGE
-
-# If we have yum requirements build a new specialized image that we will use to run our build in that includes
-# those dependencies.
-pushd ${RECIPE_ROOT}
-if [ -f ${RECIPE_ROOT}/yum_requirements.txt ]; then
-
-    cat >Dockerfile.yum <<DOCKERFILE
-FROM ${DOCKER_IMAGE}
-ADD yum_requirements.txt /opt/requirements.txt
-RUN yum -y install \$(cat /opt/requirements.txt)
-DOCKERFILE
-
-    export NEW_DOCKER_IMAGE="conda-smithy-$(openssl rand -hex 12)"
-    docker build -t ${NEW_DOCKER_IMAGE} --file Dockerfile.yum .
-    export DOCKER_IMAGE=$NEW_DOCKER_IMAGE
-    echo "Generated new image!"
-fi
-popd
 
 {%- if docker.interactive is defined %}
     {%- if docker.interactive %}

--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -39,6 +39,27 @@ mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
 
+# Set up the docker image that we are going to use.  This is used to install yum requirements at build time if needed
+{{ docker.executable }} pull $DOCKER_IMAGE
+
+# If we have yum requirements build a new specialized image that we will use to run our build in that includes
+# those dependencies.
+pushd ${RECIPE_ROOT}
+if [ -f ${RECIPE_ROOT}/yum_requirements.txt ]; then
+
+    cat >Dockerfile.yum <<DOCKERFILE
+FROM ${DOCKER_IMAGE}
+ADD yum_requirements.txt /opt/requirements.txt
+RUN yum -y install \$(cat /opt/requirements.txt)
+DOCKERFILE
+
+    export NEW_DOCKER_IMAGE="conda-smithy-$(openssl rand -hex 12)"
+    docker build -t ${NEW_DOCKER_IMAGE} --file Dockerfile.yum .
+    export DOCKER_IMAGE=$NEW_DOCKER_IMAGE
+    echo "Generated new image!"
+fi
+popd
+
 {%- if docker.interactive is defined %}
     {%- if docker.interactive %}
 # Enable running in interactive mode attached to a tty
@@ -53,15 +74,17 @@ DOCKER_RUN_ARGS=" -it "
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 {{ docker.executable }} run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:ro,z \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
-           -e CONFIG \
-           -e BINSTAR_TOKEN \
-           -e HOST_USER_ID \
-           -e UPLOAD_PACKAGES \
-           $DOCKER_IMAGE \
-           {{ docker.command }} \
-           /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh
+    -v "${RECIPE_ROOT}":/home/conda/recipe_root:ro,z \
+    -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+    -e CONFIG \
+    -e BINSTAR_TOKEN \
+    -e HOST_USER_ID \
+    -e UPLOAD_PACKAGES \
+    $DOCKER_IMAGE \
+    {{ docker.command }} \
+    /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh
+
+
 
 # verify that the end of the script was reached
 test -f "$DONE_CANARY"

--- a/news/yum-rework.rst
+++ b/news/yum-rework.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Changed how yum_requirements.txt is used in the docker build.  It now installs the yum_requirements
+  prior to doing the primary conda build without needing to use sudo.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -149,19 +149,6 @@ def test_circle_with_yum_reqs(py_recipe, jinja_env):
     )
 
 
-def test_circle_with_empty_yum_reqs_raises(py_recipe, jinja_env):
-    with open(
-        os.path.join(py_recipe.recipe, "recipe", "yum_requirements.txt"), "w"
-    ) as f:
-        f.write("# effectively empty")
-    with pytest.raises(ValueError):
-        cnfgr_fdstk.render_circle(
-            jinja_env=jinja_env,
-            forge_config=py_recipe.config,
-            forge_dir=py_recipe.recipe,
-        )
-
-
 def test_circle_osx(py_recipe, jinja_env):
     forge_dir = py_recipe.recipe
     travis_yml_file = os.path.join(forge_dir, ".travis.yml")


### PR DESCRIPTION
This removes the need to specially deal with yum_requirements in conda-smithy itself.  This allows us to get rid of a fair bit of code and remove the need to rerender when just changing yum_requirements