### PR TITLE
Suggest Python noarch

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -406,7 +406,8 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
                 )
 
     # 2: suggest python noarch
-    if build_section.get("noarch") is None and build_reqs and ("compiler" not in build_reqs) and ("pip" in build_reqs):
+    if build_section.get("noarch") is None and build_reqs and not any(["_compiler_stub" in b for b in build_reqs]) \
+            and ("pip" in build_reqs):
         with io.open(meta_fname, "rt") as fh:
             in_runreqs = False
             no_arch_possible = True

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -405,6 +405,33 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
                     "See https://conda-forge.org/docs/meta.html#use-pip"
                 )
 
+    # 2: suggest python noarch
+    if build_section.get("noarch") is None and build_reqs and ("compiler" not in build_reqs) and ("pip" in build_reqs):
+        with io.open(meta_fname, "rt") as fh:
+            in_runreqs = False
+            no_arch_possible = True
+            for line in fh:
+                line_s = line.strip()
+                if line_s == "host:" or line_s == "run:":
+                    in_runreqs = True
+                    runreqs_spacing = line[: -len(line.lstrip())]
+                    continue
+                if line_s.startswith("skip:") and is_selector_line(line):
+                    no_arch_possible = False
+                    break
+                if in_runreqs:
+                    if runreqs_spacing == line[: -len(line.lstrip())]:
+                        in_runreqs = False
+                        continue
+                    if is_selector_line(line):
+                        no_arch_possible = False
+                        break
+            if no_arch_possible:
+                hints.append(
+                    "Whenever possible python packages should use noarch. "
+                    "See https://conda-forge.org/docs/meta.html#building-noarch-packages"
+                )
+
     return lints, hints
 
 

--- a/news/suggest_noarch.rst
+++ b/news/suggest_noarch.rst
@@ -1,0 +1,3 @@
+**Added:**
+
+* hint to suggest using python noarch, when the build requirements include pip and no compiler is specified. 

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -439,7 +439,6 @@ class Test_linter(unittest.TestCase):
                 is_good=True,
             )
 
-
     def test_jinja_os_environ(self):
         # Test that we can use os.environ in a recipe. We don't care about
         # the results here.

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -366,6 +366,80 @@ class Test_linter(unittest.TestCase):
                             """
             )
 
+    def test_suggest_noarch(self):
+        expected_start = "Whenever possible python packages should use noarch."
+
+        with tmp_directory() as recipe_dir:
+
+            def assert_noarch_hint(meta_string, is_good=False):
+                with io.open(os.path.join(recipe_dir, "meta.yaml"), "w") as fh:
+                    fh.write(meta_string)
+                lints, hints = linter.main(recipe_dir, return_hints=True)
+                if is_good:
+                    message = (
+                        "Found hints when there shouldn't have "
+                        "been a lint for '{}'."
+                    ).format(meta_string)
+                else:
+                    message = (
+                        "Expected hints for '{}', but didn't " "get any."
+                    ).format(meta_string)
+                self.assertEqual(
+                    not is_good,
+                    any(lint.startswith(expected_start) for lint in hints),
+                    message,
+                )
+
+            assert_noarch_hint(
+                """
+                            build:
+                              noarch: python
+                              script:
+                                - echo "hello" 
+                            requirements:
+                              build:
+                                - python
+                                - pip
+                            """,
+                is_good=True,
+            )
+            assert_noarch_hint(
+                """
+                            build:
+                              script:
+                                - echo "hello" 
+                            requirements:
+                              build:
+                                - python
+                                - pip
+                            """
+            )
+            assert_noarch_hint(
+                """
+                            build:
+                              script:
+                                - echo "hello" 
+                            requirements:
+                              build:
+                                - python
+                            """,
+                is_good=True
+            )
+            assert_noarch_hint(
+                """
+                            build:
+                              script:
+                                - echo "hello" 
+                            requirements:
+                              build:
+                                - python
+                                - {{ compiler('c') }}
+                                - pip
+                            """,
+                is_good=True,
+            )
+
+
     def test_jinja_os_environ(self):
         # Test that we can use os.environ in a recipe. We don't care about
         # the results here.


### PR DESCRIPTION
Checklist
* [x] Added a ``news`` entry

@chrisburr and I noticed that it would be nice if conda-smithy could suggest to use noarch for packages which do not have operation system dependent requirements, are installed via pip and do not require a compiler.  
https://github.com/conda-forge/staged-recipes/pull/7780

I tired to implement a corresponding hint in the `lint_recipe.py`. 