### PR TITLE
Azure: osx forward env vars set by conda-forge-ci-setup

### DIFF
--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -32,7 +32,9 @@ jobs:
       rm ~/uninstall_homebrew
     displayName: Remove homebrew
 
-  - bash: echo "##vso[task.prependpath]$CONDA/bin"
+  - bash: |
+      echo "##vso[task.prependpath]$CONDA/bin"
+      sudo chown -R $USER $CONDA
     displayName: Add conda to PATH
 
   - script: |

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -32,25 +32,16 @@ jobs:
       rm ~/uninstall_homebrew
     displayName: Remove homebrew
 
-  - script: |
-      echo "Installing Miniconda"
-      set -x -e
-      curl -o $(Build.StagingDirectory)/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-      chmod +x $(Build.StagingDirectory)/miniconda.sh
-      $(Build.StagingDirectory)/miniconda.sh -b -p $(Build.StagingDirectory)/miniconda
-      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
-      echo "Setting up Conda environment"
-    displayName: 'Install miniconda'
+  - bash: echo "##vso[task.prependpath]$CONDA/bin"
+    displayName: Add conda to PATH
 
   - script: |
-      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
-      set -x -e
+      source activate base
       conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build shyaml
     displayName: 'Add conda-forge-ci-setup=2'
 
   - script: |
-      set -x -e
-      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
+      source activate base
       echo "Configuring conda."
 
       setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
@@ -67,30 +58,22 @@ jobs:
     displayName: Configure conda and conda-build
 
   - script: |
-      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
-      set -x -e
+      source activate base
       mangle_compiler ./ ./recipe ./.ci_support/${CONFIG}.yaml
     displayName: Mangle compiler
 
   - script: |
-      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
-      set -x -e
+      source activate base
       make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
     displayName: Generate build number clobber file
 
   - script: |
-      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
-      set -x -e
-      # set CONDA_BUILD_SYSROOT env which conda-forge-ci-setup stored
-      # in .ci_support/{config}.yaml in a previous stage.
-      # Without doing this, conda-build omits this env from the test stage
-      export CONDA_BUILD_SYSROOT=$(cat .ci_support/${CONFIG}.yaml  | shyaml get-value CONDA_BUILD_SYSROOT.0 $CONDA_BUILD_SYSROOT)
+      source activate base
       conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
     displayName: Build recipe
 
   - script: |
-      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
-      set -x -e
+      source activate base
       upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
     displayName: Upload recipe
     env:

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -57,6 +57,10 @@ jobs:
 
       source run_conda_forge_build_setup
       conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
+
+      # ensure that we export the variables that we set here to the next stage
+      echo "##vso[task.setvariable variable=CONDA_BUILD_SYSROOT]$CONDA_BUILD_SYSROOT"
+      echo "##vso[task.setvariable variable=MACOSX_DEPLOYMENT_TARGET]$MACOSX_DEPLOYMENT_TARGET"
     env: {
       OSX_FORCE_SDK_DOWNLOAD: "1"
     }
@@ -80,7 +84,7 @@ jobs:
       # set CONDA_BUILD_SYSROOT env which conda-forge-ci-setup stored
       # in .ci_support/{config}.yaml in a previous stage.
       # Without doing this, conda-build omits this env from the test stage
-      export CONDA_BUILD_SYSROOT=$(cat .ci_support/${CONFIG}.yaml  | shyaml get-value CONDA_BUILD_SYSROOT.0)
+      export CONDA_BUILD_SYSROOT=$(cat .ci_support/${CONFIG}.yaml  | shyaml get-value CONDA_BUILD_SYSROOT.0 $CONDA_BUILD_SYSROOT)
       conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
     displayName: Build recipe
 

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -48,10 +48,6 @@ jobs:
 
       source run_conda_forge_build_setup
       conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
-
-      # ensure that we export the variables that we set here to the next stage
-      echo "##vso[task.setvariable variable=CONDA_BUILD_SYSROOT]$CONDA_BUILD_SYSROOT"
-      echo "##vso[task.setvariable variable=MACOSX_DEPLOYMENT_TARGET]$MACOSX_DEPLOYMENT_TARGET"
     env: {
       OSX_FORCE_SDK_DOWNLOAD: "1"
     }


### PR DESCRIPTION
Rework osx azure build to `conda activate base` at every step.
I've also updated how we get conda as the official approach outlined in the documentation works now.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
