### PR TITLE
Added azure buildid and azure badges to readme

### DIFF
--- a/conda_smithy/azure_ci_utils.py
+++ b/conda_smithy/azure_ci_utils.py
@@ -207,7 +207,7 @@ def get_build_id(user, repo, project_name=AZURE_PROJECT_NAME):
     of badges.
     This is needed by non-conda-forge use cases"""
     bclient = build_client()
-    bdef_header = bclient.get_definitions(project=AZURE_PROJECT_NAME, name=repo)[0]
+    bdef_header = bclient.get_definitions(project=project_name, name=repo)[0]
     bdef: BuildDefinition = bclient.get_definition(
         bdef_header.id, bdef_header.project.name
     )

--- a/conda_smithy/azure_ci_utils.py
+++ b/conda_smithy/azure_ci_utils.py
@@ -1,7 +1,8 @@
 import os
 import typing
+import warnings
 
-from msrest.authentication import BasicAuthentication
+from msrest.authentication import Authentication, BasicAuthentication
 from vsts.build.v4_1.build_client import BuildClient
 from vsts.build.v4_1.models import (
     BuildDefinition,
@@ -15,53 +16,78 @@ from vsts.task_agent.v4_0.models import TaskAgentQueue
 from vsts.task_agent.v4_0.task_agent_client import TaskAgentClient
 from vsts.vss_connection import VssConnection
 
-AZURE_ORG_OR_USER = os.getenv("AZURE_ORG_OR_USER", "conda-forge")
-# This will only need to be changed if you need to point to a non-standard azure
-# instance.
-AZURE_TEAM_INSTANCE = os.getenv(
-    "AZURE_INSTANCE", f"https://dev.azure.com/{AZURE_ORG_OR_USER}"
-)
-AZURE_PROJECT_NAME = os.getenv("AZURE_PROJECT_NAME", "feedstock-builds")
 
-# By default for now don't report on the build information back to github
-AZURE_REPORT_BUILD_STATUS = os.getenv("AZURE_REPORT_BUILD_STATUS", "false")
+class AzureConfig:
 
-try:
-    with open(os.path.expanduser("~/.conda-smithy/azure.token"), "r") as fh:
-        AZURE_TOKEN = fh.read().strip()
-    if not AZURE_TOKEN:
-        raise ValueError()
-except (IOError, ValueError):
-    print(
-        "No azure token.  Create a token at https://dev.azure.com/conda-forge/_usersSettings/tokens and\n"
-        "put it in ~/.conda-smithy/azure.token"
-    )
+    _default_org = "conda-forge"
+    _default_project_name = "feedstock-builds"
+
+    def __init__(self, org_or_user=None, project_name=None, team_instance=None):
+        self.org_or_user = org_or_user or os.getenv(
+            "AZURE_ORG_OR_USER", self._default_org
+        )
+        # This will only need to be changed if you need to point to a non-standard azure
+        # instance.
+        self.instance_base_url = team_instance or os.getenv(
+            "AZURE_INSTANCE", f"https://dev.azure.com/{self.org_or_user}"
+        )
+        self.project_name = project_name or os.getenv(
+            "AZURE_PROJECT_NAME", self._default_project_name
+        )
+
+        try:
+            with open(os.path.expanduser("~/.conda-smithy/azure.token"), "r") as fh:
+                self.token = fh.read().strip()
+            if not self.token:
+                raise ValueError()
+        except (IOError, ValueError):
+            print(
+                "No azure token.  Create a token at https://dev.azure.com/conda-forge/_usersSettings/tokens and\n"
+                "put it in ~/.conda-smithy/azure.token"
+            )
+            self.token = None
+
+        # By default for now don't report on the build information back to github
+        self.azure_report_build_status = os.getenv("AZURE_REPORT_BUILD_STATUS", "false")
+
+    @property
+    def connection(self):
+        connection = VssConnection(
+            base_url=self.instance_base_url, creds=self.credentials
+        )
+        return connection
+
+    @property
+    def credentials(self):
+        if self.token:
+            return BasicAuthentication("", self.token)
+        else:
+            warnings.warn("No token available.  No modfications will be possible!")
+            return Authentication()
 
 
-credentials = BasicAuthentication("", AZURE_TOKEN)
-connection = VssConnection(base_url=AZURE_TEAM_INSTANCE, creds=credentials)
+default_config = AzureConfig()
 
 
-def get_service_endpoint(project_name=AZURE_PROJECT_NAME):
+def get_service_endpoint(config: AzureConfig = default_config):
     service_endpoint_client = ServiceEndpointClient(
-        base_url=AZURE_TEAM_INSTANCE, creds=credentials
+        base_url=config.azure_team_instance, creds=config.credentials
     )
     endpoints: typing.List[
         ServiceEndpoint
     ] = service_endpoint_client.get_service_endpoints(
-        project=project_name, type="GitHub"
+        project=config.project_name, type="GitHub"
     )
     for service_endpoint in endpoints:
-        if service_endpoint.name == AZURE_ORG_OR_USER:
+        if service_endpoint.name == config.azure_org_or_user:
             return service_endpoint
     else:
         raise KeyError("Service endpoint not found")
 
 
-def get_queues(project_name=AZURE_PROJECT_NAME):
-    aclient = TaskAgentClient(AZURE_TEAM_INSTANCE, credentials)
-    queues: typing.List[TaskAgentQueue] = aclient.get_agent_queues(project_name)
-    return queues
+def get_queues(config: AzureConfig = default_config) -> typing.List[TaskAgentQueue]:
+    aclient = TaskAgentClient(config.azure_team_instance, config.credentials)
+    return aclient.get_agent_queues(config.project_name)
 
 
 def get_default_queue(project_name):
@@ -73,13 +99,13 @@ def get_default_queue(project_name):
         raise ValueError("Default queue not found")
 
 
-def get_repo_reference(project_name, github_org, repo_name):
-    service_endpoint = get_service_endpoint(project_name)
-    bclient: BuildClient = connection.get_client(
+def get_repo_reference(config: AzureConfig, github_org, repo_name):
+    service_endpoint = get_service_endpoint(config)
+    bclient: BuildClient = config.connection.get_client(
         "vsts.build.v4_1.build_client.BuildClient"
     )
     repos: SourceRepositories = bclient.list_repositories(
-        project=project_name,
+        project=config.project_name,
         provider_name="github",
         repository=f"{github_org}/{repo_name}",
         service_endpoint_id=service_endpoint.id,
@@ -89,7 +115,7 @@ def get_repo_reference(project_name, github_org, repo_name):
     return repo
 
 
-def register_repo(github_org, repo_name, project_name=AZURE_PROJECT_NAME):
+def register_repo(github_org, repo_name, config: AzureConfig = default_config):
     from vsts.build.v4_1.models import (
         BuildDefinition,
         BuildDefinitionReference,
@@ -99,9 +125,9 @@ def register_repo(github_org, repo_name, project_name=AZURE_PROJECT_NAME):
     import inspect
 
     bclient = build_client()
-    aclient = TaskAgentClient(AZURE_TEAM_INSTANCE, credentials)
+    aclient = TaskAgentClient(config.azure_team_instance, config.credentials)
 
-    source_repo = get_repo_reference(project_name, github_org, repo_name)
+    source_repo = get_repo_reference(config, github_org, repo_name)
 
     new_repo = BuildRepository(
         type="GitHub",
@@ -120,12 +146,12 @@ def register_repo(github_org, repo_name, project_name=AZURE_PROJECT_NAME):
     new_repo.properties["labelSources"] = "0"
     new_repo.properties["fetchDepth"] = "0"
     new_repo.properties["labelSourcesFormat"] = "$(build.buildNumber)"
-    new_repo.properties["reportBuildStatus"] = AZURE_REPORT_BUILD_STATUS
+    new_repo.properties["reportBuildStatus"] = config.azure_report_build_status
     new_repo.clean = False
 
-    queues = get_queues(project_name)
-    default_queue = get_default_queue(project_name)
-    service_endpoint = get_service_endpoint(project_name)
+    queues = get_queues(config)
+    default_queue = get_default_queue(config)
+    service_endpoint = get_service_endpoint(config)
 
     build_definition = BuildDefinition(
         process={
@@ -163,7 +189,7 @@ def register_repo(github_org, repo_name, project_name=AZURE_PROJECT_NAME):
             },
         ],
         variable_groups=aclient.get_variable_groups(
-            project=project_name, group_name="anaconda-org"
+            project=config.project_name, group_name="anaconda-org"
         ),
         type="build",
     )
@@ -171,7 +197,7 @@ def register_repo(github_org, repo_name, project_name=AZURE_PROJECT_NAME):
     # clean up existing builds for the same feedstock if present
     existing_definitions: typing.List[
         BuildDefinitionReference
-    ] = bclient.get_definitions(project=project_name, name=repo_name)
+    ] = bclient.get_definitions(project=config.project_name, name=repo_name)
     if existing_definitions:
         assert len(existing_definitions) == 1
         ed = existing_definitions[0]
@@ -179,43 +205,46 @@ def register_repo(github_org, repo_name, project_name=AZURE_PROJECT_NAME):
             definition=build_definition, definition_id=ed.id, project=ed.project.name
         )
     else:
-        bclient.create_definition(definition=build_definition, project=project_name)
+        bclient.create_definition(
+            definition=build_definition, project=config.project_name
+        )
 
 
-def build_client() -> BuildClient:
-    return connection.get_client("vsts.build.v4_1.build_client.BuildClient")
+def build_client(config: AzureConfig = default_config) -> BuildClient:
+    return config.connection.get_client("vsts.build.v4_1.build_client.BuildClient")
 
 
-def repo_registered(github_org, repo_name, project_name=AZURE_PROJECT_NAME):
-    existing_definitions: typing.List[
-        BuildDefinitionReference
-    ] = build_client().get_definitions(project=project_name, name=repo_name)
+def repo_registered(
+    github_org: str, repo_name: str, config: AzureConfig = default_config
+) -> bool:
+    existing_definitions: typing.List[BuildDefinitionReference] = build_client(
+        config
+    ).get_definitions(project=config.project_name, name=repo_name)
 
     return bool(existing_definitions)
 
 
-def enable_reporting(user, repo, project_name=AZURE_PROJECT_NAME):
-    bclient = build_client()
-    bdef_header = bclient.get_definitions(project=project_name, name=repo)[0]
+def enable_reporting(repo, config: AzureConfig = default_config) -> None:
+    bclient = build_client(config)
+    bdef_header = bclient.get_definitions(project=config.project_name, name=repo)[0]
     bdef = bclient.get_definition(bdef_header.id, bdef_header.project.name)
     bdef.repository.properties["reportBuildStatus"] = "true"
     bclient.update_definition(bdef, bdef.id, bdef.project.name)
 
 
-def get_build_id(user, repo, project_name=AZURE_PROJECT_NAME):
+def get_build_id(repo, config: AzureConfig = default_config) -> dict:
     """Get the neccesary build information to persist in the config file to allow rendering
     of badges.
     This is needed by non-conda-forge use cases"""
-    bclient = build_client()
-    bdef_header = bclient.get_definitions(project=project_name, name=repo)[0]
+    bclient = build_client(config)
+    bdef_header = bclient.get_definitions(project=config.project_name, name=repo)[0]
     bdef: BuildDefinition = bclient.get_definition(
         bdef_header.id, bdef_header.project.name
     )
 
     return dict(
-        user_or_org=AZURE_ORG_OR_USER,
-        project_name=project_name,
+        user_or_org=config.org_or_user,
+        project_name=config.project_name,
         build_id=bdef.id,
         project_id=bdef.project.id,
     )
-

--- a/conda_smithy/azure_ci_utils.py
+++ b/conda_smithy/azure_ci_utils.py
@@ -41,10 +41,6 @@ class AzureConfig:
             if not self.token:
                 raise ValueError()
         except (IOError, ValueError):
-            print(
-                "No azure token.  Create a token at https://dev.azure.com/conda-forge/_usersSettings/tokens and\n"
-                "put it in ~/.conda-smithy/azure.token"
-            )
             self.token = None
 
         # By default for now don't report on the build information back to github

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -258,13 +258,7 @@ class AddAzureBuildId(Subcommand):
         # conda-smithy azure-buildid ./
         super(AddAzureBuildId, self).__init__(
             parser,
-            dedent("""\
-                Update the azure configuration stored in the config file.
-                This command is affected by the following environment variables:
-                    AZURE_ORG_OR_USER
-                    AZURE_PROJECT_NAME
-                """
-            )
+            dedent("Update the azure configuration stored in the config file.")
         )
         scp = self.subcommand_parser
         scp.add_argument(

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -7,6 +7,8 @@ import time
 import argparse
 import io
 
+from textwrap import dedent
+
 import conda
 from distutils.version import LooseVersion
 from conda_build.metadata import MetaData
@@ -252,10 +254,16 @@ class AddAzureBuildId(Subcommand):
     subcommand = "azure-buildid"
 
     def __init__(self, parser):
-        # conda-smithy register-ci ./
+        # conda-smithy azure-buildid ./
         super(AddAzureBuildId, self).__init__(
             parser,
-            "Update the azure build id stored in the config file.",
+            dedent("""\
+                Update the azure configuration stored in the config file.
+                This command is affected by the following environment variables:
+                    AZURE_ORG_OR_USER
+                    AZURE_PROJECT_NAME
+                """
+            )
         )
         scp = self.subcommand_parser
         scp.add_argument(
@@ -279,13 +287,16 @@ class AddAzureBuildId(Subcommand):
         owner = args.user or args.organization
         repo = os.path.basename(os.path.abspath(args.feedstock_directory))
 
-        build_id = get_build_id(owner, repo)
+        build_info = get_build_id(owner, repo)
         import ruamel.yaml
 
         from .utils import update_conda_forge_config
         with update_conda_forge_config(args.feedstock_directory) as config:
             config.setdefault("azure", {})
-            config["azure"]["build_id"] = build_id
+            config["azure"]["build_id"] = build_info['build_id']
+            config["azure"]["user_or_org"] = build_info['user_or_org']
+            config["azure"]["project_name"] = build_info['project_name']
+            config["azure"]["project_id"] = build_info['project_id']
 
 
 class Regenerate(Subcommand):

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -17,6 +17,7 @@ from conda_build.utils import ensure_list
 from . import configure_feedstock
 from . import feedstock_io
 from . import lint_recipe
+from . import azure_ci_utils
 from . import __version__
 
 
@@ -273,21 +274,29 @@ class AddAzureBuildId(Subcommand):
         )
         group = scp.add_mutually_exclusive_group()
         group.add_argument(
-            "--user", help="github username under which to register this repo"
+            "--user", help="azure username for which this repo is enabled already"
         )
         group.add_argument(
             "--organization",
-            default="conda-forge",
-            help="github organisation under which to register this repo",
+            default=azure_ci_utils.AzureConfig._default_org,
+            help="azure organisation for which this repo is enabled already",
+        )
+        scp.add_argument(
+            '--project_name',
+            default=azure_ci_utils.AzureConfig._default_project_name,
+            help="project name that feedstocks are registered under"
         )
 
     def __call__(self, args):
-        from conda_smithy.azure_ci_utils import get_build_id
-
         owner = args.user or args.organization
         repo = os.path.basename(os.path.abspath(args.feedstock_directory))
 
-        build_info = get_build_id(owner, repo)
+        config = azure_ci_utils.AzureConfig(
+            org_or_user=owner,
+            project_name=args.project_name
+        )
+
+        build_info = azure_ci_utils.get_build_id(repo, config)
         import ruamel.yaml
 
         from .utils import update_conda_forge_config

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -233,6 +233,11 @@ class RegisterCI(Subcommand):
         else:
             print("Circle registration disabled.")
         if args.azure:
+            if azure_ci_utils.default_config.token is None:
+                print(
+                    "No azure token.  Create a token at https://dev.azure.com/conda-forge/_usersSettings/tokens and\n"
+                    "put it in ~/.conda-smithy/azure.token"
+                )
             ci_register.add_project_to_azure(owner, repo)
         else:
             print("Azure registration disabled.")

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1075,7 +1075,7 @@ def render_README(jinja_env, forge_config, forge_dir):
 
     ci_support_path = os.path.join(forge_dir, ".ci_support")
     variants = []
-    if os.path.exist(ci_support_path):
+    if os.path.exists(ci_support_path):
         for filename in os.listdir(ci_support_path):
             if filename.endswith('.yaml'):
                 variant_name, _ = os.path.splitext(filename)

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1075,10 +1075,11 @@ def render_README(jinja_env, forge_config, forge_dir):
 
     ci_support_path = os.path.join(forge_dir, ".ci_support")
     variants = []
-    for filename in os.listdir(ci_support_path):
-        if filename.endswith('.yaml'):
-            variant_name, _ = os.path.splitext(filename)
-            variants.append(variant_name)
+    if os.path.exist(ci_support_path):
+        for filename in os.listdir(ci_support_path):
+            if filename.endswith('.yaml'):
+                variant_name, _ = os.path.splitext(filename)
+                variants.append(variant_name)
 
     template = jinja_env.get_template("README.md.tmpl")
     target_fname = os.path.join(forge_dir, "README.md")

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1097,8 +1097,23 @@ def render_README(jinja_env, forge_config, forge_dir):
             )
         )
     )
+
+    if forge_config['azure'].get('build_id') is None:
+        # Try to retrieve the build_id from the interwebs
+        import requests
+        resp = requests.get(
+            "https://dev.azure.com/{org}/{project_name}/_apis/build/definitions?name={repo}".format(
+                org=forge_config["azure"]["user_or_org"],
+                project_name=forge_config["azure"]["project_name"],
+                repo=forge_config["github"]["repo_name"]
+            ))
+        build_def = resp.json()["value"][0]
+        forge_config['azure']['build_id'] = build_def['id']
+
     print("README")
     print(yaml.dump(forge_config))
+
+
 
     with write_file(target_fname) as fh:
         fh.write(template.render(**forge_config))

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1101,15 +1101,19 @@ def render_README(jinja_env, forge_config, forge_dir):
 
     if forge_config['azure'].get('build_id') is None:
         # Try to retrieve the build_id from the interwebs
-        import requests
-        resp = requests.get(
-            "https://dev.azure.com/{org}/{project_name}/_apis/build/definitions?name={repo}".format(
-                org=forge_config["azure"]["user_or_org"],
-                project_name=forge_config["azure"]["project_name"],
-                repo=forge_config["github"]["repo_name"]
-            ))
-        build_def = resp.json()["value"][0]
-        forge_config['azure']['build_id'] = build_def['id']
+        try:
+            import requests
+            resp = requests.get(
+                "https://dev.azure.com/{org}/{project_name}/_apis/build/definitions?name={repo}".format(
+                    org=forge_config["azure"]["user_or_org"],
+                    project_name=forge_config["azure"]["project_name"],
+                    repo=forge_config["github"]["repo_name"]
+                ))
+            build_def = resp.json()["value"][0]
+            forge_config['azure']['build_id'] = build_def['id']
+        except IndexError, IOError:
+            pass
+
 
     print("README")
     print(yaml.dump(forge_config))

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1111,7 +1111,7 @@ def render_README(jinja_env, forge_config, forge_dir):
                 ))
             build_def = resp.json()["value"][0]
             forge_config['azure']['build_id'] = build_def['id']
-        except IndexError, IOError:
+        except (IndexError, IOError):
             pass
 
 

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -20,49 +20,121 @@ Current build status
 ====================
 {%- set appveyor_url_name = github.repo_name.replace('_', '-').replace('.', '-') %}
 {%- set shield = "https://img.shields.io/" %}
-{# #}
+{#  Due to github's markdown rendering within tables being a bit shaky, we have to fall back to an HTML table here since we wish
+  to use a <details> tag.  Markdown rendering within html tables is weird and only works if you make EVERYTHING a paragraph which
+  looks terrible.  This is the lesser of the evils.
+#}
 
-{%- if noarch_python %}
-{%- if circle.enabled %}
-All platforms:
-[![noarch]({{ shield }}circleci/project/github/{{ github.user_or_org }}/{{ github.repo_name }}/{{ github.branch_name }}.svg?label=noarch)](https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }})
-{%- else %}
-All platforms: ![noarch disabled]({{ shield }}badge/noarch-disabled-lightgrey.svg)
+<table>
+{%- if noarch_python -%}
+  {%- if circle.enabled -%}
+  <tr>
+    <td>All platforms:</td>
+    <td>
+      <a href="https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }}">
+        <img src="{{ shield }}circleci/project/github/{{ github.user_or_org }}/{{ github.repo_name }}/{{ github.branch_name }}.svg?label=noarch">
+      </a>
+    </td>
+  </tr>
+  {%- else -%}
+  <tr>
+    <td>All platforms:</td>
+    <td>
+      <img src="{{ shield }}badge/noarch-disabled-lightgrey.svg" alt="noarch disabled">
+    </td>
+  </tr>
+  {%- endif -%}
+{%- else -%}
+  {%- if circle.enabled -%}
+  <tr>
+    <td>CircleCI</td>
+    <td>
+      <a href="https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }}">
+        <img alt="{{ circle.platforms }}" src="{{ shield }}circleci/project/github/{{ github.user_or_org }}/{{ github.repo_name }}/{{ github.branch_name }}.svg?label={{ circle.platforms }}">
+      </a>
+    </td>
+  </tr>
+  {%- endif -%}
+  {%- if travis.enabled -%}
+  <tr>
+    <td>Travis</td>
+    <td>
+      <a href="https://travis-ci.org/{{ github.user_or_org }}/{{ github.repo_name }}">
+        <img alt="macOS" src="{{ shield }}travis/{{ github.user_or_org }}/{{ github.repo_name }}/{{ github.branch_name }}.svg?label=macOS">
+      </a>
+    </td>
+  </tr>
+  {%- endif -%}
+  {%- if appveyor.enabled -%}
+  <tr>
+    <td>Appveyor</td>
+    <td>
+      <a href="https://ci.appveyor.com/project/{{ github.user_or_org }}/{{ appveyor_url_name }}/branch/{{ github.branch_name }}">
+        <img alt="windows" src="{{ shield }}appveyor/ci/{{ github.user_or_org }}/{{ appveyor_url_name }}/{{ github.branch_name }}.svg?label=Windows">
+      </a>
+    </td>
+  </tr>
+  {%- endif -%}
+  {%- if azure.enabled -%}
+    {#- Sample url #-}
+    {#- [![Azure Status](https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cryptography-feedstock?branchName=master)](https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=195&branchName=master) -#}
+    {% set azure_url %}https://dev.azure.com/{{ azure.user_or_org }}/{{ azure.project_name }}/_build/latest?definitionId={{ azure.build_id }}&branchName={{ github.branch_name }}{% endset %}
+    {% set azure_image_url %}https://dev.azure.com/{{ azure.user_or_org }}/{{ azure.project_name }}/_apis/build/status/{{ github.repo_name }}?branchName={{ github.branch_name }}{% endset %}
+  <tr>
+    <td>Azure</td>
+    <td>
+      <details>
+        <summary>
+          <a href="{{ azure_url }}">
+            <img src="{{ azure_image_url }}">
+          </a>
+        </summary>
+        <table>
+          <thead><tr><th>Variant</th><th>Status</th></tr></thead>
+          <tbody>
+          {%- for variant in variants -%}
+            {%- set variant_os = variant.split('_')[0] -%}
+            <tr>
+              <td>{{ variant.strip('_') }}</td>
+              <td>
+                <a href="{{ azure_url }}"">
+                  <img src="{{ azure_image_url }}&jobName={{ variant_os }}&configuration={{ variant }}" alt="variant">
+                </a>
+              </td>
+            </tr>
+          {%- endfor %}
+          </tbody>
+        </table>
+      </details>
+    </td>
+  </tr>
+  {%- endif %}
+  {%- if not linux.enabled %}
+  <tr>
+    <td>Linux</td>
+    <td>
+      <img src="{{ shield }}badge/linux-disabled-lightgrey.svg" alt="linux disabled">
+    </td>
+  </tr>
+  {%- endif %}
+  {%- if not osx.enabled %}
+  <tr>
+    <td>OSX</td>
+    <td>
+      <img src="{{ shield }}badge/OSX-disabled-lightgrey.svg" alt="OSX disabled">
+    </td>
+  </tr>
+  {%- endif %}
+  {%- if not win.enabled %}
+  <tr>
+    <td>Windows</td>
+    <td>
+      <img src="{{ shield }}badge/Windows-disabled-lightgrey.svg" alt="Windows disabled">
+    </td>
+  </tr>
+  {%- endif %}
 {%- endif %}
-{%- else %}
-{%- if circle.enabled %}
-[![{{ circle.platforms }}]({{ shield }}circleci/project/github/{{ github.user_or_org }}/{{ github.repo_name }}/{{ github.branch_name }}.svg?label={{ circle.platforms }})](https://circleci.com/gh/{{ github.user_or_org }}/{{ github.repo_name }})
-{%- endif %}
-{%- if travis.enabled %}
-[![OSX]({{ shield }}travis/{{ github.user_or_org }}/{{ github.repo_name }}/{{ github.branch_name }}.svg?label=macOS)](https://travis-ci.org/{{ github.user_or_org }}/{{ github.repo_name }})
-{%- endif %}
-{%- if appveyor.enabled %}
-[![Windows]({{ shield }}appveyor/ci/{{ github.user_or_org }}/{{ appveyor_url_name }}/{{ github.branch_name }}.svg?label=Windows)](https://ci.appveyor.com/project/{{ github.user_or_org }}/{{ appveyor_url_name }}/branch/{{ github.branch_name }})
-{%- endif %}
-{%- if azure.enabled %}
-{#- Sample url}
-{#- [![Azure Status](https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cryptography-feedstock?branchName=master)](https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=195&branchName=master) #}
-[![Build Status](https://dev.azure.com/{{ azure.user_or_org }}/{{ azure.project_name }}/_apis/build/status/{{ github.repo_name }}?branchName={{ github.branch_name }})](https://dev.azure.com/{{ azure.user_or_org }}/{{ azure.project_name }}/_build/latest?definitionId={{ azure.build_id }}&branchName={{ github.branch_name }})
-{%- endif %}
-{%- if not linux.enabled %}
-![Linux disabled]({{ shield }}badge/linux-disabled-lightgrey.svg)
-{%- endif %}
-{%- if not osx.enabled %}
-![OSX disabled]({{ shield }}badge/OSX-disabled-lightgrey.svg)
-{%- endif %}
-{%- if not win.enabled %}
-![Windows disabled]({{ shield }}badge/Windows-disabled-lightgrey.svg)
-{%- endif %}
-{%- endif %}
-
-{%- if azure.enabled %}
-| Variant | Status |
-| ------- | ------ |
-{%- for variant in variants %}
-{%- set variant_os = variant.split('_')[0] %}
-| `{{ variant.strip('_') }}` | [![Build Status](https://dev.azure.com/{{ azure.user_or_org }}/{{ azure.project_name }}/_apis/build/status/{{ github.repo_name }}?branchName={{ github.branch_name }}&jobName={{ variant_os }}&configuration={{ variant }})](https://dev.azure.com/{{ azure.user_or_org }}/{{ azure.project_name }}/_build/latest?definitionId={{ azure.build_id }}&branchName={{ github.branch_name }}) |
-{%- endfor %}
-{%- endif %}
+</table>
 
 Current release info
 ====================

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -1,7 +1,7 @@
 {%- set channel_name = channels.targets[0][0] -%}
-<!--
+{#-
 # -*- mode: jinja -*-
--->
+-#}
 
 About {{ package_name }}
 ======{{ '=' * package_name|length }}
@@ -39,6 +39,11 @@ All platforms: ![noarch disabled]({{ shield }}badge/noarch-disabled-lightgrey.sv
 {%- if appveyor.enabled %}
 [![Windows]({{ shield }}appveyor/ci/{{ github.user_or_org }}/{{ appveyor_url_name }}/{{ github.branch_name }}.svg?label=Windows)](https://ci.appveyor.com/project/{{ github.user_or_org }}/{{ appveyor_url_name }}/branch/{{ github.branch_name }})
 {%- endif %}
+{%- if azure.enabled %}
+{#- Sample url}
+{#- [![Azure Status](https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cryptography-feedstock?branchName=master)](https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=195&branchName=master) #}
+[![Build Status](https://dev.azure.com/{{ azure.user_or_org }}/{{ azure.project_name }}/_apis/build/status/{{ github.repo_name }}?branchName={{ github.branch_name }})](https://dev.azure.com/{{ azure.user_or_org }}/{{ azure.project_name }}/_build/latest?definitionId={{ azure.build_id }}&branchName={{ github.branch_name }})
+{%- endif %}
 {%- if not linux.enabled %}
 ![Linux disabled]({{ shield }}badge/linux-disabled-lightgrey.svg)
 {%- endif %}
@@ -48,6 +53,15 @@ All platforms: ![noarch disabled]({{ shield }}badge/noarch-disabled-lightgrey.sv
 {%- if not win.enabled %}
 ![Windows disabled]({{ shield }}badge/Windows-disabled-lightgrey.svg)
 {%- endif %}
+{%- endif %}
+
+{%- if azure.enabled %}
+| Variant | Status |
+| ------- | ------ |
+{%- for variant in variants %}
+{%- set variant_os = variant.split('_')[0] %}
+| `{{ variant.strip('_') }}` | [![Build Status](https://dev.azure.com/{{ azure.user_or_org }}/{{ azure.project_name }}/_apis/build/status/{{ github.repo_name }}?branchName={{ github.branch_name }}&jobName={{ variant_os }}&configuration={{ variant }})](https://dev.azure.com/{{ azure.user_or_org }}/{{ azure.project_name }}/_build/latest?definitionId={{ azure.build_id }}&branchName={{ github.branch_name }}) |
+{%- endfor %}
 {%- endif %}
 
 Current release info

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -97,7 +97,7 @@ Current build status
             <tr>
               <td>{{ variant.strip('_') }}</td>
               <td>
-                <a href="{{ azure_url }}"">
+                <a href="{{ azure_url }}">
                   <img src="{{ azure_image_url }}&jobName={{ variant_os }}&configuration={{ variant }}" alt="variant">
                 </a>
               </td>

--- a/news/azure-buildid.rst
+++ b/news/azure-buildid.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Added a utility to retrieve the azure buildid.  This is needed to make badges
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+

--- a/news/azure-buildid.rst
+++ b/news/azure-buildid.rst
@@ -1,6 +1,7 @@
 **Added:**
 
-* Added a utility to retrieve the azure buildid.  This is needed to make badges
+* Added a utility to retrieve the azure buildid.  This is needed to make badges for non-conda forge users.
+* Added badges for azure ci builds.
 
 **Changed:**
 


### PR DESCRIPTION
This command will retrieve the build id from azure.  With this we can make badges and improve UX for azure.

This adds an additional subcommand that non-conda-forge users will want to use in order to get the correct azure metadata for making badges stores in the config file.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->