### PR TITLE
Only do noarch linting in staged-recipes, not feedstocks

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -134,6 +134,9 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
     package_section = get_section(meta, "package", lints)
     outputs_section = get_section(meta, "outputs", lints)
 
+    recipe_dirname = os.path.basename(recipe_dir) if recipe_dir else "recipe"
+    is_staged_recipes = recipe_dirname != "recipe"
+    
     # 0: Top level keys should be expected
     unexpected_sections = []
     for section in major_sections:
@@ -405,9 +408,9 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
                     "See https://conda-forge.org/docs/meta.html#use-pip"
                 )
 
-    # 2: suggest python noarch
+    # 2: suggest python noarch (skip on feedstocks)
     if build_section.get("noarch") is None and build_reqs and not any(["_compiler_stub" in b for b in build_reqs]) \
-            and ("pip" in build_reqs):
+            and ("pip" in build_reqs) and is_staged_recipes:
         with io.open(meta_fname, "rt") as fh:
             in_runreqs = False
             no_arch_possible = True

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -410,7 +410,7 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
 
     # 2: suggest python noarch (skip on feedstocks)
     if build_section.get("noarch") is None and build_reqs and not any(["_compiler_stub" in b for b in build_reqs]) \
-            and ("pip" in build_reqs) and is_staged_recipes:
+            and ("pip" in build_reqs) and (is_staged_recipes or not conda_forge):
         with io.open(meta_fname, "rt") as fh:
             in_runreqs = False
             no_arch_possible = True

--- a/news/noarch_staged_recipes_only.rst
+++ b/news/noarch_staged_recipes_only.rst
@@ -1,0 +1,4 @@
+**Changed:**
+
+* Only suggest noarch in linting staged-recipes pull requests, not feedstocks.
+  Refer to issues #1021, #1030, #1031. Linter is not checking all prerequisites for noarch.


### PR DESCRIPTION
As discussed in https://github.com/conda-forge/conda-smithy/pull/1021#issuecomment-467253422 - this would resolve #1030, and the similar #1031, in a conservative way for existing recipes. Hopefully the staged-recipes PR's are getting enough manual review to identify when the linter should be listened to or ignored.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
