### PR TITLE
Fix bug preventing feedstock conversion in staged-recipes

### DIFF
--- a/conda_smithy/azure_ci_utils.py
+++ b/conda_smithy/azure_ci_utils.py
@@ -67,7 +67,7 @@ default_config = AzureConfig()
 
 def get_service_endpoint(config: AzureConfig = default_config):
     service_endpoint_client = ServiceEndpointClient(
-        base_url=config.azure_team_instance, creds=config.credentials
+        base_url=config.instance_base_url, creds=config.credentials
     )
     endpoints: typing.List[
         ServiceEndpoint
@@ -82,7 +82,7 @@ def get_service_endpoint(config: AzureConfig = default_config):
 
 
 def get_queues(config: AzureConfig = default_config) -> typing.List[TaskAgentQueue]:
-    aclient = TaskAgentClient(config.azure_team_instance, config.credentials)
+    aclient = TaskAgentClient(config.instance_base_url, config.credentials)
     return aclient.get_agent_queues(config.project_name)
 
 

--- a/conda_smithy/azure_ci_utils.py
+++ b/conda_smithy/azure_ci_utils.py
@@ -121,7 +121,7 @@ def register_repo(github_org, repo_name, config: AzureConfig = default_config):
     import inspect
 
     bclient = build_client()
-    aclient = TaskAgentClient(config.azure_team_instance, config.credentials)
+    aclient = TaskAgentClient(config.instance_base_url, config.credentials)
 
     source_repo = get_repo_reference(config, github_org, repo_name)
 

--- a/news/fix-staged-recipes.rst
+++ b/news/fix-staged-recipes.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Use `config.instance_base_url` instead of `config.azure_team_instance` when creating new feedstocks
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
Feedstock conversion is currently broken in staged-recipes, see [here](https://travis-ci.org/conda-forge/staged-recipes/builds/508675401#L851-L862).

I think this PR fixes it, I might not have time to look at this again today so feel free to edit this PR or replace it with a new one if needed.

Checklist
* [x] Added a ``news`` entry

