### PR TITLE
Linter: Accept toolchain usage for R packages

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -388,7 +388,8 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
             )
 
     # 21: Legacy usage of compilers
-    if build_reqs and ("toolchain" in build_reqs):
+    host_reqs = requirements_section.get("host", None)
+    if build_reqs and ("toolchain" in build_reqs) and not (host_reqs and ("r-base" in host_reqs)):
         lints.append(
             "Using toolchain directly in this manner is deprecated.  Consider "
             "using the compilers outlined "

--- a/news/r-compilers.rst
+++ b/news/r-compilers.rst
@@ -1,0 +1,3 @@
+**Changed:**
+
+* Linter: Accept toolchain usage for R packages.

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -433,6 +433,56 @@ class Test_linter(unittest.TestCase):
                 is_good=True,
             )
 
+    def test_legacy_compilers(self):
+        expected_start = "Using toolchain directly in this manner is deprecated."
+
+        with tmp_directory() as recipe_dir:
+
+            def assert_legacy_compilers(meta_string, is_good=False):
+                with io.open(os.path.join(recipe_dir, "meta.yaml"), "w") as fh:
+                    fh.write(meta_string)
+                lints, hints = linter.main(recipe_dir, return_hints=True)
+                if is_good:
+                    message = (
+                        "Found hints when there shouldn't have " "been a lint for '{}'."
+                    ).format(meta_string)
+                else:
+                    message = (
+                        "Expected hints for '{}', but didn't " "get any."
+                    ).format(meta_string)
+                self.assertEqual(
+                    not is_good,
+                    any(lint.startswith(expected_start) for lint in lints),
+                    message,
+                )
+
+            assert_legacy_compilers(
+                """
+                            requirements:
+                              build:
+                                - toolchain
+                            """
+            )
+            assert_legacy_compilers(
+                """
+                            requirements:
+                              build:
+                                - toolchain
+                              host:
+                                - abc
+                            """
+            )
+            assert_legacy_compilers(
+                """
+                            requirements:
+                              build:
+                                - toolchain
+                              host:
+                                - r-base
+                            """,
+                is_good=True,
+            )
+
     def test_jinja_os_environ(self):
         # Test that we can use os.environ in a recipe. We don't care about
         # the results here.


### PR DESCRIPTION
R recipes remain fine with "- {{native}}toolchain        # [win]".

Also "conda-skeleton cran" and "conda_r_skeleton_helper" are creating recipes based on the toolchain.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This hopefully reduces the false negative linter rates on R recipes. Or is there a different solution?

Tagging @conda-forge/r 