### PR TITLE
Compiling with visual studio 2015 (msvc14) seems to require a 2015 image

### DIFF
--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -5,7 +5,7 @@
 jobs:
 - job: win
   pool:
-    vmImage: vs2017-win2016
+    vmImage: vs2015-win2012r2
   timeoutInMinutes: {{ azure.timeout_minutes }}
   strategy:
     maxParallel: 4


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

This should hopefully fix the issues explained at https://github.com/conda-forge/sdl2_mixer-feedstock/pull/5/ and https://github.com/orgs/conda-forge/teams/core/discussions/3.

The short summary is that there is a build difference between appveyor and azure when using msvc 14. On azure, as the image seems to be visual studio 2017, it only has a bare minimum set of tools for visual studio 2015. This means that building with 2015 (msvc 14.0, which is required by python, and seems to be what conda is using in general) breaks. You can see the details in links above.

This is not the best solution, the best solution would be installing full versions of all visual studio versions used by conda just like [appveyor is doing](https://www.appveyor.com/docs/windows-images-software/#visual-studio-2008) (and hence why it builds properly on appveyor). But, if that is not possible (I'm not sure how this would be done), using the 2015 image is the next best thing, especially since conda doesn't use the 2017 runtime (I think!?). Although if 2008 builds have similar issues, this does not solve it.