### PR TITLE
Clean up azure table whitespace in README

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -40,8 +40,8 @@ Current build status
   <tr>
     {#- Sample url #-}
     {#- [![Azure Status](https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cryptography-feedstock?branchName=master)](https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=195&branchName=master) -#}
-    {% set azure_url %}https://dev.azure.com/{{ azure.user_or_org }}/{{ azure.project_name }}/_build/latest?definitionId={{ azure.build_id }}&branchName={{ github.branch_name }}{% endset %}
-    {% set azure_image_url %}https://dev.azure.com/{{ azure.user_or_org }}/{{ azure.project_name }}/_apis/build/status/{{ github.repo_name }}?branchName={{ github.branch_name }}{% endset %}
+    {%- set azure_url %}https://dev.azure.com/{{ azure.user_or_org }}/{{ azure.project_name }}/_build/latest?definitionId={{ azure.build_id }}&branchName={{ github.branch_name }}{%- endset -%}
+    {%- set azure_image_url %}https://dev.azure.com/{{ azure.user_or_org }}/{{ azure.project_name }}/_apis/build/status/{{ github.repo_name }}?branchName={{ github.branch_name }}{%- endset -%}
     <td>All platforms:</td>
     <td>
       <a href="{{ azure_url }}">

--- a/news/azure-table-whitespace.rst
+++ b/news/azure-table-whitespace.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* removed empty lines causing current build status table to render as code


### PR DESCRIPTION
This cleans out some extra whitespace that trigger a code block in the azure table:
![Screenshot from 2019-05-20 20-05-56](https://user-images.githubusercontent.com/45380/58059410-b49cb800-7b3a-11e9-8e7a-ae7e6d58c006.png)

I haven't _fully_ tested this... but ran into it while looking at other stuff...