### PR TITLE
[wip] publish test reports

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1144,6 +1144,8 @@ def _load_forge_config(forge_dir, exclusive_config_file):
             "branch_name": "master",
         },
         "recipe_dir": "recipe",
+        "test_reports": None,
+        "coverage_report": None
     }
 
     # An older conda-smithy used to have some files which should no longer exist,

--- a/conda_smithy/feedstock_content/build-locally.py
+++ b/conda_smithy/feedstock_content/build-locally.py
@@ -12,6 +12,8 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    os.environ["UPLOAD_TEST_REPORTS"] = "False"
+    os.environ["UPLOAD_COVERAGE_REPORT"] = "False"
 
 
 def run_docker_build(ns):

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -15,6 +15,8 @@ jobs:
       {{ config_name }}:
         CONFIG: {{ config_name }}
         UPLOAD_PACKAGES: {{ upload }}
+        UPLOAD_TEST_REPORTS: "False"
+        UPLOAD_COVERAGE_REPORT: "False"
         DOCKER_IMAGE: {{ config["docker_image"][-1] }}
     {%- endif %}
     {%- endfor %}

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -15,6 +15,8 @@ jobs:
       {{ config_name }}:
         CONFIG: {{ config_name }}
         UPLOAD_PACKAGES: {{ upload }}
+        UPLOAD_TEST_REPORTS: "False"
+        UPLOAD_COVERAGE_REPORT: "False"
     {%- endif %}
     {%- endfor %}
 

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -69,7 +69,7 @@ jobs:
 
   - script: |
       source activate base
-      conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+      conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml --keep-old-work
     displayName: Build recipe
 
   - script: |

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -16,6 +16,8 @@ jobs:
         CONFIG: {{ config_name}}
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: {{ upload }}
+        UPLOAD_TEST_REPORTS: "False"
+        UPLOAD_COVERAGE_REPORT: "False"
     {%- endif %}
     {%- endfor %}
   steps:
@@ -104,4 +106,3 @@ jobs:
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
-

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -33,10 +33,19 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
+    --keep-old-work
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
     upload_package "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+fi
+
+if [[ "${UPLOAD_TEST_REPORTS}" != "False" ]]; then
+    echo "how do you upload test reports?"
+fi
+
+if [[ "${UPLOAD_COVERAGE_REPORT}" != "False" ]]; then
+  echo "how do you upload coverage report?"
 fi
 
 touch "/home/conda/feedstock_root/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -57,6 +57,8 @@ if [ -z "${CI}" ]; then
 fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
+export UPLOAD_TEST_REPORTS="${UPLOAD_TEST_REPORTS:-False}"
+export UPLOAD_COVERAGE_REPORT="${UPLOAD_COVERAGE_REPORT:-False}"
 {{ docker.executable }} run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:ro,z \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
@@ -64,6 +66,8 @@ export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
            -e BINSTAR_TOKEN \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \
+           -e UPLOAD_TEST_REPORTS \
+           -e UPLOAD_COVERAGE_REPORT \
            -e CI \
            $DOCKER_IMAGE \
            {{ docker.command }} \

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -35,6 +35,6 @@ set -e
 
 make_build_number ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
 
-conda build ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+conda build ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml --keep-old-work
 
 upload_package ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -26,14 +26,14 @@ matrix:
   include:
     {%- for config_name, platform, upload, config in configs | sort %}
     {%- if platform.startswith("osx") %}
-    - env: CONFIG={{ config_name }} UPLOAD_PACKAGES={{ upload }} PLATFORM={{ platform }}
+    - env: CONFIG={{ config_name }} UPLOAD_PACKAGES={{ upload }} PLATFORM={{ platform }} UPLOAD_TEST_REPORTS=False UPLOAD_COVERAGE_REPORT=False
       os: osx
       osx_image: {{ travis.get('osx_image', 'xcode9.4') }}
     {%- elif platform.startswith("linux-ppc64le") %}
-    - env: CONFIG={{ config_name }} UPLOAD_PACKAGES={{ upload }} PLATFORM={{ platform }} DOCKER_IMAGE={{ config["docker_image"][-1] }}
+    - env: CONFIG={{ config_name }} UPLOAD_PACKAGES={{ upload }} PLATFORM={{ platform }} UPLOAD_TEST_REPORTS=False UPLOAD_COVERAGE_REPORT=False DOCKER_IMAGE={{ config["docker_image"][-1] }}
       os: linux-ppc64le
     {%- elif platform.startswith("linux-64") %}
-    - env: CONFIG={{ config_name }} UPLOAD_PACKAGES={{ upload }} PLATFORM={{ platform }} DOCKER_IMAGE={{ config["docker_image"][-1] }}
+    - env: CONFIG={{ config_name }} UPLOAD_PACKAGES={{ upload }} PLATFORM={{ platform }} UPLOAD_TEST_REPORTS=False UPLOAD_COVERAGE_REPORT=False DOCKER_IMAGE={{ config["docker_image"][-1] }}
       os: linux
     {%- endif %}
 {% endfor %}


### PR DESCRIPTION
**Checklist**
* [ ] Added a ``news`` entry

**Issues**
- fixes #1076 

**Why**
The hope is this will become something that can capture structured data test reports, increasing the maintainer value of running actual tests. It seems the de facto format is the `xunit`/`junit` ~~standard~~, supported by at least circle, azure and appveyor.

Python-town has about ~200 packages that are presently running tests with `pytest` or `nosetests` and a smattering from other language groups. For `make check`-style tests, the situation is less clear, though there appear to be various _x_`2junit` utilities... who knows.

**Implementation sketch**
- [ ] decide where to put report info, thinking in `meta.yaml`:
```yaml
extras:
  test_reports:
    - *.xunit.xml   # relative to test dir?
```
- [ ] decide where to render report info (still learning)
- [x] run `conda-build` with `--keep-old-work`
- [ ] find `test_reports` and `coverage_reports` after build
- [ ] use ci-specific tools to upload test results, tagged with config
  - [ ] [azure](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/publish-test-results?view=azure-devops&tabs=yaml#publishtestindocker)
  - [ ] [circle](https://circleci.com/docs/2.0/collect-test-data/)
  - [ ] [appveyor](https://www.appveyor.com/docs/running-tests/#uploading-xml-test-results)
- [ ] render test badges to README

Thinking on this more, I probably won't do coverage on this first go-around, as its value is a bit dubious, and often hard to reconcile between multiple platforms... something like codecov or coveralls would be better, but even that might not be worth the work.

I can't promise I'll be able to drive this home quickly, as I'm mostly nights-and-weekends of late. Happy or any insights/discussion!