### PR TITLE
Fix checking in pyc files

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1138,7 +1138,7 @@ def render_README(jinja_env, forge_config, forge_dir):
 
 def copy_feedstock_content(forge_dir):
     feedstock_content = os.path.join(conda_forge_content, "feedstock_content")
-    copytree(feedstock_content, forge_dir, "README")
+    copytree(feedstock_content, forge_dir, ("README", "__pycache__"))
 
 
 def _load_forge_config(forge_dir, exclusive_config_file):

--- a/news/pyc.rst
+++ b/news/pyc.rst
@@ -1,0 +1,4 @@
+**Fixed:**
+
+* Fixed checking in .pyc files
+


### PR DESCRIPTION
When conda_smithy is installed `feedstock_content/build-locally.py` is
compiled to python bytecode. When conda-smithy copies that folder
to the feedstock and git adds the content, the bytecode files are also
checked in the feedstock git repo.

This commit ignore .pyc files when copying the tree

Fixes https://github.com/conda-forge/conda-smithy/issues/1082