### PR TITLE
bump conda version check (from 4.7 to 5.0)

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -472,7 +472,7 @@ def main():
         args = parser.parse_args()
 
     # Check conda version for compatibility
-    CONDA_VERSION_MAX = "4.7"
+    CONDA_VERSION_MAX = "5.0"
     if LooseVersion(conda.__version__) >= LooseVersion(CONDA_VERSION_MAX):
         print(
             "You appear to be using conda {}, but conda-smithy {}\n"

--- a/news/conda_version_bump.rst
+++ b/news/conda_version_bump.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* bumped conda version check in CLI to 5.0 (from 4.7)
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I did a successful rerender with conda 4.7.5.  I don't think this needs to be constrained so tightly.  We'll be much more conservative about semver under my watch, so the next major version should be appropriate here.