### PR TITLE
requirements: update to conda-build>=3.18.3

### DIFF
--- a/conda_smithy.recipe/meta.yaml
+++ b/conda_smithy.recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   run:
     - python >=3.6
     - conda >=4.2
-    - conda-build >=3.1.2
+    - conda-build >=3.18.3
     - jinja2
     - requests
     - pycrypto

--- a/conda_smithy/variant_algebra.py
+++ b/conda_smithy/variant_algebra.py
@@ -17,7 +17,7 @@ import yaml
 import toolz
 from conda_build.utils import ensure_list
 import conda_build.variants as variants
-from conda.models.version import VersionOrder
+from conda.exports import VersionOrder
 from conda_build.config import Config
 from functools import partial
 

--- a/news/update-3.4.1-deps.rst
+++ b/news/update-3.4.1-deps.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* requirements: update to conda-build>=3.18.3
+* fix non-public conda import, use conda.exports
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

Dependency update addresses:
- https://github.com/conda-forge/conda-smithy-feedstock/pull/156
- https://github.com/conda-forge/pingouin-feedstock/pull/7

Changed `VersionOrder` import to `conda.exports` as other `conda` modules are to be considered non-public.