### PR TITLE
Mark generated files as such to github

### DIFF
--- a/conda_smithy/feedstock_content/.gitattributes
+++ b/conda_smithy/feedstock_content/.gitattributes
@@ -5,3 +5,18 @@
 meta.yaml text eol=lf
 build.sh text eol=lf
 bld.bat text eol=crlf
+
+# github helper pieces to make some files not show up in diffs automatically
+.azure-pipelines/* linguist-generated=true
+.circleci/* linguist-generated=true
+.github/* linguist-generated=true
+.travis/* linguist-generated=true
+.appveyor.yml linguist-generated=true 
+.gitattributes linguist-generated=true 
+.gitignore linguist-generated=true
+.travis.yml linguist-generated=true
+LICENSE.txt linguist-generated=true 
+README.md linguist-generated=true 
+azure-pipelines.yml linguist-generated=true
+build-locally.py linguist-generated=true
+shippable.yml linguist-generated=true

--- a/news/mark-as-generated.rst
+++ b/news/mark-as-generated.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Mark generated files as generated so that github collapses them by deafult in diffs.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
According to https://github.com/github/linguist#generated-code we can mark our generated portions and github will collapse them
in pull requests automatically.  This should reduce mouse wheel fatigue for conda-forge reviewers.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->