### PR TITLE
consolidate yaml loader in utils.yaml

### DIFF
--- a/conda_smithy/ci_register.py
+++ b/conda_smithy/ci_register.py
@@ -4,8 +4,6 @@ import requests
 import time
 import sys
 
-import ruamel.yaml
-
 from . import github
 from .utils import update_conda_forge_config
 

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -290,7 +290,6 @@ class AddAzureBuildId(Subcommand):
         )
 
         build_info = azure_ci_utils.get_build_id(repo, config)
-        import ruamel.yaml
 
         from .utils import update_conda_forge_config
         with update_conda_forge_config(args.feedstock_directory) as config:

--- a/conda_smithy/feedstocks.py
+++ b/conda_smithy/feedstocks.py
@@ -8,10 +8,10 @@ from git import Repo, GitCommandError
 from github import Github
 
 from . import github as smithy_github
-from .utils import render_meta_yaml
+from .utils import render_meta_yaml, yaml
 
 
-def feedstock_repos(gh_organization):
+def feedstock_repos(gh_organization='conda-forge'):
     token = smithy_github.gh_token()
     gh = Github(token)
     org = gh.get_organization(gh_organization)
@@ -209,10 +209,7 @@ def yaml_meta(content):
     Read the contents of meta.yaml into a ruamel.yaml document.
 
     """
-    yaml = ruamel.yaml.load(
-        render_meta_yaml(content), ruamel.yaml.RoundTripLoader
-    )
-    return yaml
+    return yaml.load(render_meta_yaml(content))
 
 
 def feedstocks_yaml(

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -10,7 +10,6 @@ import os
 import re
 
 import github
-import ruamel.yaml
 
 from conda_build.metadata import (
     ensure_valid_license_family,
@@ -18,7 +17,7 @@ from conda_build.metadata import (
 )
 import conda_build.conda_interface
 
-from .utils import render_meta_yaml
+from .utils import render_meta_yaml, yaml
 
 
 FIELDS = copy.deepcopy(cbfields)
@@ -533,7 +532,7 @@ def main(recipe_dir, conda_forge=False, return_hints=False):
 
     with io.open(recipe_meta, "rt") as fh:
         content = render_meta_yaml("".join(fh))
-        meta = ruamel.yaml.load(content, ruamel.yaml.RoundTripLoader)
+        meta = yaml.load(content)
     results, hints = lintify(meta, recipe_dir, conda_forge)
     if return_hints:
         return results, hints

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -1,13 +1,20 @@
 import shutil
 import tempfile
 import jinja2
-import six
 import datetime
 import time
 import os
 from collections import defaultdict
 from contextlib import contextmanager
+
 import ruamel.yaml
+
+
+# define global yaml API
+# roundrip-loader and allowing duplicate keys
+# for handling # [filter] / # [not filter]
+yaml = ruamel.yaml.YAML(typ='rt')
+yaml.allow_duplicate_keys = True
 
 
 @contextmanager
@@ -68,7 +75,7 @@ def update_conda_forge_config(feedstock_directory):
     forge_yaml = os.path.join(feedstock_directory, "conda-forge.yml")
     if os.path.exists(forge_yaml):
         with open(forge_yaml, "r") as fh:
-            code = ruamel.yaml.load(fh, ruamel.yaml.RoundTripLoader)
+            code = yaml.load(fh)
     else:
         code = {}
 
@@ -79,4 +86,4 @@ def update_conda_forge_config(feedstock_directory):
     yield code
 
     with open(forge_yaml, "w") as fh:
-        fh.write(ruamel.yaml.dump(code, Dumper=ruamel.yaml.RoundTripDumper))
+        fh.write(yaml.dump(code))

--- a/news/duplicate-yaml-keys.rst
+++ b/news/duplicate-yaml-keys.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* recipe-lint compatibility with ruamel.yaml 0.16


### PR DESCRIPTION
- use simpler ruamel.yaml API
- explicitly allow duplicate keys, required for ruamel.yaml 0.16

This fixes recipe-lint failures caused by the recent [disallowing of duplicate keys in 0.16](https://yaml.readthedocs.io/en/latest/api.html#duplicate-keys)

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->