### PR TITLE
Mock PY_VER for recipe check

### DIFF
--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -14,7 +14,7 @@ import ruamel.yaml
 # define global yaml API
 # roundrip-loader and allowing duplicate keys
 # for handling # [filter] / # [not filter]
-yaml = ruamel.yaml.YAML(typ='rt')
+yaml = ruamel.yaml.YAML(typ="rt")
 yaml.allow_duplicate_keys = True
 
 
@@ -61,8 +61,8 @@ def render_meta_yaml(text):
         )
     )
     mockos = MockOS()
-    py_ver = '.'.join([str(v) for v in sys.version_info[:2]])
-    context = {'os':mockos, 'environ':mockos.environ, 'PY_VER':py_ver}
+    py_ver = ".".join([str(v) for v in sys.version_info[:2]])
+    context = {"os": mockos, "environ": mockos.environ, "PY_VER": py_ver}
     content = env.from_string(text).render(context)
     return content
 

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -61,7 +61,7 @@ def render_meta_yaml(text):
         )
     )
     mockos = MockOS()
-    py_ver = ".".join([str(v) for v in sys.version_info[:2]])
+    py_ver = "3.7"
     context = {"os": mockos, "environ": mockos.environ, "PY_VER": py_ver}
     content = env.from_string(text).render(context)
     return content

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -4,6 +4,7 @@ import jinja2
 import datetime
 import time
 import os
+import sys
 from collections import defaultdict
 from contextlib import contextmanager
 
@@ -60,7 +61,9 @@ def render_meta_yaml(text):
         )
     )
     mockos = MockOS()
-    content = env.from_string(text).render(os=mockos, environ=mockos.environ)
+    py_ver = '.'.join([str(v) for v in sys.version_info[:2]])
+    context = {'os':mockos, 'environ':mockos.environ, 'PY_VER':py_ver}
+    content = env.from_string(text).render(context)
     return content
 
 

--- a/news/mock-py_ver.rst
+++ b/news/mock-py_ver.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Mock PY_VER in recipe check


### PR DESCRIPTION
PY_VER is provided for the recipe check. This variable is defined:

  https://docs.conda.io/projects/conda-build/en/latest/user-guide/environment-variables.html

and a reasonable default based on sys.version_info is provided based on:

  https://github.com/conda/conda-build/blob/dd74b17f4e7cb4286fe9a403895f9d34feb8e071/conda_build/environ.py#L49-L53

Fixes #1112