### PR TITLE
Extend linter to check shell scripts via shellcheck

### DIFF
--- a/conda_smithy.recipe/meta.yaml
+++ b/conda_smithy.recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - conda-forge-pinning
     - vsts-python-api
     - toolz
+    - shellcheck
 
 test:
   requires:

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -558,6 +558,9 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
             cmd + shell_scripts,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            env={
+                "PATH": os.getenv("PATH")
+            },  # exclude other env variables to protect against token leakage
         )
         sc_stdout, _ = p.communicate()
 

--- a/news/shellcheck_hints.rst
+++ b/news/shellcheck_hints.rst
@@ -1,0 +1,5 @@
+**Added:**
+
+* Use shellcheck to lint *.sh files and provide findings as hints. Can be
+  enabled via conda-forge.yaml (shellcheck: enabled: True), default (no entry)
+  is False.

--- a/news/shellcheck_hints.rst
+++ b/news/shellcheck_hints.rst
@@ -1,5 +1,5 @@
 **Added:**
 
-* Use shellcheck to lint *.sh files and provide findings as hints. Can be
+* Use shellcheck to lint ``*.sh`` files and provide findings as hints. Can be
   enabled via conda-forge.yaml (shellcheck: enabled: True), default (no entry)
   is False.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ ruamel.yaml
 conda-forge-pinning
 vsts-python-api
 toolz
+shellcheck

--- a/tests/conda-forge.yml
+++ b/tests/conda-forge.yml
@@ -1,0 +1,2 @@
+shellcheck:
+  enabled: True

--- a/tests/recipes/build_script_with_findings/build.sh
+++ b/tests/recipes/build_script_with_findings/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -o errtrace -o pipefail -o errexit
+
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/ascii
+  mv * $PREFIX/lib/R/library/ascii
+  if [[ $target_platform == osx-64 ]]; then
+    pushd $PREFIX
+      for libdir in lib/R/lib lib/R/modules lib/R/library lib/R/bin/exec sysroot/usr/lib; do
+        pushd $libdir || exit 1
+          for SHARED_LIB in $(find . -type f -iname "*.dylib" -or -iname "*.so" -or -iname "R"); do
+            echo "fixing SHARED_LIB $SHARED_LIB"
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5.0-MRO/Resources/lib/libR.dylib "$PREFIX"/lib/R/lib/libR.dylib $SHARED_LIB || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libR.dylib "$PREFIX"/lib/R/lib/libR.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/local/clang4/lib/libomp.dylib "$PREFIX"/lib/libomp.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/local/gfortran/lib/libgfortran.3.dylib "$PREFIX"/lib/libgfortran.3.dylib $SHARED_LIB || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libquadmath.0.dylib "$PREFIX"/lib/libquadmath.0.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/local/gfortran/lib/libquadmath.0.dylib "$PREFIX"/lib/libquadmath.0.dylib $SHARED_LIB || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libgfortran.3.dylib "$PREFIX"/lib/libgfortran.3.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libgcc_s.1.dylib "$PREFIX"/lib/libgcc_s.1.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libiconv.2.dylib "$PREFIX"/sysroot/usr/lib/libiconv.2.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libncurses.5.4.dylib "$PREFIX"/sysroot/usr/lib/libncurses.5.4.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libicucore.A.dylib "$PREFIX"/sysroot/usr/lib/libicucore.A.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libexpat.1.dylib "$PREFIX"/lib/libexpat.1.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libcurl.4.dylib "$PREFIX"/lib/libcurl.4.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libc++.1.dylib "$PREFIX"/lib/libc++.1.dylib $SHARED_LIB || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libc++.1.dylib "$PREFIX"/lib/libc++.1.dylib $SHARED_LIB || true
+          done
+        popd
+      done
+    popd
+  fi
+fi

--- a/tests/recipes/build_script_with_findings/meta.yaml
+++ b/tests/recipes/build_script_with_findings/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: test_cb3_multiple_sources
+  version: 1.0
+
+source:
+  - url: https://storage.googleapis.com/golang/go{{ version }}.src.tar.gz
+    sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  host:
+    - toolchain
+
+test:
+  commands:
+    - echo 'works'
+
+about:
+  home: home
+  summary: summary
+  license: Creative Commons
+
+extra:
+  recipe-maintainers:
+    - gopher

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -903,6 +903,14 @@ class Test_linter(unittest.TestCase):
             lints,
         )
 
+    def test_build_sh_with_shellcheck_findings(self):
+        lints, hints = linter.main(
+            os.path.join(_thisdir, "recipes", "build_script_with_findings"),
+            return_hints=True,
+        )
+        assert "Whenever possible fix all shellcheck findings" in hints[0]
+        assert len(hints) == (50 + 2)
+
 
 @pytest.mark.cli
 class TestCLI_recipe_lint(unittest.TestCase):


### PR DESCRIPTION
closes https://github.com/conda-forge/conda-smithy/issues/118

As the shell script syntax dates back to the 1970s, there are plenty of pitfalls and old types of syntax that won't get removed due to backward compatibility, which shellcheck can help to find for us.

This could be especially useful as it lints the build.sh, the important companion to the meta.yaml to
build complex recipes.

This is ready for comments.

Potential TODOs:
- [x] a test
- [x] a news entry
- [x] restrict to max XX lines of output, as it can create lots of noise
- [x] custom flags / disable via `conda-forge.yaml` including test

Outside this PR
- [x] make the build.sh templates of conda-build (e.g. part of the cran skeleton) shellcheck clean.
- [ ] ~~teach bot/conda-forge-admin `shellcheck ... *.sh --f diff | git apply`~~ not reliable 