### PR TITLE
build on drive C:\ on Windows

### DIFF
--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -14,7 +14,7 @@ jobs:
     {%- if platform.startswith('win') %}
       {{ config_name }}:
         CONFIG: {{ config_name}}
-        CONDA_BLD_PATH: D:\\bld\\
+        CONDA_BLD_PATH: C:\\bld\\
         UPLOAD_PACKAGES: {{ upload }}
     {%- endif %}
     {%- endfor %}


### PR DESCRIPTION
@mariusvniekerk does this makes sense as a global option? Right now we have to hack into the azure file and do this for `qgis`, `qt`, and other heavy weight builds that fill the drive `D:\`.