### PR TITLE
fix render_README crash when azure api returns 404

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1183,6 +1183,7 @@ def render_README(jinja_env, forge_config, forge_dir):
                     project_name=forge_config["azure"]["project_name"],
                     repo=forge_config["github"]["repo_name"]
                 ))
+            resp.raise_for_status()
             build_def = resp.json()["value"][0]
             forge_config['azure']['build_id'] = build_def['id']
         except (IndexError, IOError):

--- a/news/render_README.rst
+++ b/news/render_README.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix render_README crash when azure api returns 404
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
If `user_or_org` is set and no azure account is set up for the specified name, the request returns a 404 response, which leads to an uncaught `JSONDecodeError`.

This fix raises an `HTTPError` which is caught by the except clause's `IOError`.

