### PR TITLE
CI: Add a missing displayName for Windows Azure template

### DIFF
--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -77,7 +77,7 @@ jobs:
       export UPLOAD_ON_BRANCH="{{ upload_on_branch }}"
 {%- endif %}
       upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
-    displayName: Upload recipe
+    displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
     condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -105,6 +105,7 @@ jobs:
         set "UPLOAD_ON_BRANCH={{ upload_on_branch }}"
 {%- endif %}
         upload_package .\ .\{{ recipe_dir }} .ci_support\%CONFIG%.yaml
+      displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))


### PR DESCRIPTION
This PR names the uploading step of the Azure Pipelines job for Windows.
Also, it corrects the name of the corresponding step for OSX as uploading happens for a built package, not a recipe.
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
