### PR TITLE
ENH: remove .github/CODEOWNERS if recipe maintainers list is empty

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1195,13 +1195,15 @@ def render_README(jinja_env, forge_config, forge_dir):
     with write_file(target_fname) as fh:
         fh.write(template.render(**forge_config))
 
+    code_owners_file = os.path.join(forge_dir, ".github", "CODEOWNERS")
     if len(forge_config["maintainers"]) > 0:
-        code_owners_file = os.path.join(forge_dir, ".github", "CODEOWNERS")
         with write_file(code_owners_file) as fh:
             line = "*"
             for maintainer in forge_config["maintainers"]:
                 line = line + " @" + maintainer
             fh.write(line)
+    else:
+        remove_file_or_dir(code_owners_file)
 
 
 def copy_feedstock_content(forge_config, forge_dir):

--- a/news/remove_github_codeowners.rst
+++ b/news/remove_github_codeowners.rst
@@ -1,0 +1,5 @@
+**Added:**
+
+* conda-smithy will remove the ``.github/CODEOWNERS`` file in case the recipe
+  maintainers list is empty
+


### PR DESCRIPTION
This PR allows to remove the `.github/CODEOWNERS` file in case the recipe maintainers list is empty (pretty useful for our work https://github.com/nsls-ii-forge where the entire team is considered as maintainers, so no need to put it to the recipes).
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
