### PR TITLE
make azure default provider for windows

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1241,7 +1241,7 @@ def _load_forge_config(forge_dir, exclusive_config_file):
         "provider": {
             "linux": "azure",
             "osx": "azure",
-            "win": "appveyor",
+            "win": "azure",
             # Following platforms are disabled by default
             "linux_aarch64": None,
             "linux_ppc64le": None,


### PR DESCRIPTION
it's currently appveyor, but conda-forge-ci-setup assumes azure is default and fails (https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/62) if appveyor is still present even though it's the default.

Example failure: https://ci.appveyor.com/project/conda-forge/nodejs-feedstock/builds/27712210


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->