### PR TITLE
Drone update and apply black to fix formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
     - "[ ! -f ${HOME}/cache/miniconda.sh ] && wget https://repo.continuum.io/miniconda/Miniconda${PYTHON}-latest-Linux-x86_64.sh -O ${HOME}/cache/miniconda.sh || :"
     - bash ${HOME}/cache/miniconda.sh -b -p ${CONDA_INSTALL_LOCN}
     - source ${CONDA_INSTALL_LOCN}/bin/activate base
-    - conda install -n base conda
+    - conda install --yes -n base conda
 
     # Re-use the packages in the cache, and download any new ones into that location.
     - rm -rf ${CONDA_INSTALL_LOCN}/pkgs && ln -s ${HOME}/cache/pkgs ${CONDA_INSTALL_LOCN}/pkgs

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ install:
     - mkdir -p ${HOME}/cache/pkgs
     - "[ ! -f ${HOME}/cache/miniconda.sh ] && wget https://repo.continuum.io/miniconda/Miniconda${PYTHON}-latest-Linux-x86_64.sh -O ${HOME}/cache/miniconda.sh || :"
     - bash ${HOME}/cache/miniconda.sh -b -p ${CONDA_INSTALL_LOCN}
-    - source ${CONDA_INSTALL_LOCN}/bin/activate root
-    - conda update --yes --quiet conda
+    - source ${CONDA_INSTALL_LOCN}/bin/activate base
+    - conda install -n base conda
 
     # Re-use the packages in the cache, and download any new ones into that location.
     - rm -rf ${CONDA_INSTALL_LOCN}/pkgs && ln -s ${HOME}/cache/pkgs ${CONDA_INSTALL_LOCN}/pkgs

--- a/conda_smithy/azure_ci_utils.py
+++ b/conda_smithy/azure_ci_utils.py
@@ -92,7 +92,7 @@ def get_service_endpoint(config: AzureConfig = default_config):
 
 
 def get_queues(
-    config: AzureConfig = default_config
+    config: AzureConfig = default_config,
 ) -> typing.List[TaskAgentQueue]:
     aclient = TaskAgentClient(config.instance_base_url, config.credentials)
     return aclient.get_agent_queues(config.project_name)

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -543,7 +543,10 @@ def _render_ci_provider(
         )
 
         # Get the combined variants from normal variant locations prior to running migrations
-        combined_variant_spec, _ = conda_build.variants.get_package_combined_spec(
+        (
+            combined_variant_spec,
+            _,
+        ) = conda_build.variants.get_package_combined_spec(
             os.path.join(forge_dir, "recipe"), config=config
         )
 
@@ -885,9 +888,12 @@ def render_circle(jinja_env, forge_config, forge_dir):
         "osx": [os.path.join(forge_dir, ".circleci", "run_osx_build.sh")],
     }
 
-    platforms, archs, keep_noarchs, upload_packages = _get_platforms_of_provider(
-        "circle", forge_config
-    )
+    (
+        platforms,
+        archs,
+        keep_noarchs,
+        upload_packages,
+    ) = _get_platforms_of_provider("circle", forge_config)
 
     return _render_ci_provider(
         "circle",
@@ -970,9 +976,12 @@ def render_travis(jinja_env, forge_config, forge_dir):
     """
     )
 
-    platforms, archs, keep_noarchs, upload_packages = _get_platforms_of_provider(
-        "travis", forge_config
-    )
+    (
+        platforms,
+        archs,
+        keep_noarchs,
+        upload_packages,
+    ) = _get_platforms_of_provider("travis", forge_config)
 
     extra_platform_files = {
         "linux": [
@@ -1023,9 +1032,12 @@ def render_appveyor(jinja_env, forge_config, forge_dir):
     )
     template_filename = "appveyor.yml.tmpl"
 
-    platforms, archs, keep_noarchs, upload_packages = _get_platforms_of_provider(
-        "appveyor", forge_config
-    )
+    (
+        platforms,
+        archs,
+        keep_noarchs,
+        upload_packages,
+    ) = _get_platforms_of_provider("appveyor", forge_config)
 
     return _render_ci_provider(
         "appveyor",
@@ -1078,9 +1090,12 @@ def render_azure(jinja_env, forge_config, forge_dir):
     template_filename = "azure-pipelines.yml.tmpl"
     fast_finish_text = ""
 
-    platforms, archs, keep_noarchs, upload_packages = _get_platforms_of_provider(
-        "azure", forge_config
-    )
+    (
+        platforms,
+        archs,
+        keep_noarchs,
+        upload_packages,
+    ) = _get_platforms_of_provider("azure", forge_config)
 
     return _render_ci_provider(
         "azure",
@@ -1128,9 +1143,12 @@ def render_drone(jinja_env, forge_config, forge_dir):
     template_filename = "drone.yml.tmpl"
     fast_finish_text = ""
 
-    platforms, archs, keep_noarchs, upload_packages = _get_platforms_of_provider(
-        "drone", forge_config
-    )
+    (
+        platforms,
+        archs,
+        keep_noarchs,
+        upload_packages,
+    ) = _get_platforms_of_provider("drone", forge_config)
 
     return _render_ci_provider(
         "drone",

--- a/conda_smithy/templates/drone.yml.tmpl
+++ b/conda_smithy/templates/drone.yml.tmpl
@@ -19,7 +19,7 @@ steps:
       from_secret: BINSTAR_TOKEN
   {%- if 'linux' in platform %}
   commands:
-    - export FEEDSTOCK_ROOT="$CI_WORKSPACE"
+    - export FEEDSTOCK_ROOT="${CI_WORKSPACE:-$(pwd)}"
     - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
     - export CI=drone
     - export GIT_BRANCH="$DRONE_BRANCH"

--- a/conda_smithy/templates/drone.yml.tmpl
+++ b/conda_smithy/templates/drone.yml.tmpl
@@ -19,7 +19,7 @@ steps:
       from_secret: BINSTAR_TOKEN
   {%- if 'linux' in platform %}
   commands:
-    - export FEEDSTOCK_ROOT="${CI_WORKSPACE:-$(pwd)}"
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
     - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
     - export CI=drone
     - export GIT_BRANCH="$DRONE_BRANCH"

--- a/news/drone-fixup.rst
+++ b/news/drone-fixup.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Drone changed their service to no longer send the same environment variables.  Falling back to pwd

--- a/news/drone-fixup.rst
+++ b/news/drone-fixup.rst
@@ -1,3 +1,3 @@
 **Fixed:**
 
-* Drone changed their service to no longer send the same environment variables.  Falling back to pwd
+* Drone changed their service to no longer send the same environment variables. Changed to use ``$DRONE_WORKSPACE``.


### PR DESCRIPTION
Contains #1185 with black applied to fix formatting. Looks like they now add trailing commas in multiline tuples/function argument declarations.

Update: I've moved to using `$DRONE_WORKSPACE` instead of `$CI_WORKSPACE`. It's not documented but appears to be the official supported variable: https://discourse.drone.io/t/feature-request-drone-project-dir-env-variable/4804/2

Checklist
* [x] Added a ``news`` entry