### PR TITLE
run conda render prior to build

### DIFF
--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -67,6 +67,11 @@ jobs:
 
   - script: |
       source activate base
+      conda render ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+    displayName: Render recipe
+
+  - script: |
+      source activate base
       conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
     displayName: Build recipe
 

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -83,6 +83,12 @@ jobs:
       continueOnError: true
       displayName: remove strawberryperl
 
+    - script: |
+        conda.exe render recipe -m .ci_support\%CONFIG%.yaml
+      displayName: Render recipe
+      env:
+        PYTHONUNBUFFERED: 1
+
     # Special cased version setting some more things!
     - script: |
         conda.exe build recipe -m .ci_support\%CONFIG%.yaml

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -32,6 +32,9 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+conda render "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -35,6 +35,7 @@ set -e
 
 make_build_number ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
 
-conda build ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+conda render ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+conda build  ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
 
 upload_package ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml

--- a/news/render.rst
+++ b/news/render.rst
@@ -1,0 +1,3 @@
+**Added:**
+
+* Include `conda render` output prior to build for easier manual verification of final recipes.


### PR DESCRIPTION
makes it easier to verify that the recipe (especially dependencies and run_exports) is as expected

otherwise, dependencies and run_exports cannot be verified until after upload

cross-ref conda-build feature request that would make this obsolete: conda/conda-build#3798

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->