### PR TITLE
Test re-rendering is run in a feedstock

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1357,10 +1357,10 @@ def _load_forge_config(forge_dir, exclusive_config_file):
     if not os.path.exists(forge_yml):
         raise RuntimeError(
             f"Could not find `conda-forge.yml` in {forge_dir}."
-             " Either you are not rerendering inside the recipe instead of"
-             " inside the feedstock root (likely) or there's no `conda-forge.yml` in"
-             " the feedstock root (unlikely). Add an empty `conda-forge.yml` file in"
-             " feedstock root if it's the latter."
+            " Either you are not rerendering inside the recipe instead of"
+            " inside the feedstock root (likely) or there's no `conda-forge.yml` in"
+            " the feedstock root (unlikely). Add an empty `conda-forge.yml` file in"
+            " feedstock root if it's the latter."
         )
     else:
         with open(forge_yml, "r") as fh:

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1562,6 +1562,10 @@ def main(
 
     forge_dir = os.path.abspath(forge_file_directory)
 
+    # Check we are in a feedstock
+    if not os.path.exists(os.path.join(forge_dir, "conda-forge.yml")):
+        raise RuntimeError(f"Could not find `conda-forge.yml` in {forge_dir}.")
+
     if exclusive_config_file is not None:
         exclusive_config_file = os.path.join(forge_dir, exclusive_config_file)
         if not os.path.exists(exclusive_config_file):

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1355,7 +1355,13 @@ def _load_forge_config(forge_dir, exclusive_config_file):
 
     forge_yml = os.path.join(forge_dir, "conda-forge.yml")
     if not os.path.exists(forge_yml):
-        warnings.warn("No conda-forge.yml found. Assuming default options.")
+        raise RuntimeError(
+            f"Could not find `conda-forge.yml` in {forge_dir}."
+             " Either you are not rerendering inside the recipe instead of"
+             " inside the feedstock root (likely) or there's no `conda-forge.yml` in"
+             " the feedstock root (unlikely). Add an empty `conda-forge.yml` file in"
+             " feedstock root if it's the latter."
+        )
     else:
         with open(forge_yml, "r") as fh:
             file_config = list(yaml.safe_load_all(fh))[0] or {}
@@ -1561,10 +1567,6 @@ def main(
     check_version_uptodate(r, "conda-smithy", __version__, error_on_warn)
 
     forge_dir = os.path.abspath(forge_file_directory)
-
-    # Check we are in a feedstock
-    if not os.path.exists(os.path.join(forge_dir, "conda-forge.yml")):
-        raise RuntimeError(f"Could not find `conda-forge.yml` in {forge_dir}.")
 
     if exclusive_config_file is not None:
         exclusive_config_file = os.path.join(forge_dir, exclusive_config_file)

--- a/news/validate_feedstock_rerender.rst
+++ b/news/validate_feedstock_rerender.rst
@@ -1,0 +1,3 @@
+**Added:**
+
+* Check that the current working directory is a feedstock before re-rendering.


### PR DESCRIPTION
Make sure that `conda-forge.yml` exists in the current working directory before re-rendering. If it does not exist, raise a `RuntimeError`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
