### PR TITLE
Render noarch python with highest versio n of python

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -15,6 +15,7 @@ import conda_build.utils
 import conda_build.variants
 import conda_build.conda_interface
 import conda_build.render
+from conda_build.metadata import MetaData
 
 from copy import deepcopy
 
@@ -567,6 +568,14 @@ def _render_ci_provider(
         migrated_combined_variant_spec = migrate_combined_spec(
             combined_variant_spec, forge_dir, config
         )
+
+        # If we have a noarch: python recipe., prefer the most recent python versio
+        m = MetaData(
+            os.path.join(forge_dir, "recipe"),
+            config=config
+        )
+        if (m.noarch_python) or (m.noarch == 'python'):
+            migrated_combined_variant_spec["python"] = list(reversed(migrated_combined_variant_spec["python"]))
 
         metas = conda_build.api.render(
             os.path.join(forge_dir, "recipe"),

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -61,6 +61,24 @@ def test_noarch_runs_on_azure(noarch_recipe, jinja_env):
     assert len(os.listdir(matrix_dir)) == 1
 
 
+def test_noarch_python_renders_with_py3(noarch_recipe, jinja_env):
+    cnfgr_fdstk.render_azure(
+        jinja_env=jinja_env,
+        forge_config=noarch_recipe.config,
+        forge_dir=noarch_recipe.recipe,
+    )
+    # this configuration should be run
+    assert noarch_recipe.config["azure"]["enabled"]
+    matrix_dir = os.path.join(noarch_recipe.recipe, ".ci_support")
+    assert os.path.isdir(matrix_dir)
+    # single matrix entry - readme is generated later in main function
+    variants = os.listdir(matrix_dir)
+    assert len(variants) == 1
+    with open(Path(matrix_dir) / variants[0]) as fo:
+        variant = yaml.safe_load(fo)
+        assert variant['python'] != ['2.7']
+
+
 def test_r_skips_appveyor(r_recipe, jinja_env):
     r_recipe.config["provider"]["win"] = "appveyor"
     cnfgr_fdstk.render_appveyor(


### PR DESCRIPTION
Variant files are implicitly assumed to be sorted in conda-forge.
By ensuring that we rearrange the variant for python, we can generally
achieve the outcome that the generated variant file will be using python
3.x instead of 2.x

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
