### PR TITLE
Add CMAKE_GENERATOR to always_keep_keys 

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -293,6 +293,7 @@ def _collapse_subpackage_variants(list_of_metas, root_path):
     always_keep_keys = {
         "zip_keys",
         "pin_run_as_build",
+        "CMAKE_GENERATOR",
         "MACOSX_DEPLOYMENT_TARGET",
         "macos_min_version",
         "macos_machine",

--- a/news/always_keep_keys-CMAKE_GENERATOR.rst
+++ b/news/always_keep_keys-CMAKE_GENERATOR.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Add CMAKE_GENERATOR to the keys which are always included in the build variants.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
Checklist
* [x] Added a ``news`` entry

To make [`Use NMake instead of visual studio generator`](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/216) take effect, we would need this PR and https://github.com/AnacondaRecipes/aggregate/pull/182 .

@isuruf , does it makes sense to set always override `CMAKE_GENERATOR` (for the platforms, i.e., `win`, it is defined for in `conda-forge-pinning`)?