### PR TITLE
Unset Azure Boost_ROOT

### DIFF
--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -65,8 +65,10 @@ jobs:
         updateConda: false
       displayName: Install conda-build and activate environment
 
-    - script: set PYTHONUNBUFFERED=1
+    - script: set "Boost_ROOT="
 
+    - script: set PYTHONUNBUFFERED=1
+    
     # Configure the VM
     - script: setup_conda_rc .\ .\{{ recipe_dir }} .\.ci_support\%CONFIG%.yaml
 

--- a/news/boost_root_azure_win.rst
+++ b/news/boost_root_azure_win.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Unset Azure Boost_ROOT windows environment variable


### PR DESCRIPTION
Azure felt it was a good idea to set Boost_ROOT env var to their preinstalled image, which can interfere with our cmake builds.
https://developercommunity.visualstudio.com/idea/556787/stop-setting-boost-root-as-predefined-variable.html

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
