### PR TITLE
Fix crash of linter when package in run section starts with python in nameing

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -462,12 +462,12 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
             filtered_host_reqs = [
                 req
                 for req in host_reqs
-                if req == str(language) or req.startswith(str(language))
+                if req.partition(" ")[0] == str(language)
             ]
             filtered_run_reqs = [
                 req
                 for req in run_reqs
-                if req == str(language) or req.startswith(str(language))
+                if req.partition(" ")[0] == str(language)
             ]
             if filtered_host_reqs and not filtered_run_reqs:
                 lints.append(

--- a/news/fix_linter_bug.rst
+++ b/news/fix_linter_bug.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fix crash of linter when requirements contains packages that start with python in name

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -918,6 +918,12 @@ class Test_linter(unittest.TestCase):
             lints,
         )
 
+        meta = {
+            "requirements": {"host": ["python"], "run": ["python-dateutil"]}
+        }
+        # Test that this doesn't crash
+        lints, hints = linter.lintify(meta)
+
     def test_r_base_requirements(self):
         meta = {"requirements": {"host": ["r-base >=3.5"]}}
         lints, hints = linter.lintify(meta)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

Fixes #1231

Todo:
* [x] Add test that shows fix