### PR TITLE
macOS-10.15 image for Azure Pipelines

### DIFF
--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.14
+    vmImage: macOS-10.15
   timeoutInMinutes: {{ azure.timeout_minutes }}
   strategy:
     maxParallel: 8

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.13
+    vmImage: macOS-10.14
   timeoutInMinutes: {{ azure.timeout_minutes }}
   strategy:
     maxParallel: 8

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.15
+    vmImage: macOS-latest
   timeoutInMinutes: {{ azure.timeout_minutes }}
   strategy:
     maxParallel: 8

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-latest
+    vmImage: macOS-10.14
   timeoutInMinutes: {{ azure.timeout_minutes }}
   strategy:
     maxParallel: 8

--- a/news/macos_10.14.rst
+++ b/news/macos_10.14.rst
@@ -1,3 +1,0 @@
-**Changed:**
-
-* Updated the version of macOS image to 10.14 for Azure Pipelines.

--- a/news/macos_10.14.rst
+++ b/news/macos_10.14.rst
@@ -1,0 +1,3 @@
+**Changed:**
+
+* Updated the version of macOS image to 10.14 for Azure Pipelines.

--- a/news/macos_10.15.rst
+++ b/news/macos_10.15.rst
@@ -1,0 +1,3 @@
+**Changed:**
+
+* Updated the version of macOS image to 10.15 for Azure Pipelines.


### PR DESCRIPTION
This PR resolves the upcoming discontinuation of the macOS-10.13 image on Azure Pipelines (March 23, 2020). See https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/ for details. Thanks to @dmgav for pointing to the issue.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
