### PR TITLE
If conda-forge-pinning package has migrations installed, use those

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1596,6 +1596,10 @@ def make_jinja_env(feedstock_directory):
 
 
 def get_migrations_in_dir(migrations_root):
+    """
+    Given a directory, return the migrations as a mapping
+    from the timestamp to a tuple of (filename, migration_number)
+    """
     res = {}
     for fn in glob.glob(os.path.join(migrations_root, "*.yaml")):
         with open(fn, "r") as f:
@@ -1613,6 +1617,25 @@ def get_migrations_in_dir(migrations_root):
 
 
 def set_migration_fns(forge_dir, forge_config):
+    """
+    This will calculate the migration files and set migration_fns
+    in the forge_config as a list.
+    
+    First, this will look in the conda-forge-pinning (CFP) package
+    to see if it has migrations installed. If not, the filenames of
+    the migrations the feedstock are used.
+    
+    Then, this will look at migrations in the feedstock and if they
+    have a timestamp and doesn't exist in the CFP package, the
+    migration is considered old and deleted.
+    
+    Then, if there is a migration in the feedstock with the same
+    migration number and timestamp in the CFP package, the filename of
+    the migration in the CFP package is used.
+    
+    Finally, if none of the conditions are met for a migration in the
+    feedstock, the filename of the migration in the feedstock is used.
+    """
     exclusive_config_file = forge_config["exclusive_config_file"]
     cfp_migrations_dir = os.path.join(
         os.path.dirname(exclusive_config_file),

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1600,17 +1600,23 @@ def get_migrations_in_dir(migrations_root):
     for fn in glob.glob(os.path.join(migrations_root, "*.yaml")):
         with open(fn, "r") as f:
             contents = f.read()
-            migration_yaml = yaml.load(contents, Loader=yaml.loader.BaseLoader) or {}
+            migration_yaml = (
+                yaml.load(contents, Loader=yaml.loader.BaseLoader) or {}
+            )
             # Use a object as timestamp to not delete it
-            ts = migration_yaml.get('migrator_ts', object())
+            ts = migration_yaml.get("migrator_ts", object())
             res[ts] = fn
     return res
 
 
 def set_migration_fns(forge_dir, forge_config):
     exclusive_config_file = forge_config["exclusive_config_file"]
-    cfp_migrations_dir = os.path.join(os.path.dirname(exclusive_config_file),
-                                      "share", "conda-forge", "migrations")
+    cfp_migrations_dir = os.path.join(
+        os.path.dirname(exclusive_config_file),
+        "share",
+        "conda-forge",
+        "migrations",
+    )
 
     migrations_root = os.path.join(forge_dir, ".ci_support", "migrations")
     migrations_in_feedstock = get_migrations_in_dir(migrations_root)

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -9,6 +9,7 @@ import warnings
 from collections import OrderedDict
 import copy
 import hashlib
+import time
 
 import conda_build.api
 import conda_build.utils
@@ -486,7 +487,7 @@ def _get_fast_finish_script(
     return fast_finish_text
 
 
-def migrate_combined_spec(combined_spec, forge_dir, config):
+def migrate_combined_spec(combined_spec, forge_dir, config, forge_config):
     """CFEP-9 variant migrations
 
     Apply the list of migrations configurations to the build (in the correct sequence)
@@ -499,10 +500,9 @@ def migrate_combined_spec(combined_spec, forge_dir, config):
 
     """
     combined_spec = combined_spec.copy()
-    migrations_root = os.path.join(
-        forge_dir, ".ci_support", "migrations", "*.yaml"
-    )
-    migrations = glob.glob(migrations_root)
+    if "migration_fns" not in forge_config:
+        migrations = set_migration_fns(forge_dir, forge_config)
+    migrations = forge_config["migration_fns"]
 
     from .variant_algebra import parse_variant, variant_add
 
@@ -510,6 +510,7 @@ def migrate_combined_spec(combined_spec, forge_dir, config):
         (fn, parse_variant(open(fn, "r").read(), config=config))
         for fn in migrations
     ]
+
     migration_variants.sort(
         key=lambda fn_v: (fn_v[1]["migration_ts"], fn_v[0])
     )
@@ -566,7 +567,7 @@ def _render_ci_provider(
         )
 
         migrated_combined_variant_spec = migrate_combined_spec(
-            combined_variant_spec, forge_dir, config
+            combined_variant_spec, forge_dir, config, forge_config,
         )
 
         metas = conda_build.api.render(
@@ -1594,6 +1595,47 @@ def make_jinja_env(feedstock_directory):
     return env
 
 
+def get_migrations_in_dir(migrations_root):
+    res = {}
+    for fn in glob.glob(os.path.join(migrations_root, "*.yaml")):
+        with open(fn, "r") as f:
+            contents = f.read()
+            migration_yaml = yaml.load(contents, Loader=yaml.loader.BaseLoader) or {}
+            # Use a object as timestamp to not delete it
+            ts = migration_yaml.get('migrator_ts', object())
+            res[ts] = fn
+    return res
+
+
+def set_migration_fns(forge_dir, forge_config):
+    exclusive_config_file = forge_config["exclusive_config_file"]
+    cfp_migrations_dir = os.path.join(os.path.dirname(exclusive_config_file),
+                                      "share", "conda-forge", "migrations")
+
+    migrations_root = os.path.join(forge_dir, ".ci_support", "migrations")
+    migrations_in_feedstock = get_migrations_in_dir(migrations_root)
+
+    if not os.path.exists(cfp_migrations_dir):
+        forge_config["migration_fns"] = list(migrations_in_feedstock.values())
+        return
+
+    migrations_in_cfp = get_migrations_in_dir(cfp_migrations_dir)
+
+    result = []
+    for ts, fn in migrations_in_feedstock.items():
+        if type(ts) == object:
+            # This file doesn't have a timestamp. Use it as it is.
+            result.append(fn)
+        elif ts in migrations_in_cfp:
+            # Use the one from cfp.
+            result.append(migrations_in_cfp[ts])
+        else:
+            # Delete this as this migration is over.
+            remove_file(fn)
+    forge_config["migration_fns"] = result
+    return
+
+
 def main(
     forge_file_directory,
     no_check_uptodate=False,
@@ -1655,6 +1697,7 @@ def main(
         set_exe_file(os.path.join(forge_dir, "build-locally.py"))
     clear_variants(forge_dir)
     clear_scripts(forge_dir)
+    set_migration_fns(forge_dir, config)
 
     # the order of these calls appears to matter
     render_info = []

--- a/conda_smithy/variant_algebra.py
+++ b/conda_smithy/variant_algebra.py
@@ -41,7 +41,7 @@ def parse_variant(
     Parameters
     ----------
     variant_file_content : str
-        The loaded vaiant contents.  This can include selectors etc.
+        The loaded variant contents.  This can include selectors etc.
     """
     if not config:
         from conda_build.config import Config

--- a/news/migration_cfp.rst
+++ b/news/migration_cfp.rst
@@ -1,0 +1,28 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* If conda-forge-pinning package has migrations installed, use those
+  migration yaml files instead of the ones from the feedstock if the
+  timestamp field match and remove if the migration yaml has a
+  timestamp and there's no corresponding one in conda-forge-pinning
+  which indicates that the migration is over.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,6 +245,7 @@ about:
     ) as fh:
         fh.write(
             """
+migrator_ts: 1
 zlib:
     - 1000
 """

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -447,7 +447,7 @@ def test_migrator_recipe(recipe_migration_cfep9, jinja_env):
         assert variant["zlib"] == ["1000"]
 
 
-def test_migrator_cfp(recipe_migration_cfep9, jinja_env):
+def test_migrator_cfp_override(recipe_migration_cfep9, jinja_env):
     cfp_file = recipe_migration_cfep9.config["exclusive_config_file"]
     cfp_migration_dir = os.path.join(
         os.path.dirname(cfp_file), "share", "conda-forge", "migrations"
@@ -478,6 +478,27 @@ def test_migrator_cfp(recipe_migration_cfep9, jinja_env):
     ) as fo:
         variant = yaml.safe_load(fo)
         assert variant["zlib"] == ["1001"]
+
+
+def test_migrator_delete_old(recipe_migration_cfep9, jinja_env):
+    cfp_file = recipe_migration_cfep9.config["exclusive_config_file"]
+    cfp_migration_dir = os.path.join(
+        os.path.dirname(cfp_file), "share", "conda-forge", "migrations"
+    )
+    os.makedirs(cfp_migration_dir, exist_ok=True)
+    cnfgr_fdstk.render_azure(
+        jinja_env=jinja_env,
+        forge_config=recipe_migration_cfep9.config,
+        forge_dir=recipe_migration_cfep9.recipe,
+    )
+    assert not os.path.exists(
+        os.path.join(
+            recipe_migration_cfep9.recipe,
+            ".ci_support",
+            "migrations",
+            "zlib.yaml",
+        )
+    )
 
 
 def test_migrator_downgrade_recipe(

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -428,6 +428,7 @@ def test_readme_has_terminating_newline(noarch_recipe, jinja_env):
         readme_file.seek(-1, os.SEEK_END)
         assert readme_file.read() == b"\n"
 
+
 def test_migrator_recipe(recipe_migration_cfep9, jinja_env):
     cnfgr_fdstk.render_azure(
         jinja_env=jinja_env,
@@ -448,12 +449,14 @@ def test_migrator_recipe(recipe_migration_cfep9, jinja_env):
 
 def test_migrator_cfp(recipe_migration_cfep9, jinja_env):
     cfp_file = recipe_migration_cfep9.config["exclusive_config_file"]
-    cfp_migration_dir = os.path.join(os.path.dirname(cfp_file), "share",
-                           "conda-forge", "migrations")
+    cfp_migration_dir = os.path.join(
+        os.path.dirname(cfp_file), "share", "conda-forge", "migrations"
+    )
     os.makedirs(cfp_migration_dir, exist_ok=True)
     with open(os.path.join(cfp_migration_dir, "zlib2.yaml"), "w") as f:
         f.write(
-            textwrap.dedent("""
+            textwrap.dedent(
+                """
                 migrator_ts: 1
                 zlib:
                    - 1001

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -485,6 +485,14 @@ def test_migrator_delete_old(recipe_migration_cfep9, jinja_env):
     cfp_migration_dir = os.path.join(
         os.path.dirname(cfp_file), "share", "conda-forge", "migrations"
     )
+    assert os.path.exists(
+        os.path.join(
+            recipe_migration_cfep9.recipe,
+            ".ci_support",
+            "migrations",
+            "zlib.yaml",
+        )
+    )
     os.makedirs(cfp_migration_dir, exist_ok=True)
     cnfgr_fdstk.render_azure(
         jinja_env=jinja_env,


### PR DESCRIPTION
instead of the ones from the feedstock if the
timestamp field match and remove if the migration yaml has a
timestamp and there's no corresponding one in conda-forge-pinning
which indicates that the migration is over.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
