### PR TITLE
Fix rerender using hardcoded 'recipe' instead of forge_config["recipe_dir"]

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -447,7 +447,7 @@ def _get_fast_finish_script(
     fast_finish_script = ""
     tooling_branch = "master"
 
-    cfbs_fpath = os.path.join(forge_dir, "recipe", "ff_ci_pr_build.py")
+    cfbs_fpath = os.path.join(forge_dir, forge_config["recipe_dir"], "ff_ci_pr_build.py")
     if provider_name == "appveyor":
         if os.path.exists(cfbs_fpath):
             fast_finish_script = "{recipe_dir}\\ff_ci_pr_build".format(
@@ -563,7 +563,7 @@ def _render_ci_provider(
             combined_variant_spec,
             _,
         ) = conda_build.variants.get_package_combined_spec(
-            os.path.join(forge_dir, "recipe"), config=config
+            os.path.join(forge_dir, forge_config["recipe_dir"]), config=config
         )
 
         migrated_combined_variant_spec = migrate_combined_spec(
@@ -571,7 +571,7 @@ def _render_ci_provider(
         )
 
         metas = conda_build.api.render(
-            os.path.join(forge_dir, "recipe"),
+            os.path.join(forge_dir, forge_config["recipe_dir"]),
             platform=platform,
             arch=arch,
             ignore_system_variants=True,
@@ -673,7 +673,7 @@ def _render_ci_provider(
         # If the recipe supplies its own upload_or_check_non_existence.py upload script,
         # we use it instead of the global one.
         upload_fpath = os.path.join(
-            forge_dir, "recipe", "upload_or_check_non_existence.py"
+            forge_dir, forge_config["recipe_dir"], "upload_or_check_non_existence.py"
         )
         if os.path.exists(upload_fpath):
             if provider_name == "circle":
@@ -733,15 +733,15 @@ def _get_build_setup_line(forge_dir, platform, forge_config):
     # we use it instead of the global one.
     if platform == "linux":
         cfbs_fpath = os.path.join(
-            forge_dir, "recipe", "run_conda_forge_build_setup_linux"
+            forge_dir, forge_config["recipe_dir"], "run_conda_forge_build_setup_linux"
         )
     elif platform == "win":
         cfbs_fpath = os.path.join(
-            forge_dir, "recipe", "run_conda_forge_build_setup_win.bat"
+            forge_dir, forge_config["recipe_dir"], "run_conda_forge_build_setup_win.bat"
         )
     else:
         cfbs_fpath = os.path.join(
-            forge_dir, "recipe", "run_conda_forge_build_setup_osx"
+            forge_dir, forge_config["recipe_dir"], "run_conda_forge_build_setup_osx"
         )
 
     build_setup = ""
@@ -793,7 +793,7 @@ def _get_build_setup_line(forge_dir, platform, forge_config):
 def _circle_specific_setup(jinja_env, forge_config, forge_dir, platform):
 
     if platform == "linux":
-        yum_build_setup = generate_yum_requirements(forge_dir)
+        yum_build_setup = generate_yum_requirements(forge_config, forge_dir)
         if yum_build_setup:
             forge_config["yum_build_setup"] = yum_build_setup
 
@@ -824,10 +824,10 @@ def _circle_specific_setup(jinja_env, forge_config, forge_dir, platform):
         set_exe_file(target_fname, True)
 
 
-def generate_yum_requirements(forge_dir):
+def generate_yum_requirements(forge_config, forge_dir):
     # If there is a "yum_requirements.txt" file in the recipe, we honour it.
     yum_requirements_fpath = os.path.join(
-        forge_dir, "recipe", "yum_requirements.txt"
+        forge_dir, forge_config["recipe_dir"], "yum_requirements.txt"
     )
     yum_build_setup = ""
     if os.path.exists(yum_requirements_fpath):
@@ -952,7 +952,7 @@ def _travis_specific_setup(jinja_env, forge_config, forge_dir, platform):
     template_files = platform_templates.get(platform, [])
 
     if platform == "linux":
-        yum_build_setup = generate_yum_requirements(forge_dir)
+        yum_build_setup = generate_yum_requirements(forge_config, forge_dir)
         if yum_build_setup:
             forge_config["yum_build_setup"] = yum_build_setup
 
@@ -1091,7 +1091,7 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
     build_setup = _get_build_setup_line(forge_dir, platform, forge_config)
 
     if platform == "linux":
-        yum_build_setup = generate_yum_requirements(forge_dir)
+        yum_build_setup = generate_yum_requirements(forge_config, forge_dir)
         if yum_build_setup:
             forge_config["yum_build_setup"] = yum_build_setup
 
@@ -1128,6 +1128,8 @@ def render_azure(jinja_env, forge_config, forge_dir, return_metadata=False):
         upload_packages,
     ) = _get_platforms_of_provider("azure", forge_config)
 
+    logger.debug("azure platforms retreived")
+
     return _render_ci_provider(
         "azure",
         jinja_env=jinja_env,
@@ -1156,7 +1158,7 @@ def _drone_specific_setup(jinja_env, forge_config, forge_dir, platform):
     build_setup = _get_build_setup_line(forge_dir, platform, forge_config)
 
     if platform == "linux":
-        yum_build_setup = generate_yum_requirements(forge_dir)
+        yum_build_setup = generate_yum_requirements(forge_config, forge_dir)
         if yum_build_setup:
             forge_config["yum_build_setup"] = yum_build_setup
 
@@ -1209,7 +1211,7 @@ def render_README(jinja_env, forge_config, forge_dir, render_info=None):
     # pull out relevant metadata from rendering
     try:
         metas = conda_build.api.render(
-            os.path.join(forge_dir, "recipe"),
+            os.path.join(forge_dir, forge_config["recipe_dir"]),
             exclusive_config_file=forge_config["exclusive_config_file"],
             permit_undefined_jinja=True,
             finalize=False,
@@ -1389,10 +1391,20 @@ def _load_forge_config(forge_dir, exclusive_config_file):
         with open(forge_yml, "r") as fh:
             file_config = list(yaml.safe_load_all(fh))[0] or {}
 
+        # The config is just the union of the defaults, and the overriden
+        # values.
+        for key, value in file_config.items():
+            # Deal with dicts within dicts.
+            if isinstance(value, dict):
+                config_item = config.setdefault(key, value)
+                config_item.update(value)
+            else:
+                config[key] = value
+
         # check for conda-smithy 2.x matrix which we can't auto-migrate
         # to conda_build_config
         if file_config.get("matrix") and not os.path.exists(
-            os.path.join(forge_dir, "recipe", "conda_build_config.yaml")
+            os.path.join(forge_dir, config["recipe_dir"], "conda_build_config.yaml")
         ):
             raise ValueError(
                 "Cannot rerender with matrix in conda-forge.yml."
@@ -1408,16 +1420,6 @@ def _load_forge_config(forge_dir, exclusive_config_file):
                 "Setting docker image in conda-forge.yml is removed now."
                 " Use conda_build_config.yaml instead"
             )
-
-        # The config is just the union of the defaults, and the overriden
-        # values.
-        for key, value in file_config.items():
-            # Deal with dicts within dicts.
-            if isinstance(value, dict):
-                config_item = config.setdefault(key, value)
-                config_item.update(value)
-            else:
-                config[key] = value
 
     # An older conda-smithy used to have some files which should no longer exist,
     # remove those now.
@@ -1698,7 +1700,9 @@ def main(
 
     error_on_warn = False if no_check_uptodate else True
     index = conda_build.conda_interface.get_index(channel_urls=["conda-forge"])
+    logger.debug("Beginning Resolving Index")
     r = conda_build.conda_interface.Resolve(index)
+    logger.debug("Index rendered")
 
     # Check that conda-smithy is up-to-date
     check_version_uptodate(r, "conda-smithy", __version__, error_on_warn)
@@ -1728,6 +1732,7 @@ def main(
             )
 
     env = make_jinja_env(forge_dir)
+    logger.debug("env rendered")
 
     copy_feedstock_content(config, forge_dir)
     if os.path.exists(os.path.join(forge_dir, "build-locally.py")):
@@ -1735,24 +1740,30 @@ def main(
     clear_variants(forge_dir)
     clear_scripts(forge_dir)
     set_migration_fns(forge_dir, config)
+    logger.debug("migration fns set")
 
     # the order of these calls appears to matter
     render_info = []
     render_info.append(
         render_circle(env, config, forge_dir, return_metadata=True)
     )
+    logger.debug("circle rendered")
     render_info.append(
         render_travis(env, config, forge_dir, return_metadata=True)
     )
+    logger.debug("travis rendered")
     render_info.append(
         render_appveyor(env, config, forge_dir, return_metadata=True)
     )
+    logger.debug("appveyor rendered")
     render_info.append(
         render_azure(env, config, forge_dir, return_metadata=True)
     )
+    logger.debug("azure rendered")
     render_info.append(
         render_drone(env, config, forge_dir, return_metadata=True)
     )
+    logger.debug("drone rendered")
     # put azure first just in case
     tmp = render_info[0]
     render_info[0] = render_info[-2]

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -447,7 +447,9 @@ def _get_fast_finish_script(
     fast_finish_script = ""
     tooling_branch = "master"
 
-    cfbs_fpath = os.path.join(forge_dir, forge_config["recipe_dir"], "ff_ci_pr_build.py")
+    cfbs_fpath = os.path.join(
+        forge_dir, forge_config["recipe_dir"], "ff_ci_pr_build.py"
+    )
     if provider_name == "appveyor":
         if os.path.exists(cfbs_fpath):
             fast_finish_script = "{recipe_dir}\\ff_ci_pr_build".format(
@@ -673,7 +675,9 @@ def _render_ci_provider(
         # If the recipe supplies its own upload_or_check_non_existence.py upload script,
         # we use it instead of the global one.
         upload_fpath = os.path.join(
-            forge_dir, forge_config["recipe_dir"], "upload_or_check_non_existence.py"
+            forge_dir,
+            forge_config["recipe_dir"],
+            "upload_or_check_non_existence.py",
         )
         if os.path.exists(upload_fpath):
             if provider_name == "circle":
@@ -733,15 +737,21 @@ def _get_build_setup_line(forge_dir, platform, forge_config):
     # we use it instead of the global one.
     if platform == "linux":
         cfbs_fpath = os.path.join(
-            forge_dir, forge_config["recipe_dir"], "run_conda_forge_build_setup_linux"
+            forge_dir,
+            forge_config["recipe_dir"],
+            "run_conda_forge_build_setup_linux",
         )
     elif platform == "win":
         cfbs_fpath = os.path.join(
-            forge_dir, forge_config["recipe_dir"], "run_conda_forge_build_setup_win.bat"
+            forge_dir,
+            forge_config["recipe_dir"],
+            "run_conda_forge_build_setup_win.bat",
         )
     else:
         cfbs_fpath = os.path.join(
-            forge_dir, forge_config["recipe_dir"], "run_conda_forge_build_setup_osx"
+            forge_dir,
+            forge_config["recipe_dir"],
+            "run_conda_forge_build_setup_osx",
         )
 
     build_setup = ""
@@ -1404,7 +1414,9 @@ def _load_forge_config(forge_dir, exclusive_config_file):
         # check for conda-smithy 2.x matrix which we can't auto-migrate
         # to conda_build_config
         if file_config.get("matrix") and not os.path.exists(
-            os.path.join(forge_dir, config["recipe_dir"], "conda_build_config.yaml")
+            os.path.join(
+                forge_dir, config["recipe_dir"], "conda_build_config.yaml"
+            )
         ):
             raise ValueError(
                 "Cannot rerender with matrix in conda-forge.yml."

--- a/news/1254_rerender_missing_recipe_dir_from_config.rst
+++ b/news/1254_rerender_missing_recipe_dir_from_config.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Rerender use forge_config["recipe_dir"] instead of hardcoding "recipe" (#1254)
+
+**Security:**
+
+* <news item>
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ markers =
     legacy_circle: Test designed to run as if prior to the azure migration
     legacy_travis: Test designed to run as if prior to the azure migration
     legacy_appveyor: Test designed to run as if prior to the azure migration
+    cli: CLI tests outside of test/test_cli.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,17 +46,20 @@ def testing_workdir(tmpdir, request):
 
     return str(tmpdir)
 
+@pytest.fixture(scope="function")
+def recipe_dirname():
+    return "recipe"
 
 @pytest.fixture(scope="function")
-def config_yaml(testing_workdir):
+def config_yaml(testing_workdir, recipe_dirname):
     config = {"python": ["2.7", "3.5"], "r_base": ["3.3.2", "3.4.2"]}
-    os.makedirs(os.path.join(testing_workdir, "recipe"))
+    os.makedirs(os.path.join(testing_workdir, recipe_dirname))
     with open(os.path.join(testing_workdir, "config.yaml"), "w") as f:
         f.write("docker:\n")
         f.write("  fallback_image:\n")
         f.write("  - centos:6\n")
     with open(
-        os.path.join(testing_workdir, "recipe", "default_config.yaml"), "w"
+        os.path.join(testing_workdir, recipe_dirname, "default_config.yaml"), "w"
     ) as f:
         yaml.dump(config, f, default_flow_style=False)
         # need selectors, so write these more manually
@@ -87,24 +90,24 @@ def config_yaml(testing_workdir):
     ) as f:
         f.write("echo dummy file")
     with open(
-        os.path.join(testing_workdir, "recipe", "short_config.yaml"), "w"
+        os.path.join(testing_workdir, recipe_dirname, "short_config.yaml"), "w"
     ) as f:
         config = {"python": ["2.7"]}
         yaml.dump(config, f, default_flow_style=False)
     with open(
-        os.path.join(testing_workdir, "recipe", "long_config.yaml"), "w"
+        os.path.join(testing_workdir, recipe_dirname, "long_config.yaml"), "w"
     ) as f:
         config = {"python": ["2.7", "3.5", "3.6"]}
         yaml.dump(config, f, default_flow_style=False)
     with open(os.path.join(testing_workdir, "conda-forge.yml"), "w") as f:
-        config = {"upload_on_branch": "foo-branch"}
+        config = {"upload_on_branch": "foo-branch", "recipe_dir": recipe_dirname}
         yaml.dump(config, f, default_flow_style=False)
     return testing_workdir
 
 
 @pytest.fixture(scope="function")
-def noarch_recipe(config_yaml, request):
-    with open(os.path.join(config_yaml, "recipe", "meta.yaml"), "w") as fh:
+def noarch_recipe(config_yaml, recipe_dirname, request):
+    with open(os.path.join(config_yaml, recipe_dirname, "meta.yaml"), "w") as fh:
         fh.write(
             """
 package:
@@ -124,7 +127,7 @@ requirements:
         _load_forge_config(
             config_yaml,
             exclusive_config_file=os.path.join(
-                config_yaml, "recipe", "default_config.yaml"
+                config_yaml, recipe_dirname, "default_config.yaml"
             ),
         ),
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,9 +46,11 @@ def testing_workdir(tmpdir, request):
 
     return str(tmpdir)
 
+
 @pytest.fixture(scope="function")
 def recipe_dirname():
     return "recipe"
+
 
 @pytest.fixture(scope="function")
 def config_yaml(testing_workdir, recipe_dirname):
@@ -59,7 +61,8 @@ def config_yaml(testing_workdir, recipe_dirname):
         f.write("  fallback_image:\n")
         f.write("  - centos:6\n")
     with open(
-        os.path.join(testing_workdir, recipe_dirname, "default_config.yaml"), "w"
+        os.path.join(testing_workdir, recipe_dirname, "default_config.yaml"),
+        "w",
     ) as f:
         yaml.dump(config, f, default_flow_style=False)
         # need selectors, so write these more manually
@@ -100,14 +103,19 @@ def config_yaml(testing_workdir, recipe_dirname):
         config = {"python": ["2.7", "3.5", "3.6"]}
         yaml.dump(config, f, default_flow_style=False)
     with open(os.path.join(testing_workdir, "conda-forge.yml"), "w") as f:
-        config = {"upload_on_branch": "foo-branch", "recipe_dir": recipe_dirname}
+        config = {
+            "upload_on_branch": "foo-branch",
+            "recipe_dir": recipe_dirname,
+        }
         yaml.dump(config, f, default_flow_style=False)
     return testing_workdir
 
 
 @pytest.fixture(scope="function")
 def noarch_recipe(config_yaml, recipe_dirname, request):
-    with open(os.path.join(config_yaml, recipe_dirname, "meta.yaml"), "w") as fh:
+    with open(
+        os.path.join(config_yaml, recipe_dirname, "meta.yaml"), "w"
+    ) as fh:
         fh.write(
             """
 package:

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -6,6 +6,7 @@ import copy
 import yaml
 import textwrap
 
+
 def test_noarch_skips_appveyor(noarch_recipe, jinja_env):
     noarch_recipe.config["provider"]["win"] = "appveyor"
     cnfgr_fdstk.render_appveyor(
@@ -47,7 +48,7 @@ def test_noarch_runs_on_circle(noarch_recipe, jinja_env):
     assert len(os.listdir(matrix_dir)) == 1
 
 
-@pytest.mark.parametrize('recipe_dirname', ['recipe', 'custom_recipe_dir'])
+@pytest.mark.parametrize("recipe_dirname", ["recipe", "custom_recipe_dir"])
 def test_noarch_runs_on_azure(noarch_recipe, jinja_env):
     cnfgr_fdstk.render_azure(
         jinja_env=jinja_env,

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -6,7 +6,6 @@ import copy
 import yaml
 import textwrap
 
-
 def test_noarch_skips_appveyor(noarch_recipe, jinja_env):
     noarch_recipe.config["provider"]["win"] = "appveyor"
     cnfgr_fdstk.render_appveyor(
@@ -48,6 +47,7 @@ def test_noarch_runs_on_circle(noarch_recipe, jinja_env):
     assert len(os.listdir(matrix_dir)) == 1
 
 
+@pytest.mark.parametrize('recipe_dirname', ['recipe', 'custom_recipe_dir'])
 def test_noarch_runs_on_azure(noarch_recipe, jinja_env):
     cnfgr_fdstk.render_azure(
         jinja_env=jinja_env,


### PR DESCRIPTION
Fixes #1254

Checklist
* [X] Added a ``news`` entry

I added a test for the case I ran into and confirmed that my changes fix it.  Going to let CI rerun the tests across all other platforms.

When making the fix, I did find other places where `conda_smithy/configure_feedstock.py` was hardcoding "recipe" and I changed them to use `forge_config["recipe_dir"]` instead (in one case, I had to add `forge_config` to a method signature).

I also registered `@pytest.mark.cli` in this to quiet down a pytest warning.  If you guys don't like code-gardening lumped in with PR's, I can break that out separately.
