### PR TITLE
ENH Provide a mechanism to pass extra arguments to `docker run`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,17 @@ conda-smithy Change Log
 
 .. current developments
 
+**Changed:**
+
+* Allow people to pass extra arguments to ``docker run`` by setting
+  ``$CONDA_FORGE_DOCKER_RUN_ARGS``.
+
+**Authors:**
+
+* Peter K. G. Williams
+
+
+
 v3.6.16
 ====================
 

--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -52,8 +52,10 @@ mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
 
+# Allow people to specify extra default arguments to `docker run` (e.g. `--rm`)
+DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
-    DOCKER_RUN_ARGS="-it "
+    DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"


### PR DESCRIPTION
If you're running builds locally, there's no need to keep the individual containers around. Even moreso in a CI environment.

You could perhaps call this a "fix".

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
