### PR TITLE
Clear `.azure-pipelines` directory before render

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1140,6 +1140,7 @@ def render_azure(jinja_env, forge_config, forge_dir, return_metadata=False):
 
     logger.debug("azure platforms retreived")
 
+    remove_file_or_dir(os.path.join(forge_dir, ".azure-pipelines"))
     return _render_ci_provider(
         "azure",
         jinja_env=jinja_env,

--- a/news/azure_cleanup.rst
+++ b/news/azure_cleanup.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Re-rendering now cleans old contents in ``.azure-pipelines``
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
To make sure that stray contents are not left in `.azure-pipelines`, delete the directory and its contents before rendering. That way any files that are not generated by rendering will be removed. Ones that are generated by rendering will be added anyways, which will negate this behavior.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
