### PR TITLE
REF use one osx script with miniforge

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -989,7 +989,8 @@ def _render_template_exe_files(
                     import difflib
 
                     logger.debug(
-                        "diff:\n%s" % (
+                        "diff:\n%s"
+                        % (
                             "\n".join(
                                 difflib.unified_diff(
                                     old_file_contents.splitlines(),

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -923,7 +923,7 @@ def render_circle(jinja_env, forge_config, forge_dir, return_metadata=False):
             os.path.join(forge_dir, ".scripts", "run_docker_build.sh"),
             os.path.join(forge_dir, ".scripts", "build_steps.sh"),
         ],
-        "osx": [os.path.join(forge_dir, ".circleci", "run_osx_build.sh")],
+        "osx": [os.path.join(forge_dir, ".scripts", "run_osx_build.sh")],
     }
 
     (
@@ -1038,7 +1038,7 @@ def render_travis(jinja_env, forge_config, forge_dir, return_metadata=False):
         keep_noarchs=keep_noarchs,
         platform_specific_setup=_travis_specific_setup,
         upload_packages=upload_packages,
-        extra_platform_files=extra_platform_files,
+        # extra_platform_files=extra_platform_files,
         return_metadata=return_metadata,
     )
 
@@ -1581,13 +1581,13 @@ def clear_variants(forge_dir):
 
 
 def get_common_scripts(forge_dir):
-    for old_file in ["run_docker_build.sh", "build_steps.sh"]:
+    for old_file in ["run_docker_build.sh", "build_steps.sh", "run_osx_build.sh"]:
         yield os.path.join(forge_dir, ".scripts", old_file)
 
 
 def clear_scripts(forge_dir):
     for folder in [".azure-pipelines", ".circleci", ".drone", ".travis"]:
-        for old_file in ["run_docker_build.sh", "build_steps.sh"]:
+        for old_file in ["run_docker_build.sh", "build_steps.sh", "run_osx_build.sh"]:
             remove_file(os.path.join(forge_dir, folder, old_file))
 
 

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -991,13 +991,16 @@ def _render_template_exe_files(
                 if old_file_contents != new_file_contents:
                     import difflib
                     import sys
+
                     print("diff:")
-                    sys.stdout.writelines(difflib.unified_diff(
-                        old_file_contents.splitlines(),
-                        new_file_contents.splitlines(),
-                        fromfile=target_fname,
-                        tofile=target_fname,
-                    ))
+                    sys.stdout.writelines(
+                        difflib.unified_diff(
+                            old_file_contents.splitlines(),
+                            new_file_contents.splitlines(),
+                            fromfile=target_fname,
+                            tofile=target_fname,
+                        )
+                    )
                     raise RuntimeError(
                         "Same file {} is rendered twice with different contents".format(
                             target_fname
@@ -1103,7 +1106,10 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
             ".scripts/build_steps.sh",
             ".azure-pipelines/azure-pipelines-linux.yml",
         ],
-        "osx": [".azure-pipelines/azure-pipelines-osx.yml", ".scripts/run_osx_build.sh"],
+        "osx": [
+            ".azure-pipelines/azure-pipelines-osx.yml",
+            ".scripts/run_osx_build.sh",
+        ],
         "win": [".azure-pipelines/azure-pipelines-win.yml"],
     }
     template_files = platform_templates.get(platform, [])
@@ -1576,13 +1582,27 @@ def clear_variants(forge_dir):
 
 
 def get_common_scripts(forge_dir):
-    for old_file in ["run_docker_build.sh", "build_steps.sh", "run_osx_build.sh"]:
+    for old_file in [
+        "run_docker_build.sh",
+        "build_steps.sh",
+        "run_osx_build.sh",
+    ]:
         yield os.path.join(forge_dir, ".scripts", old_file)
 
 
 def clear_scripts(forge_dir):
-    for folder in [".azure-pipelines", ".circleci", ".drone", ".travis", ".scripts"]:
-        for old_file in ["run_docker_build.sh", "build_steps.sh", "run_osx_build.sh"]:
+    for folder in [
+        ".azure-pipelines",
+        ".circleci",
+        ".drone",
+        ".travis",
+        ".scripts",
+    ]:
+        for old_file in [
+            "run_docker_build.sh",
+            "build_steps.sh",
+            "run_osx_build.sh",
+        ]:
             remove_file(os.path.join(forge_dir, folder, old_file))
 
 

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -817,7 +817,7 @@ def _circle_specific_setup(jinja_env, forge_config, forge_dir, platform):
         template_files.append(".scripts/run_docker_build.sh")
         template_files.append(".scripts/build_steps.sh")
     else:
-        template_files.append(".circleci/run_osx_build.sh")
+        template_files.append(".scripts/run_osx_build.sh")
 
     _render_template_exe_files(
         forge_config=forge_config,
@@ -956,7 +956,7 @@ def _travis_specific_setup(jinja_env, forge_config, forge_dir, platform):
 
     platform_templates = {
         "linux": [".scripts/run_docker_build.sh", ".scripts/build_steps.sh"],
-        "osx": [".travis/run_osx_build.sh"],
+        "osx": [".scripts/run_osx_build.sh"],
         "win": [],
     }
     template_files = platform_templates.get(platform, [])
@@ -1108,7 +1108,7 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
             ".scripts/build_steps.sh",
             ".azure-pipelines/azure-pipelines-linux.yml",
         ],
-        "osx": [".azure-pipelines/azure-pipelines-osx.yml"],
+        "osx": [".azure-pipelines/azure-pipelines-osx.yml", ".scripts/run_osx_build.sh"],
         "win": [".azure-pipelines/azure-pipelines-win.yml"],
     }
     template_files = platform_templates.get(platform, [])

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -961,9 +961,6 @@ def _travis_specific_setup(jinja_env, forge_config, forge_dir, platform):
         if yum_build_setup:
             forge_config["yum_build_setup"] = yum_build_setup
 
-    if platform == "osx":
-        build_setup = build_setup.strip()
-        build_setup = build_setup.replace("\n", "\n      ")
     forge_config["build_setup"] = build_setup
 
     _render_template_exe_files(
@@ -990,15 +987,17 @@ def _render_template_exe_files(
                 old_file_contents = fh.read()
                 if old_file_contents != new_file_contents:
                     import difflib
-                    import sys
 
-                    print("diff:")
-                    sys.stdout.writelines(
-                        difflib.unified_diff(
-                            old_file_contents.splitlines(),
-                            new_file_contents.splitlines(),
-                            fromfile=target_fname,
-                            tofile=target_fname,
+                    logger.debug(
+                        "diff:\n%s" % (
+                            "\n".join(
+                                difflib.unified_diff(
+                                    old_file_contents.splitlines(),
+                                    new_file_contents.splitlines(),
+                                    fromfile=target_fname,
+                                    tofile=target_fname,
+                                )
+                            )
                         )
                     )
                     raise RuntimeError(

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -21,62 +21,13 @@ jobs:
   steps:
   # TODO: Fast finish on azure pipelines?
   - script: |
-      echo "Fast Finish"
-      {{ fast_finish }}
-
-  - bash: |
-      echo "##vso[task.prependpath]$CONDA/bin"
-      sudo chown -R $USER $CONDA
-    displayName: Add conda to PATH
-
-  - script: |
-      source activate base
-      conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
-    displayName: 'Add conda-forge-ci-setup=2'
-
-  - script: |
-      echo "Mangling homebrew from Azure to avoid conflicts."
-      source activate base
-      /usr/bin/sudo mangle_homebrew
-      /usr/bin/sudo -k
-    displayName: Mangle homebrew
-
-  - script: |
-      source activate base
-      echo "Configuring conda."
-
-      setup_conda_rc ./ "./{{ recipe_dir }}" ./.ci_support/${CONFIG}.yaml
       export CI=azure
-      {{ build_setup.replace("\n", "\n      ").rstrip() }}
-      conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
-    env: {
-      OSX_FORCE_SDK_DOWNLOAD: "1"
-    }
-    displayName: Configure conda and conda-build
-
-  - script: |
-      source activate base
-      mangle_compiler ./ "./{{ recipe_dir }}" ./.ci_support/${CONFIG}.yaml
-    displayName: Mangle compiler
-
-  - script: |
-      source activate base
-      make_build_number ./ "./{{ recipe_dir }}" ./.ci_support/${CONFIG}.yaml
-    displayName: Generate build number clobber file
-
-  - script: |
-      source activate base
-      conda build "./{{ recipe_dir }}" -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
-    displayName: Build recipe
-
-  - script: |
-      source activate base
+      export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
 {%- if upload_on_branch %}
       export UPLOAD_ON_BRANCH="{{ upload_on_branch }}"
 {%- endif %}
-      upload_package ./ "./{{ recipe_dir }}" ./.ci_support/${CONFIG}.yaml
-    displayName: Upload package
+      ./.scripts/run_osx_build.sh
+    displayName: Run OSX build
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -45,7 +45,7 @@ jobs:
 {%- else %}
           command: |
             export CI=circle
-            ./.circleci/run_osx_build.sh
+            ./.scripts/run_osx_build.sh
 {%- endif %}
 {%- if idle_timeout_minutes %}
           no_output_timeout: {{ idle_timeout_minutes }}m

--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -26,6 +26,7 @@ jobs:
 {%- endif %}
     environment:
       - CONFIG: "{{ data.config_name }}"
+      - UPLOAD_PACKAGES: "{{ data.upload }}"
 {%- if data.platform.startswith('linux') %}
         DOCKER_IMAGE: "{{ data.config["docker_image"][-1] }}"
 {%- endif %}

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -11,7 +11,7 @@ MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
 bash $MINIFORGE_FILE -b
 if [[ ${CI} == "travis" ]]; then
-  echo -en 'travis_fold:end:install_\\r'
+  echo -en 'travis_fold:end:install_miniforge\\r'
 fi
 
 echo -e "\n\nConfiguring conda."

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -x
+# turn this off as the output is far too verbose
+# set -x
 
 {{ fast_finish }}
 
@@ -24,8 +25,10 @@ fi
 source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
+echo "Installing conda-forge-ci-setup=2 and conda-build."
 conda install -n base --quiet --yes conda-forge-ci-setup=2 conda-build
 
+echo "Setting up the condarc and mangling the compiler."
 setup_conda_rc ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
 mangle_compiler ./ ./{{ recipe_dir }} .ci_support/${CONFIG}.yaml
 
@@ -40,6 +43,7 @@ if [[ ${CI} == "travis" ]]; then
 fi
 
 {% if build_setup -%}
+echo "Running the build setup script."
 {{ build_setup }}
 {%- endif %}
 if [[ ${CI} == "travis" ]]; then
@@ -48,10 +52,11 @@ fi
 
 set -e
 
+echo "Making the build clobber file and running the build."
 make_build_number ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
-
 conda build ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+  echo "Uploading the packages."
   upload_package ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
 fi

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -30,14 +30,8 @@ setup_conda_rc ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
 mangle_compiler ./ ./{{ recipe_dir }} .ci_support/${CONFIG}.yaml
 
 echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
-if [[ ${CI} == "travis" ]]; then
-  echo -en 'travis_fold:start:mangle_homebrew\\r'
-fi
 /usr/bin/sudo mangle_homebrew
 /usr/bin/sudo -k
-if [[ ${CI} == "travis" ]]; then
-  echo -en 'travis_fold:end:mangle_homebrew\\r'
-fi
 
 {% if build_setup -%}
 echo -e "\n\nRunning the build setup script."

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -4,16 +4,16 @@ set -x
 
 {{ fast_finish }}
 
-echo "Installing a fresh version of Miniconda."
+echo "Installing a fresh version of Miniforge."
 if [[ ${CI} == "travis" ]]; then
-  echo -en 'travis_fold:start:install_miniconda\\r'
+  echo -en 'travis_fold:start:install_miniforge\\r'
 fi
-MINICONDA_URL="https://github.com/conda-forge/miniforge/releases/download/4.8.3-2"
-MINICONDA_FILE="Miniforge3-MacOSX-x86_64.sh"
-curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
-bash $MINICONDA_FILE -b
+MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/download/4.8.3-2"
+MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
+curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
+bash $MINIFORGE_FILE -b
 if [[ ${CI} == "travis" ]]; then
-  echo -en 'travis_fold:end:install_miniconda\\r'
+  echo -en 'travis_fold:end:install_\\r'
 fi
 
 echo "Configuring conda."
@@ -21,10 +21,10 @@ if [[ ${CI} == "travis" ]]; then
   echo -en 'travis_fold:start:configure_conda\\r'
 fi
 
-source ${HOME}/miniconda3/etc/profile.d/conda.sh
+source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
-conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
+conda install -n base --quiet --yes conda-forge-ci-setup=2 conda-build
 
 echo "Mangling homebrew in the CI to avoid conflicts."
 if [[ ${CI} == "travis" ]]; then

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -2,7 +2,7 @@
 
 set -x
 
-echo "\n\nInstalling a fresh version of Miniforge."
+echo -e "\n\nInstalling a fresh version of Miniforge."
 if [[ ${CI} == "travis" ]]; then
   echo -en 'travis_fold:start:install_miniforge\\r'
 fi
@@ -14,7 +14,7 @@ if [[ ${CI} == "travis" ]]; then
   echo -en 'travis_fold:end:install_\\r'
 fi
 
-echo "\n\nConfiguring conda."
+echo -e "\n\nConfiguring conda."
 if [[ ${CI} == "travis" ]]; then
   echo -en 'travis_fold:start:configure_conda\\r'
 fi
@@ -22,14 +22,14 @@ fi
 source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
-echo "\n\nInstalling conda-forge-ci-setup=2 and conda-build."
+echo -e "\n\nInstalling conda-forge-ci-setup=2 and conda-build."
 conda install -n base --quiet --yes conda-forge-ci-setup=2 conda-build
 
-echo "\n\nSetting up the condarc and mangling the compiler."
+echo -e "\n\nSetting up the condarc and mangling the compiler."
 setup_conda_rc ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
 mangle_compiler ./ ./{{ recipe_dir }} .ci_support/${CONFIG}.yaml
 
-echo "\n\nMangling homebrew in the CI to avoid conflicts."
+echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
 if [[ ${CI} == "travis" ]]; then
   echo -en 'travis_fold:start:mangle_homebrew\\r'
 fi
@@ -40,7 +40,7 @@ if [[ ${CI} == "travis" ]]; then
 fi
 
 {% if build_setup -%}
-echo "\n\nRunning the build setup script."
+echo -e "\n\nRunning the build setup script."
 {{ build_setup }}
 {%- endif %}
 if [[ ${CI} == "travis" ]]; then
@@ -49,11 +49,11 @@ fi
 
 set -e
 
-echo "\n\nMaking the build clobber file and running the build."
+echo -e "\n\nMaking the build clobber file and running the build."
 make_build_number ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
 conda build ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-  echo "\n\nUploading the packages."
+  echo -e "\n\nUploading the packages."
   upload_package ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
 fi

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -6,7 +6,7 @@ echo -e "\n\nInstalling a fresh version of Miniforge."
 if [[ ${CI} == "travis" ]]; then
   echo -en 'travis_fold:start:install_miniforge\\r'
 fi
-MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/download/4.8.3-2"
+MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
 MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
 bash $MINIFORGE_FILE -b

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -4,31 +4,47 @@ set -x
 
 {{ fast_finish }}
 
-echo "Installing a fresh version of Miniconda." && echo -en 'travis_fold:start:install_miniconda\\r'
-MINICONDA_URL="https://repo.continuum.io/miniconda"
-MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
+echo "Installing a fresh version of Miniconda."
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:start:install_miniconda\\r'
+fi
+MINICONDA_URL="https://github.com/conda-forge/miniforge/releases/download/4.8.3-2"
+MINICONDA_FILE="Miniforge3-MacOSX-x86_64.sh"
 curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
 bash $MINICONDA_FILE -b
-echo -en 'travis_fold:end:install_miniconda\\r'
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:end:install_miniconda\\r'
+fi
 
-echo "Configuring conda." && echo -en 'travis_fold:start:configure_conda\\r'
-source ~/miniconda3/bin/activate root
+echo "Configuring conda."
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:start:configure_conda\\r'
+fi
 
-conda install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
+source ${HOME}/miniconda3/etc/profile.d/conda.sh
+conda activate base
 
-echo "Mangling homebrew in the CI to avoid conflicts." && echo -en 'travis_fold:start:mangle_homebrew\\r'
+conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
+
+echo "Mangling homebrew in the CI to avoid conflicts."
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:start:mangle_homebrew\\r'
+fi
 /usr/bin/sudo mangle_homebrew
 /usr/bin/sudo -k
-echo -en 'travis_fold:end:mangle_homebrew\\r'
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:end:mangle_homebrew\\r'
+fi
 
 mangle_compiler ./ ./{{ recipe_dir }} .ci_support/${CONFIG}.yaml
 setup_conda_rc ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
 
-
 {% if build_setup -%}
 {{ build_setup }}
 {%- endif %}
-echo -en 'travis_fold:end:configure_conda\\r'
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:end:configure_conda\\r'
+fi
 
 set -e
 
@@ -36,4 +52,6 @@ make_build_number ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
 
 conda build ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
 
-upload_package ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
+if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+  upload_package ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
+fi

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -26,6 +26,9 @@ conda activate base
 
 conda install -n base --quiet --yes conda-forge-ci-setup=2 conda-build
 
+setup_conda_rc ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
+mangle_compiler ./ ./{{ recipe_dir }} .ci_support/${CONFIG}.yaml
+
 echo "Mangling homebrew in the CI to avoid conflicts."
 if [[ ${CI} == "travis" ]]; then
   echo -en 'travis_fold:start:mangle_homebrew\\r'
@@ -35,9 +38,6 @@ fi
 if [[ ${CI} == "travis" ]]; then
   echo -en 'travis_fold:end:mangle_homebrew\\r'
 fi
-
-mangle_compiler ./ ./{{ recipe_dir }} .ci_support/${CONFIG}.yaml
-setup_conda_rc ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
 
 {% if build_setup -%}
 {{ build_setup }}

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
 
-# turn this off as the output is far too verbose
-# set -x
+set -x
 
-{{ fast_finish }}
-
-echo "Installing a fresh version of Miniforge."
+echo "\n\nInstalling a fresh version of Miniforge."
 if [[ ${CI} == "travis" ]]; then
   echo -en 'travis_fold:start:install_miniforge\\r'
 fi
@@ -17,7 +14,7 @@ if [[ ${CI} == "travis" ]]; then
   echo -en 'travis_fold:end:install_\\r'
 fi
 
-echo "Configuring conda."
+echo "\n\nConfiguring conda."
 if [[ ${CI} == "travis" ]]; then
   echo -en 'travis_fold:start:configure_conda\\r'
 fi
@@ -25,14 +22,14 @@ fi
 source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
-echo "Installing conda-forge-ci-setup=2 and conda-build."
+echo "\n\nInstalling conda-forge-ci-setup=2 and conda-build."
 conda install -n base --quiet --yes conda-forge-ci-setup=2 conda-build
 
-echo "Setting up the condarc and mangling the compiler."
+echo "\n\nSetting up the condarc and mangling the compiler."
 setup_conda_rc ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
 mangle_compiler ./ ./{{ recipe_dir }} .ci_support/${CONFIG}.yaml
 
-echo "Mangling homebrew in the CI to avoid conflicts."
+echo "\n\nMangling homebrew in the CI to avoid conflicts."
 if [[ ${CI} == "travis" ]]; then
   echo -en 'travis_fold:start:mangle_homebrew\\r'
 fi
@@ -43,7 +40,7 @@ if [[ ${CI} == "travis" ]]; then
 fi
 
 {% if build_setup -%}
-echo "Running the build setup script."
+echo "\n\nRunning the build setup script."
 {{ build_setup }}
 {%- endif %}
 if [[ ${CI} == "travis" ]]; then
@@ -52,11 +49,11 @@ fi
 
 set -e
 
-echo "Making the build clobber file and running the build."
+echo "\n\nMaking the build clobber file and running the build."
 make_build_number ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
 conda build ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-  echo "Uploading the packages."
+  echo "\n\nUploading the packages."
   upload_package ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
 fi

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -51,7 +51,7 @@ script:
   - export UPLOAD_ON_BRANCH="{{ upload_on_branch }}"
 {%- endif %}
 {% if 'osx' in platformset %}
-  - if [[ ${PLATFORM} =~ .*osx.* ]]; then ./.travis/run_osx_build.sh; fi
+  - if [[ ${PLATFORM} =~ .*osx.* ]]; then ./.scripts/run_osx_build.sh; fi
 {%- endif %}
 {% if 'linux' in platformset %}
   - if [[ ${PLATFORM} =~ .*linux.* ]]; then ./.scripts/run_docker_build.sh; fi

--- a/news/osx_refactor.rst
+++ b/news/osx_refactor.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Refactored OSX CI scripts to be based off of a single global script on all CI platforms.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -319,12 +319,13 @@ def test_circle_osx(py_recipe, jinja_env):
 
     forge_dir = py_recipe.recipe
     travis_yml_file = os.path.join(forge_dir, ".travis.yml")
-    circle_osx_file = os.path.join(forge_dir, ".circleci", "run_osx_build.sh")
+    circle_osx_file = os.path.join(forge_dir, ".scripts", "run_osx_build.sh")
     circle_linux_file = os.path.join(
         forge_dir, ".scripts", "run_docker_build.sh"
     )
     circle_config_file = os.path.join(forge_dir, ".circleci", "config.yml")
 
+    cnfgr_fdstk.clear_scripts(forge_dir)
     cnfgr_fdstk.render_circle(
         jinja_env=jinja_env, forge_config=py_recipe.config, forge_dir=forge_dir
     )
@@ -336,6 +337,7 @@ def test_circle_osx(py_recipe, jinja_env):
     )
     assert os.path.exists(travis_yml_file)
 
+    cnfgr_fdstk.clear_scripts(forge_dir)
     config = copy.deepcopy(py_recipe.config)
     config["provider"]["osx"] = "circle"
     cnfgr_fdstk.render_circle(
@@ -349,6 +351,7 @@ def test_circle_osx(py_recipe, jinja_env):
     )
     assert not os.path.exists(travis_yml_file)
 
+    cnfgr_fdstk.clear_scripts(forge_dir)
     config = copy.deepcopy(py_recipe.config)
     config["provider"]["linux"] = "dummy"
     config["provider"]["osx"] = "circle"
@@ -362,7 +365,7 @@ def test_circle_osx(py_recipe, jinja_env):
 
 def test_circle_skipped(linux_skipped_recipe, jinja_env):
     forge_dir = linux_skipped_recipe.recipe
-    circle_osx_file = os.path.join(forge_dir, ".circleci", "run_osx_build.sh")
+    circle_osx_file = os.path.join(forge_dir, ".scripts", "run_osx_build.sh")
     circle_linux_file = os.path.join(
         forge_dir, ".scripts", "run_docker_build.sh"
     )


### PR DESCRIPTION
This PR centralizes the OSX CI scripts to use a single build script with miniforge. 

closes #1292 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
