### PR TITLE
Support self-hosted Azure agents

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1361,6 +1361,10 @@ def _load_forge_config(forge_dir, exclusive_config_file):
             "project_id": "84710dde-1620-425b-80d0-4cf5baca359d",
             # Default to a timeout of 6 hours.  This is the maximum for azure by default
             "timeout_minutes": 360,
+            "strategy": {
+                # Could be overwritten for self-hosted agents; used when "matrix" is set.
+                "maxParallel": 8,
+            }
         },
         "provider": {
             "linux": "azure",

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1353,6 +1353,7 @@ def _load_forge_config(forge_dir, exclusive_config_file):
         "appveyor": {"image": "Visual Studio 2017"},
         "azure": {
             # default choices for MS-hosted agents
+            # for self-hosted agents, "vmImage" is replaced by "name" (of the pool)
             "pool_linux": {"vmImage": "ubuntu-16.04"},
             "pool_osx": {"vmImage": "macOS-10.14"},
             "pool_win": {"vmImage": "vs2017-win2016"},
@@ -1433,15 +1434,12 @@ def _load_forge_config(forge_dir, exclusive_config_file):
             else:
                 config[key] = value
 
-        # for self-hosted Azure agents
-        use_self_hosted_agent = False
-        for pool in ("pool_linux", "pool_osx", "pool_win"):
-            if "name" in config["azure"][pool]:
-                use_self_hosted_agent = True
-        if not use_self_hosted_agent:
-            # overwrite the default on Win
-            if config["win"]["enabled"]:
+        # overwrite the default on Win for MS-hosted Azure agents
+        if config["win"]["enabled"]:
+            if "vmImage" in config["azure"]["pool_win"]:
                 config["azure"]["strategy"]["maxParallel"] = 4
+
+        # value not specified in conda-forge.yml, remove the key
         if config["azure"]["workspace"]["clean"] is None:
             del config["azure"]["workspace"]
 

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1368,7 +1368,6 @@ def _load_forge_config(forge_dir, exclusive_config_file):
         "appveyor": {"image": "Visual Studio 2017"},
         "azure": {
             # default choices for MS-hosted agents
-            # for self-hosted agents, "vmImage" is replaced by "name" (of the pool)
             "settings_linux": {
                 "pool": {
                     "vmImage": "ubuntu-16.04",
@@ -1398,8 +1397,6 @@ def _load_forge_config(forge_dir, exclusive_config_file):
             # name and id of azure project that the build pipeline is in
             "project_name": "feedstock-builds",
             "project_id": "84710dde-1620-425b-80d0-4cf5baca359d",
-            # valid only when using self-hosted agents
-            "workspace": {"clean": None},
         },
         "provider": {
             "linux": "azure",

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1429,6 +1429,10 @@ def _load_forge_config(forge_dir, exclusive_config_file):
             else:
                 config[key] = value
 
+        # overwrite the default on Win
+        if config["win"]["enabled"]:
+            config["azure"]["strategy"]["maxParallel"] = 4
+
         # check for conda-smithy 2.x matrix which we can't auto-migrate
         # to conda_build_config
         if file_config.get("matrix") and not os.path.exists(

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1364,7 +1364,7 @@ def _load_forge_config(forge_dir, exclusive_config_file):
             "strategy": {
                 # Could be overwritten for self-hosted agents; used when "matrix" is set.
                 "maxParallel": 8,
-            }
+            },
         },
         "provider": {
             "linux": "azure",

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1397,6 +1397,8 @@ def _load_forge_config(forge_dir, exclusive_config_file):
             # name and id of azure project that the build pipeline is in
             "project_name": "feedstock-builds",
             "project_id": "84710dde-1620-425b-80d0-4cf5baca359d",
+            # Set timeout for all platforms at once.
+            "timeout_minutes": None,
         },
         "provider": {
             "linux": "azure",
@@ -1482,6 +1484,10 @@ def _load_forge_config(forge_dir, exclusive_config_file):
                 "Setting docker image in conda-forge.yml is removed now."
                 " Use conda_build_config.yaml instead"
             )
+
+        if config["azure"]["timeout_minutes"] is not None:
+            for plat in ["linux", "osx", "win"]:
+                config["azure"][f"settings_{plat}"]["timeoutInMinutes"] = config["azure"]["timeout_minutes"]
 
     # An older conda-smithy used to have some files which should no longer exist,
     # remove those now.

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1136,13 +1136,17 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
     for data in forge_config["configs"]:
         if not data["platform"].startswith(platform):
             continue
-        config_rendered = OrderedDict({
-            "CONFIG": data["config_name"],
-            "UPLOAD_PACKAGES": data["upload"],
-        })
+        config_rendered = OrderedDict(
+            {
+                "CONFIG": data["config_name"],
+                "UPLOAD_PACKAGES": str(data["upload"]),
+            }
+        )
+        # fmt: off
         if "docker_image" in data["config"]:
             config_rendered["DOCKER_IMAGE"] = data["config"]["docker_image"][-1]
         azure_settings["strategy"]["matrix"][data["config_name"]] = config_rendered
+        # fmt: on
 
     forge_config["azure_yaml"] = yaml.dump(azure_settings)
     _render_template_exe_files(
@@ -1355,10 +1359,12 @@ def copy_feedstock_content(forge_config, forge_dir):
 
 
 def _update_dict_within_dict(items, config):
-    ''' recursively update dict within dict, if any '''
+    """ recursively update dict within dict, if any """
     for key, value in items:
         if isinstance(value, dict):
-            config[key] = _update_dict_within_dict(value.items(), config.get(key, {}))
+            config[key] = _update_dict_within_dict(
+                value.items(), config.get(key, {})
+            )
         else:
             config[key] = value
     return config
@@ -1379,26 +1385,20 @@ def _load_forge_config(forge_dir, exclusive_config_file):
         "azure": {
             # default choices for MS-hosted agents
             "settings_linux": {
-                "pool": {
-                    "vmImage": "ubuntu-16.04",
-                },
+                "pool": {"vmImage": "ubuntu-16.04",},
                 "timeoutInMinutes": 360,
-                "strategy": { "maxParallel": 8 }
+                "strategy": {"maxParallel": 8},
             },
             "settings_osx": {
-                "pool": {
-                    "vmImage": "macOS-10.14",
-                },
+                "pool": {"vmImage": "macOS-10.14",},
                 "timeoutInMinutes": 360,
-                "strategy": { "maxParallel": 8 }
+                "strategy": {"maxParallel": 8},
             },
             "settings_win": {
-                "pool": {
-                    "vmImage": "vs2017-win2016",
-                },
+                "pool": {"vmImage": "vs2017-win2016",},
                 "timeoutInMinutes": 360,
-                "strategy": { "maxParallel": 4 },
-                "variables": { "CONDA_BLD_PATH": r"D:\\bld\\" }
+                "strategy": {"maxParallel": 4},
+                "variables": {"CONDA_BLD_PATH": r"D:\\bld\\"},
             },
             # disallow publication of azure artifacts for now.
             "upload_packages": False,
@@ -1491,7 +1491,9 @@ def _load_forge_config(forge_dir, exclusive_config_file):
 
         for plat in ["linux", "osx", "win"]:
             if config["azure"]["timeout_minutes"] is not None:
+                # fmt: off
                 config["azure"][f"settings_{plat}"]["timeoutInMinutes"] = config["azure"]["timeout_minutes"]
+                # fmt: on
             if "name" in config["azure"][f"settings_{plat}"]["pool"]:
                 del config["azure"][f"settings_{plat}"]["pool"]["vmImage"]
 

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -7,7 +7,11 @@ jobs:
   pool:
   {%- if azure.pool is defined %}
   # self-hosted agent
+    {%- if azure.pool.name is defined %}
     name: {{ azure.pool.name }}
+    {%- else %}
+    name: {{ azure.pool }}
+    {%- endif %}
   {%- if azure.pool.demands is defined %}
     demands:
     {%- for requirement in azure.pool.demands %}
@@ -24,11 +28,7 @@ jobs:
   {%- endif %}
   timeoutInMinutes: {{ azure.timeout_minutes }}
   strategy:
-    {%- if azure.strategy is defined and azure.strategy.maxParallel is defined %}
     maxParallel: {{ azure.strategy.maxParallel }}
-    {%- else %}
-    maxParallel: 8
-    {%- endif %}
     matrix:
     {%- for data in configs %}
     {%- if data.platform.startswith('linux') %}

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -4,33 +4,7 @@
 
 jobs:
 - job: linux
-  pool:
-  {%- for spec in azure.pool_linux %}
-    {%- if azure.pool_linux[spec] is string %}
-    {{ spec }}: {{ azure.pool_linux[spec] }}
-    {%- else %}
-    {{ spec }}:
-    {%- for item in azure.pool_linux[spec] %}
-    - {{ item }}
-    {%- endfor %}
-    {%- endif %}
-  {%- endfor %}
-  {%- if azure.workspace is defined %}
-  workspace:
-    clean: {{ azure.workspace.clean }}
-  {%- endif %}
-  timeoutInMinutes: {{ azure.timeout_minutes }}
-  strategy:
-    maxParallel: {{ azure.strategy.maxParallel }}
-    matrix:
-    {%- for data in configs %}
-    {%- if data.platform.startswith('linux') %}
-      {{ data.config_name }}:
-        CONFIG: {{ data.config_name }}
-        UPLOAD_PACKAGES: {{ data.upload }}
-        DOCKER_IMAGE: {{ data.config["docker_image"][-1] }}
-    {%- endif %}
-    {%- endfor %}
+  {{ azure_yaml|indent(2) }}
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -6,7 +6,7 @@ jobs:
 - job: linux
   pool:
   {%- if azure.pool is defined %}
-  # self-hosted agent
+    # self-hosted agent
     {%- if azure.pool.name is defined %}
     name: {{ azure.pool.name }}
     {%- else %}
@@ -23,7 +23,7 @@ jobs:
     clean: {{ azure.workspace.clean }}
   {%- endif %}
   {%- else %}
-  # MS-hosted agent
+    # MS-hosted agent
     vmImage: ubuntu-16.04
   {%- endif %}
   timeoutInMinutes: {{ azure.timeout_minutes }}

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -5,10 +5,30 @@
 jobs:
 - job: linux
   pool:
+  {%- if azure.pool is defined %}
+  # self-hosted agent
+    name: {{ azure.pool.name }}
+  {%- if azure.pool.demands is defined %}
+    demands:
+    {%- for requirement in azure.pool.demands %}
+    - {{ requirement }}
+    {%- endfor %}
+  {%- endif %}
+  {%- if azure.workspace is defined %}
+  workspace:
+    clean: {{ azure.workspace.clean }}
+  {%- endif %}
+  {%- else %}
+  # MS-hosted agent
     vmImage: ubuntu-16.04
+  {%- endif %}
   timeoutInMinutes: {{ azure.timeout_minutes }}
   strategy:
+    {%- if azure.strategy is defined and azure.strategy.maxParallel is defined %}
+    maxParallel: {{ azure.strategy.maxParallel }}
+    {%- else %}
     maxParallel: 8
+    {%- endif %}
     matrix:
     {%- for data in configs %}
     {%- if data.platform.startswith('linux') %}
@@ -32,6 +52,9 @@ jobs:
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
 {%- if upload_on_branch %}
         export UPLOAD_ON_BRANCH="{{ upload_on_branch }}"
+{%- endif %}
+{%- if docker.run_args is defined %}
+        export CONDA_FORGE_DOCKER_RUN_ARGS="{{ docker.run_args }}"
 {%- endif %}
         .scripts/run_docker_build.sh
     displayName: Run docker build

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -5,26 +5,19 @@
 jobs:
 - job: linux
   pool:
-  {%- if azure.pool is defined %}
-    # self-hosted agent
-    {%- if azure.pool.name is defined %}
-    name: {{ azure.pool.name }}
+  {%- for spec in azure.pool_linux %}
+    {%- if azure.pool_linux[spec] is string %}
+    {{ spec }}: {{ azure.pool_linux[spec] }}
     {%- else %}
-    name: {{ azure.pool }}
-    {%- endif %}
-  {%- if azure.pool.demands is defined %}
-    demands:
-    {%- for requirement in azure.pool.demands %}
-    - {{ requirement }}
+    {{ spec }}:
+    {%- for item in azure.pool_linux[spec] %}
+    - {{ item }}
     {%- endfor %}
-  {%- endif %}
+    {%- endif %}
+  {%- endfor %}
   {%- if azure.workspace is defined %}
   workspace:
     clean: {{ azure.workspace.clean }}
-  {%- endif %}
-  {%- else %}
-    # MS-hosted agent
-    vmImage: ubuntu-16.04
   {%- endif %}
   timeoutInMinutes: {{ azure.timeout_minutes }}
   strategy:

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -5,26 +5,19 @@
 jobs:
 - job: osx
   pool:
-  {%- if azure.pool is defined %}
-    # self-hosted agent
-    {%- if azure.pool.name is defined %}
-    name: {{ azure.pool.name }}
+  {%- for spec in azure.pool_osx %}
+    {%- if azure.pool_osx[spec] is string %}
+    {{ spec }}: {{ azure.pool_osx[spec] }}
     {%- else %}
-    name: {{ azure.pool }}
-    {%- endif %}
-  {%- if azure.pool.demands is defined %}
-    demands:
-    {%- for requirement in azure.pool.demands %}
-    - {{ requirement }}
+    {{ spec }}:
+    {%- for item in azure.pool_osx[spec] %}
+    - {{ item }}
     {%- endfor %}
-  {%- endif %}
+    {%- endif %}
+  {%- endfor %}
   {%- if azure.workspace is defined %}
   workspace:
     clean: {{ azure.workspace.clean }}
-  {%- endif %}
-  {%- else %}
-    # MS-hosted agent
-    vmImage: macOS-10.14
   {%- endif %}
   timeoutInMinutes: {{ azure.timeout_minutes }}
   strategy:

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -5,10 +5,30 @@
 jobs:
 - job: osx
   pool:
+  {%- if azure.pool is defined %}
+    # self-hosted agent
+    {%- if azure.pool.name is defined %}
+    name: {{ azure.pool.name }}
+    {%- else %}
+    name: {{ azure.pool }}
+    {%- endif %}
+  {%- if azure.pool.demands is defined %}
+    demands:
+    {%- for requirement in azure.pool.demands %}
+    - {{ requirement }}
+    {%- endfor %}
+  {%- endif %}
+  {%- if azure.workspace is defined %}
+  workspace:
+    clean: {{ azure.workspace.clean }}
+  {%- endif %}
+  {%- else %}
+    # MS-hosted agent
     vmImage: macOS-10.14
+  {%- endif %}
   timeoutInMinutes: {{ azure.timeout_minutes }}
   strategy:
-    maxParallel: 8
+    maxParallel: {{ azure.strategy.maxParallel }}
     matrix:
     {%- for data in configs %}
     {%- if data.platform.startswith('osx') %}

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -4,33 +4,7 @@
 
 jobs:
 - job: osx
-  pool:
-  {%- for spec in azure.pool_osx %}
-    {%- if azure.pool_osx[spec] is string %}
-    {{ spec }}: {{ azure.pool_osx[spec] }}
-    {%- else %}
-    {{ spec }}:
-    {%- for item in azure.pool_osx[spec] %}
-    - {{ item }}
-    {%- endfor %}
-    {%- endif %}
-  {%- endfor %}
-  {%- if azure.workspace is defined %}
-  workspace:
-    clean: {{ azure.workspace.clean }}
-  {%- endif %}
-  timeoutInMinutes: {{ azure.timeout_minutes }}
-  strategy:
-    maxParallel: {{ azure.strategy.maxParallel }}
-    matrix:
-    {%- for data in configs %}
-    {%- if data.platform.startswith('osx') %}
-      {{ data.config_name }}:
-        CONFIG: {{ data.config_name }}
-        UPLOAD_PACKAGES: {{ data.upload }}
-    {%- endif %}
-    {%- endfor %}
-
+  {{ azure_yaml|indent(2) }}
   steps:
   # TODO: Fast finish on azure pipelines?
   - script: |

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -5,26 +5,19 @@
 jobs:
 - job: win
   pool:
-  {%- if azure.pool is defined %}
-    # self-hosted agent
-    {%- if azure.pool.name is defined %}
-    name: {{ azure.pool.name }}
+  {%- for spec in azure.pool_win %}
+    {%- if azure.pool_win[spec] is string %}
+    {{ spec }}: {{ azure.pool_win[spec] }}
     {%- else %}
-    name: {{ azure.pool }}
-    {%- endif %}
-  {%- if azure.pool.demands is defined %}
-    demands:
-    {%- for requirement in azure.pool.demands %}
-    - {{ requirement }}
+    {{ spec }}:
+    {%- for item in azure.pool_win[spec] %}
+    - {{ item }}
     {%- endfor %}
-  {%- endif %}
+    {%- endif %}
+  {%- endfor %}
   {%- if azure.workspace is defined %}
   workspace:
     clean: {{ azure.workspace.clean }}
-  {%- endif %}
-  {%- else %}
-    # MS-hosted agent
-    vmImage: vs2017-win2016
   {%- endif %}
   timeoutInMinutes: {{ azure.timeout_minutes }}
   strategy:

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -5,10 +5,30 @@
 jobs:
 - job: win
   pool:
+  {%- if azure.pool is defined %}
+    # self-hosted agent
+    {%- if azure.pool.name is defined %}
+    name: {{ azure.pool.name }}
+    {%- else %}
+    name: {{ azure.pool }}
+    {%- endif %}
+  {%- if azure.pool.demands is defined %}
+    demands:
+    {%- for requirement in azure.pool.demands %}
+    - {{ requirement }}
+    {%- endfor %}
+  {%- endif %}
+  {%- if azure.workspace is defined %}
+  workspace:
+    clean: {{ azure.workspace.clean }}
+  {%- endif %}
+  {%- else %}
+    # MS-hosted agent
     vmImage: vs2017-win2016
+  {%- endif %}
   timeoutInMinutes: {{ azure.timeout_minutes }}
   strategy:
-    maxParallel: 4
+    maxParallel: {{ azure.strategy.maxParallel }}
     matrix:
     {%- for data in configs %}
     {%- if data.platform.startswith('win') %}

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -4,39 +4,8 @@
 
 jobs:
 - job: win
-  pool:
-  {%- for spec in azure.pool_win %}
-    {%- if azure.pool_win[spec] is string %}
-    {{ spec }}: {{ azure.pool_win[spec] }}
-    {%- else %}
-    {{ spec }}:
-    {%- for item in azure.pool_win[spec] %}
-    - {{ item }}
-    {%- endfor %}
-    {%- endif %}
-  {%- endfor %}
-  {%- if azure.workspace is defined %}
-  workspace:
-    clean: {{ azure.workspace.clean }}
-  {%- endif %}
-  timeoutInMinutes: {{ azure.timeout_minutes }}
-  strategy:
-    maxParallel: {{ azure.strategy.maxParallel }}
-    matrix:
-    {%- for data in configs %}
-    {%- if data.platform.startswith('win') %}
-      {{ data.config_name }}:
-        CONFIG: {{ data.config_name }}
-        CONDA_BLD_PATH: D:\\bld\\
-        UPLOAD_PACKAGES: {{ data.upload }}
-    {%- endif %}
-    {%- endfor %}
+  {{ azure_yaml|indent(2) }}
   steps:
-    # TODO: Fast finish on azure pipelines?
-    - script: |
-        ECHO ON
-        {{ fast_finish }}
-
     - script: |
         choco install vcpython27 -fdv -y --debug
       condition: contains(variables['CONFIG'], 'vs2008')

--- a/news/self_hosted_azure_agent.rst
+++ b/news/self_hosted_azure_agent.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Support self-hosted Azure agents in Linux
+* Support self-hosted Azure agents
 
 **Changed:**
 

--- a/news/self_hosted_azure_agent_linux.rst
+++ b/news/self_hosted_azure_agent_linux.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Support self-hosted Azure agents in Linux
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This PR supports self-hosted Azure agents, which we will use to help some facility-specific needs. The following example shows the newly accepted variables in `conda-forge.yml` for this capability:
```jinja
azure:
  pool:
    name: Our_Local_Pool
    demands:
      - tagA -equals 2
  workspace:
    clean: all
  strategy:
    maxParallel: 1
docker:
  run_args: -t --rm
```
nsls-ii-forge/cupy-feedstock#1 is a real working PR with the Azure (Linux) agent backed by a local machine. The meanings and the hierarchy of variables follow directly the definition in the [Azure Pipelines documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#define-a-single-job). 

The addition of the `run_args` variable is a follow-up of #1279, which will be passed to `CONDA_FORGE_DOCKER_RUN_ARGS`. Seems only valid for Linux.

cc: @mrakitin 