### PR TITLE
ENH use read-write permissions for docker mounts

### DIFF
--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -60,7 +60,7 @@ fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 {{ docker.executable }} run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:ro,z \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
            -e CONFIG \
            -e BINSTAR_TOKEN \

--- a/news/docker_rw.rst
+++ b/news/docker_rw.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Changed the docker mount to the recipe directory to have read-write permissions instead
+  of read-only.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
This fixes a pip install issue @isuruf found when making a change to the conda-forge-ci-setup feedstock. 

https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/87/files

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
