### PR TITLE
Allow to explicitly name the feedstock

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -29,6 +29,7 @@ from conda_smithy.feedstock_io import (
     copy_file,
     remove_file_or_dir,
 )
+from conda_smithy.utils import get_feedstock_name_from_meta
 from . import __version__
 
 conda_forge_content = os.path.abspath(os.path.dirname(__file__))
@@ -1264,10 +1265,7 @@ def render_README(jinja_env, forge_config, forge_dir, render_info=None):
             " builds."
         )
 
-    if "parent_recipe" in metas[0].meta["extra"]:
-        package_name = metas[0].meta["extra"]["parent_recipe"]["name"]
-    else:
-        package_name = metas[0].name()
+    package_name = get_feedstock_name_from_meta(metas[0])
 
     ci_support_path = os.path.join(forge_dir, ".ci_support")
     variants = []

--- a/conda_smithy/github.py
+++ b/conda_smithy/github.py
@@ -10,6 +10,7 @@ from github.Team import Team
 import github
 
 import conda_build.api
+from conda_smithy.utils import get_feedstock_name_from_meta
 
 
 def gh_token():
@@ -111,10 +112,7 @@ def create_github_repo(args):
         trim_skip=False,
     )[0][0]
 
-    if "parent_recipe" in meta.meta["extra"]:
-        feedstock_name = meta.meta["extra"]["parent_recipe"]["name"]
-    else:
-        feedstock_name = meta.name()
+    feedstock_name = get_feedstock_name_from_meta(meta)
 
     gh = Github(token)
     user_or_org = None

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -32,7 +32,7 @@ if "extra" not in FIELDS.keys():
     FIELDS["extra"] = set()
 
 FIELDS["extra"].add("recipe-maintainers")
-FIELDS["extra"].add("feedstock_name")
+FIELDS["extra"].add("feedstock-name")
 
 EXPECTED_SECTION_ORDER = [
     "package",

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -32,6 +32,7 @@ if "extra" not in FIELDS.keys():
     FIELDS["extra"] = set()
 
 FIELDS["extra"].add("recipe-maintainers")
+FIELDS["extra"].add("feedstock_name")
 
 EXPECTED_SECTION_ORDER = [
     "package",

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -12,6 +12,15 @@ from contextlib import contextmanager
 import ruamel.yaml
 
 
+def get_feedstock_name_from_meta(meta):
+    """Resolve the feedtstock name from the parsed meta.yaml."""
+    if "parent_recipe" in meta.meta["extra"]:
+        return meta.meta["extra"]["parent_recipe"]["name"]
+    elif "feedstock_name" in meta.meta["extra"]:
+        return meta.meta["extra"]["feedstock_name"]
+    else:
+        return meta.name()
+
 def get_yaml():
     # define global yaml API
     # roundrip-loader and allowing duplicate keys

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -21,6 +21,7 @@ def get_feedstock_name_from_meta(meta):
     else:
         return meta.name()
 
+
 def get_yaml():
     # define global yaml API
     # roundrip-loader and allowing duplicate keys

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -14,10 +14,10 @@ import ruamel.yaml
 
 def get_feedstock_name_from_meta(meta):
     """Resolve the feedtstock name from the parsed meta.yaml."""
-    if "parent_recipe" in meta.meta["extra"]:
+    if "feedstock-name" in meta.meta["extra"]:
+        return meta.meta["extra"]["feedstock-name"]
+    elif "parent_recipe" in meta.meta["extra"]:
         return meta.meta["extra"]["parent_recipe"]["name"]
-    elif "feedstock_name" in meta.meta["extra"]:
-        return meta.meta["extra"]["feedstock_name"]
     else:
         return meta.name()
 

--- a/news/feedstock_name.rst
+++ b/news/feedstock_name.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* Option to specify the generated feedstock name via ``extra.feedstock_name``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+
+

--- a/news/feedstock_name.rst
+++ b/news/feedstock_name.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Option to specify the generated feedstock name via ``extra.feedstock_name``.
+* Option to specify the generated feedstock name via ``extra.feedstock-name``.
 
 **Changed:**
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -367,7 +367,7 @@ about:
     home: home
 
 extra:
-    feedstock_name: skip-test-meta
+    feedstock-name: skip-test-meta
     """
         )
     return RecipeConfigPair(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -365,6 +365,9 @@ requirements:
         - python
 about:
     home: home
+
+extra:
+    feedstock_name: skip-test-meta
     """
         )
     return RecipeConfigPair(

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -399,6 +399,11 @@ def test_render_with_all_skipped_generates_readme(skipped_recipe, jinja_env):
         forge_config=skipped_recipe.config,
         forge_dir=skipped_recipe.recipe,
     )
+    readme_path = os.path.join(skipped_recipe.recipe, "README.md")
+    assert os.path.exists(readme_path)
+    with open(readme_path, "rb") as readme_file:
+        content = readme_file.read()
+    assert b"skip-test-meta" in content
 
 
 def test_render_windows_with_skipped_python(python_skipped_recipe, jinja_env):


### PR DESCRIPTION
Specify the generated feedstock name via:

```
extra:
  feedstock_name: explicit_name
```

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
