### PR TITLE
BUG github team names are case-insensitive

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1341,7 +1341,11 @@ def render_README(jinja_env, forge_config, forge_dir, render_info=None):
         with write_file(code_owners_file) as fh:
             line = "*"
             for maintainer in forge_config["maintainers"]:
-                line = line + " @" + maintainer
+                if "/" in maintainer:
+                    _maintainer = maintainer.lower()
+                else:
+                    _maintainer = maintainer
+                line = line + " @" + _maintainer
             fh.write(line)
     else:
         remove_file_or_dir(code_owners_file)

--- a/news/teams.rst
+++ b/news/teams.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* CODEOWNERS file no longer treats GitHub team names as case-sensitive.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
So github team names do not appear to be case sensitive. I have also seen errors when the team name has uppercase values when we are making codeowner files. See @xhochy's PR on the pinnings repo. Thus we always make team names lower case.

This link

https://github.com/orgs/conda-forge/teams/Core

and this one 

https://github.com/orgs/conda-forge/teams/core

go to the same spot for example.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
