### PR TITLE
Use mamba for determing latest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ env:
     - CONDA_INSTALL_LOCN="${HOME}/conda"
 
     matrix:
-        - PYTHON=3 CHANNEL="--channel=conda-forge"
+        - PYTHON=3 CHANNEL="--channel=conda-forge" CONDA_PKGS="mamba=0.2"
+        - PYTHON=3 CHANNEL="--channel=conda-forge" CONDA_PKGS=""
 
 install:
     - mkdir -p ${HOME}/cache/pkgs

--- a/conda_smithy.recipe/meta.yaml
+++ b/conda_smithy.recipe/meta.yaml
@@ -35,6 +35,8 @@ requirements:
     - scrypt
     - license-expression
     - libarchive
+  run_constrained:
+    - mamba 0.2.*
 
 test:
   requires:

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import subprocess
 import sys
 import time
@@ -547,7 +548,9 @@ class UpdateCB3(Subcommand):
 
 
 def main():
-
+    # If we use the conda_build.conda_interface, this gets set to INFO anyways.
+    # If only mamba is used, set it so we get the same logs.
+    logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(
         prog="conda smithy",
         description="a tool to help create, administer and manage feedstocks.",

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -29,6 +29,7 @@ from conda_smithy.feedstock_io import (
     copy_file,
     remove_file_or_dir,
 )
+from conda_smithy.mamba_wrapper import ResolveFallback
 from conda_smithy.utils import get_feedstock_name_from_meta
 from . import __version__
 
@@ -1622,10 +1623,7 @@ def commit_changes(forge_file_directory, commit, cs_ver, cfp_ver, cb_ver):
 
 def get_cfp_file_path(temporary_directory, resolve=None):
     if resolve is None:
-        index = conda_build.conda_interface.get_index(
-            channel_urls=["conda-forge"]
-        )
-        resolve = conda_build.conda_interface.Resolve(index)
+        resolve = ResolveFallback()
 
     pkg = get_most_recent_version(resolve, "conda-forge-pinning")
     dest = os.path.join(
@@ -1795,20 +1793,14 @@ def main(
     logger.setLevel(loglevel)
 
     if check:
-        index = conda_build.conda_interface.get_index(
-            channel_urls=["conda-forge"]
-        )
-        r = conda_build.conda_interface.Resolve(index)
+        r = ResolveFallback()
 
         # Check that conda-smithy is up-to-date
         check_version_uptodate(r, "conda-smithy", __version__, True)
         return True
 
     error_on_warn = False if no_check_uptodate else True
-    index = conda_build.conda_interface.get_index(channel_urls=["conda-forge"])
-    logger.debug("Beginning Resolving Index")
-    r = conda_build.conda_interface.Resolve(index)
-    logger.debug("Index rendered")
+    r = ResolveFallback()
 
     # Check that conda-smithy is up-to-date
     check_version_uptodate(r, "conda-smithy", __version__, error_on_warn)

--- a/conda_smithy/mamba_wrapper.py
+++ b/conda_smithy/mamba_wrapper.py
@@ -1,0 +1,84 @@
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ResolveFallback:
+    """
+    Wrapper that implements a tiny subset of :class:`conda_build.conda_interface.Resolve`.
+
+    Calls are first tried using mamba and we switch to conda_build.conda_interface on failure.
+    """
+
+    def __init__(self):
+        self.use_fallback = False
+        self.conda_resolve = None
+        self.mamba_pool = None
+        self.mamba_repos = None
+
+    def _load_mamba_repos(self):
+        import mamba.mamba_api as api
+        from mamba.utils import get_index, init_api_context
+
+        if self.mamba_repos is None:
+            if self.mamba_pool is None:
+                init_api_context()
+                self.mamba_pool = api.Pool()
+
+            index = get_index(("conda-forge",), prepend=False)
+            self.mamba_repos = []
+
+            for subdir, channel in index:
+                if subdir.loaded() == False and channel.platform != "noarch":
+                    # ignore non-loaded subdir if channel is != noarch
+                    continue
+
+                repo = api.Repo(
+                    self.mamba_pool,
+                    str(channel),
+                    subdir.cache_path(),
+                    channel.url(with_credentials=True),
+                )
+                repo.set_priority(0, 0)
+                self.mamba_repos.append(repo)
+
+    def _load_conda_resolve(self):
+        import conda_build.conda_interface
+
+        if self.conda_resolve is None:
+            index = conda_build.conda_interface.get_index(
+                channel_urls=["conda-forge"]
+            )
+            self.conda_resolve = conda_build.conda_interface.Resolve(index)
+
+    def get_pkgs(self, match_spec):
+        if self.use_fallback:
+            self._load_conda_resolve()
+            return self.conda_resolve.get_pkgs(match_spec)
+
+        try:
+            import mamba.mamba_api as api
+
+            self._load_mamba_repos()
+            solver = api.Solver(self.mamba_pool, [(api.MAMBA_NO_DEPS, True)])
+            solver.set_postsolve_flags([(api.MAMBA_NO_DEPS, True)])
+            solver.add_jobs(
+                [match_spec.conda_build_form()], api.SOLVER_INSTALL
+            )
+            success = solver.solve()
+
+            package_cache = api.MultiPackageCache([""])
+            transaction = api.Transaction(solver, package_cache)
+            pkg_information = json.loads(transaction.to_conda()[1][0][2])
+
+            import conda.models.records
+
+            return [conda.models.records.PackageRecord(**pkg_information)]
+        except:
+            logger.warning(
+                "get_pkgs using mamba failed, falling back to conda",
+                exc_info=True,
+            )
+            self.use_fallback = True
+            return self.get_pkgs(match_spec)

--- a/news/mamba.rst
+++ b/news/mamba.rst
@@ -1,0 +1,5 @@
+**Added:**
+
+* Use mamba to determine the latest version of ``conda-smithy`` and
+  ``conda-forge-pinning`` if ``mamba`` is available. In case of an error, we
+  will always silently fall back to using ``conda``.


### PR DESCRIPTION
Use mamba to determine the latest version of `conda-smithy` and  `conda-forge-pinning` if `mamba` is available. In case of an error, we will always silently fall back to using `conda`.

This saves ~20s for me (12s with mamba, 32s with conda for me in `conda smithy rerender` in `arrow-cpp`).

Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
