### PR TITLE
Add linter to check if required packages are in lower-case

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -515,6 +515,18 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
                 " form. See lines %s." % (bad_lines,)
             )
 
+    # 25: requirements should be all in lower-case
+    host_reqs = requirements_section.get("host") or []
+    run_reqs = requirements_section.get("run") or []
+    for reqs in [host_reqs, run_reqs]:
+        pkg = str(reqs).partition(" ")[0]
+        if pkg.islower():
+            continue
+        else:
+            lints.append(
+                "Package {0} should be in lower-case.".format(str(pkg))
+            )
+
     # hints
     # 1: suggest pip
     if "script" in build_section:

--- a/news/linter_requirements_lower_case.rst
+++ b/news/linter_requirements_lower_case.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+Added a linter check for requirements to be in lower-case
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

Sometimes CF PRs have dependent packages with capital letter, so this PR adds a linter that checks for that.