### PR TITLE
Make CI secrets configurable

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1482,6 +1482,7 @@ def _load_forge_config(forge_dir, exclusive_config_file):
         "bot": {"automerge": False},
         "conda_forge_output_validation": False,
         "private_upload": False,
+        "secrets": ["BINSTAR_TOKEN"],
     }
 
     forge_yml = os.path.join(forge_dir, "conda-forge.yml")
@@ -1530,6 +1531,9 @@ def _load_forge_config(forge_dir, exclusive_config_file):
                 # fmt: on
             if "name" in config["azure"][f"settings_{plat}"]["pool"]:
                 del config["azure"][f"settings_{plat}"]["pool"]["vmImage"]
+
+    if config["conda_forge_output_validation"]:
+        config["secrets"] = list(set(config["secrets"] + ["FEEDSTOCK_TOKEN", "STAGING_BINSTAR_TOKEN"]))
 
     # An older conda-smithy used to have some files which should no longer exist,
     # remove those now.

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1533,14 +1533,14 @@ def _load_forge_config(forge_dir, exclusive_config_file):
                 del config["azure"][f"settings_{plat}"]["pool"]["vmImage"]
 
     if config["conda_forge_output_validation"]:
-        config["secrets"] = list(
+        config["secrets"] = sorted(
             set(
                 config["secrets"]
                 + ["FEEDSTOCK_TOKEN", "STAGING_BINSTAR_TOKEN"]
             )
         )
 
-    config["secrets"] = list(set(config["secrets"] + ["BINSTAR_TOKEN"]))
+    config["secrets"] = sorted(set(config["secrets"] + ["BINSTAR_TOKEN"]))
 
     # An older conda-smithy used to have some files which should no longer exist,
     # remove those now.

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1482,7 +1482,7 @@ def _load_forge_config(forge_dir, exclusive_config_file):
         "bot": {"automerge": False},
         "conda_forge_output_validation": False,
         "private_upload": False,
-        "secrets": ["BINSTAR_TOKEN"],
+        "secrets": [],
     }
 
     forge_yml = os.path.join(forge_dir, "conda-forge.yml")
@@ -1534,6 +1534,8 @@ def _load_forge_config(forge_dir, exclusive_config_file):
 
     if config["conda_forge_output_validation"]:
         config["secrets"] = list(set(config["secrets"] + ["FEEDSTOCK_TOKEN", "STAGING_BINSTAR_TOKEN"]))
+
+    config["secrets"] = list(set(config["secrets"] + ["BINSTAR_TOKEN"]))
 
     # An older conda-smithy used to have some files which should no longer exist,
     # remove those now.

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1533,7 +1533,12 @@ def _load_forge_config(forge_dir, exclusive_config_file):
                 del config["azure"][f"settings_{plat}"]["pool"]["vmImage"]
 
     if config["conda_forge_output_validation"]:
-        config["secrets"] = list(set(config["secrets"] + ["FEEDSTOCK_TOKEN", "STAGING_BINSTAR_TOKEN"]))
+        config["secrets"] = list(
+            set(
+                config["secrets"]
+                + ["FEEDSTOCK_TOKEN", "STAGING_BINSTAR_TOKEN"]
+            )
+        )
 
     config["secrets"] = list(set(config["secrets"] + ["BINSTAR_TOKEN"]))
 

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -27,8 +27,6 @@ jobs:
         .scripts/run_docker_build.sh
     displayName: Run docker build
     env:
-      BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-{%- if conda_forge_output_validation %}
-      FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
-      STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
-{%- endif %}
+{%- for secret in secrets %}
+      {{ secret }}: $({{ secret }})
+{%- endfor %}

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -18,8 +18,6 @@ jobs:
       ./.scripts/run_osx_build.sh
     displayName: Run OSX build
     env:
-      BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-{%- if conda_forge_output_validation %}
-      FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
-      STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
-{%- endif %}
+{%- for secret in secrets %}
+      {{ secret }}: $({{ secret }})
+{%- endfor %}

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -105,9 +105,7 @@ jobs:
         upload_package {% if conda_forge_output_validation %}--validate --feedstock-name="%FEEDSTOCK_NAME%"{% endif %}{% if private_upload %} --private{% endif %} .\ ".\{{ recipe_dir }}" .ci_support\%CONFIG%.yaml
       displayName: Upload package
       env:
-        BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-{%- if conda_forge_output_validation %}
-        FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
-        STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
-{%- endif %}
+{%- for secret in secrets %}
+        {{ secret }}: $({{ secret }})
+{%- endfor %}
       condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -36,6 +36,7 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    --suppress-variables \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
 {%- if conda_forge_output_validation %}

--- a/conda_smithy/templates/drone.yml.tmpl
+++ b/conda_smithy/templates/drone.yml.tmpl
@@ -15,14 +15,10 @@ steps:
     CONFIG: {{ data.config_name }}
     UPLOAD_PACKAGES: {{ data.upload }}
     PLATFORM: {{ data.platform }}
-    BINSTAR_TOKEN:
-      from_secret: BINSTAR_TOKEN
-{%- if conda_forge_output_validation %}
-    FEEDSTOCK_TOKEN:
-      from_secret: FEEDSTOCK_TOKEN
-    STAGING_BINSTAR_TOKEN:
-      from_secret: STAGING_BINSTAR_TOKEN
-{%- endif %}
+{%- for secret in secrets %}
+    {{ secret }}:
+      from_secret: {{ secret }}
+{%- endfor %}
 
   {%- if 'linux' in data.platform %}
   commands:

--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -73,8 +73,8 @@ export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
            -e GIT_BRANCH \
            -e UPLOAD_ON_BRANCH \
            -e CI \
-{%- if conda_forge_output_validation %}
            -e FEEDSTOCK_NAME \
+{%- if conda_forge_output_validation %}
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \
 {%- endif %}

--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -74,7 +74,7 @@ export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
            -e CI \
            -e FEEDSTOCK_NAME \
 {%- for secret in secrets %}
-           -e {{ secret }}
+           -e {{ secret }} \
 {%- endfor %}
            $DOCKER_IMAGE \
            {{ docker.command }} \

--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -67,17 +67,15 @@ export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
            -e CONFIG \
-           -e BINSTAR_TOKEN \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \
            -e GIT_BRANCH \
            -e UPLOAD_ON_BRANCH \
            -e CI \
            -e FEEDSTOCK_NAME \
-{%- if conda_forge_output_validation %}
-           -e FEEDSTOCK_TOKEN \
-           -e STAGING_BINSTAR_TOKEN \
-{%- endif %}
+{%- for secret in secrets %}
+           -e {{ secret }}
+{%- endfor %}
            $DOCKER_IMAGE \
            {{ docker.command }} \
            /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -50,7 +50,7 @@ set -e
 
 echo -e "\n\nMaking the build clobber file and running the build."
 make_build_number ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
-conda build ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+conda build ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
 
 {%- if conda_forge_output_validation %}
 validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/news/secrets.rst
+++ b/news/secrets.rst
@@ -1,0 +1,13 @@
+**Added:**
+
+* Additional secrets can be passed to the build by setting `secrets: ["BINSTAR_TOKEN", "ANOTHER_SECRET"]`
+  in `conda-forge.yml`. These secrets are read from the CI configuration and
+  then exposed as environment variables. To make them visible to build scripts,
+  they need to be whitelisted in `build.script_env` of `meta.yaml`.
+  This can, e.g., be used to collect coverage statistics during a build or test
+  and upload them to sites such as coveralls.
+
+**Security:**
+
+* Added --suppress-variables so that CI secrets cannot be leaked by conda-build into CI logs.
+

--- a/tests/recipes/click-test-feedstock/.appveyor.yml
+++ b/tests/recipes/click-test-feedstock/.appveyor.yml
@@ -52,6 +52,6 @@ install:
 build: off
 
 test_script:
-    - conda build recipe -m .ci_support\appveyor_%CONFIG%.yaml --quiet
+    - conda build recipe -m .ci_support\appveyor_%CONFIG%.yaml --suppress-variables --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main -m .ci_support\appveyor_%CONFIG%.yaml

--- a/tests/recipes/click-test-feedstock/.circleci/run_docker_build.sh
+++ b/tests/recipes/click-test-feedstock/.circleci/run_docker_build.sh
@@ -58,7 +58,7 @@ source run_conda_forge_build_setup
 # testing purposes: get conda-build from defaults
 conda install -n root --quiet --yes -c defaults conda-build
 
-conda build /recipe_root -m /feedstock_root/.ci_support/circle_${CONFIG}.yaml --quiet || exit 1
+conda build /recipe_root -m /feedstock_root/.ci_support/circle_${CONFIG}.yaml --quiet --suppress-variables || exit 1
 upload_or_check_non_existence /recipe_root conda-forge --channel=main -m /feedstock_root/.ci_support/circle_${CONFIG}.yaml || exit 1
 
 touch /feedstock_root/build_artefacts/conda-forge-build-done

--- a/tests/recipes/click-test-feedstock/.travis.yml
+++ b/tests/recipes/click-test-feedstock/.travis.yml
@@ -53,6 +53,6 @@ install:
       conda install -n root --quiet --yes -c defaults conda-build
 
 script:
-  - conda build ./recipe -m ./.ci_support/travis_${CONFIG}.yaml
+  - conda build ./recipe -m ./.ci_support/travis_${CONFIG}.yaml --suppress-variables
 
   - upload_or_check_non_existence ./recipe conda-forge --channel=main -m ./.ci_support/travis_${CONFIG}.yaml

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -439,26 +439,51 @@ def test_readme_has_terminating_newline(noarch_recipe, jinja_env):
 
 
 def test_secrets(py_recipe, jinja_env):
-    cnfgr_fdstk.render_azure(jinja_env=jinja_env, forge_config=py_recipe.config, forge_dir=py_recipe.recipe)
+    cnfgr_fdstk.render_azure(
+        jinja_env=jinja_env,
+        forge_config=py_recipe.config,
+        forge_dir=py_recipe.recipe,
+    )
 
-    run_docker_build = os.path.join(py_recipe.recipe, ".scripts", "run_docker_build.sh")
+    run_docker_build = os.path.join(
+        py_recipe.recipe, ".scripts", "run_docker_build.sh"
+    )
     with open(run_docker_build, "rb") as run_docker_build_file:
         content = run_docker_build_file.read()
     assert b"-e BINSTAR_TOKEN" in content
 
-    for config_yaml in os.listdir(os.path.join(py_recipe.recipe, ".azure-pipelines")):
+    for config_yaml in os.listdir(
+        os.path.join(py_recipe.recipe, ".azure-pipelines")
+    ):
         if config_yaml.endswith(".yaml"):
             with open(config_yaml) as fo:
                 config = yaml.safe_load(fo)
                 if "jobs" in config:
-                    assert any(any(step.get('env', {}).get('BINSTAR_TOKEN', None) == '$(BINSTAR_TOKEN)' for step in job['steps']) for job in config['jobs'])
+                    assert any(
+                        any(
+                            step.get("env", {}).get("BINSTAR_TOKEN", None)
+                            == "$(BINSTAR_TOKEN)"
+                            for step in job["steps"]
+                        )
+                        for job in config["jobs"]
+                    )
 
     py_recipe.config["provider"]["linux_aarch64"] = "drone"
-    cnfgr_fdstk.render_drone(jinja_env=jinja_env, forge_config=py_recipe.config, forge_dir=py_recipe.recipe)
+    cnfgr_fdstk.render_drone(
+        jinja_env=jinja_env,
+        forge_config=py_recipe.config,
+        forge_dir=py_recipe.recipe,
+    )
 
-    with open(os.path.join(py_recipe.recipe, '.drone.yml')) as fo:
+    with open(os.path.join(py_recipe.recipe, ".drone.yml")) as fo:
         config = list(yaml.safe_load_all(fo))[-1]
-        assert any(step.get('environment', {}).get('BINSTAR_TOKEN', {}).get('from_secret', None) == 'BINSTAR_TOKEN' for step in config['steps'])
+        assert any(
+            step.get("environment", {})
+            .get("BINSTAR_TOKEN", {})
+            .get("from_secret", None)
+            == "BINSTAR_TOKEN"
+            for step in config["steps"]
+        )
 
 
 def test_migrator_recipe(recipe_migration_cfep9, jinja_env):


### PR DESCRIPTION
Additional secrets can be passed to the build by setting `secrets: ["BINSTAR_TOKEN", "ANOTHER_SECRET"]` in `conda-forge.yml`. These secrets are read from the CI configuration and then exposed as environment variables. To make them visible to build scripts, they need to be whitelisted in `build.script_env` of `meta.yaml`. This can, e.g., be used to collect coverage statistics during a build or test and upload them to sites such as coveralls.

Fixes #1162.

I tested this in actual CI runs for
* arb-feedstock which builds on [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/arb.svg)](https://anaconda.org/conda-forge/arb): https://github.com/conda-forge/arb-feedstock/pull/20
* and pyeantic which actually wants to set additional secrets: https://github.com/flatsurf/pyeantic/pull/41 note that this recipe was rendered with additional patches in conda-smithy from https://github.com/saraedum/conda-smithy