### PR TITLE
Remove `/opt/ghc` on Linux

### DIFF
--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -9,7 +9,7 @@ jobs:
   - script: |
          rm -rf /opt/ghc
          df -h
-    displayName: Manage disk space (rm /opt/ghc)
+    displayName: Manage disk space
 
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -9,7 +9,7 @@ jobs:
   - script: |
          rm -rf /opt/ghc
          df -h
-     displayName: Manage disk space (rm /opt/ghc)
+    displayName: Manage disk space (rm /opt/ghc)
 
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -6,6 +6,11 @@ jobs:
 - job: linux
   {{ azure_yaml|indent(2) }}
   steps:
+  - script: |
+         rm -rf /opt/ghc
+         df -h
+     displayName: Manage disk space (rm /opt/ghc)
+
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/news/rm_opt_ghc_linux_azure.rst
+++ b/news/rm_opt_ghc_linux_azure.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* <news item>
+* Removes ``/opt/ghc`` on Azure Linux images to free up space
 
 **Changed:**
 
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Removes ``/opt/ghc`` on Azure Linux images to free up space
+* <news item>
 
 **Security:**
 

--- a/news/rm_opt_ghc_linux_azure.rst
+++ b/news/rm_opt_ghc_linux_azure.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Removes ``/opt/ghc`` on Azure Linux images to free up space
+
+**Security:**
+
+* <news item>
+

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -241,11 +241,11 @@ def test_upload_on_branch_azure(upload_on_branch_recipe, jinja_env):
         content_lin = yaml.load(fp)
     assert (
         'UPLOAD_ON_BRANCH="foo-branch"'
-        in content_lin["jobs"][0]["steps"][1]["script"]
+        in content_lin["jobs"][0]["steps"][2]["script"]
     )
     assert (
         "BUILD_SOURCEBRANCHNAME"
-        in content_lin["jobs"][0]["steps"][1]["script"]
+        in content_lin["jobs"][0]["steps"][2]["script"]
     )
 
 


### PR DESCRIPTION
The content in `/opt/ghc` seems to take up a fair bit of space on the Linux images and we don't use it. As it limits the memory available for jobs that are more memory hungry and doesn't seem to take long to clear, go ahead and remove `/opt/ghc` at the start of the job.

cc @beckermr @isuruf @h-vetinari @pearu

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

xref: https://github.com/conda-forge/faiss-split-feedstock/pull/10
xref: https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/105
xref: https://github.com/conda-forge/omniscidb-feedstock/issues/5
xref: https://github.com/conda-forge/faiss-split-feedstock/pull/5