### PR TITLE
Use 50/72 rule with git commit messages

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -106,9 +106,13 @@ class Init(Subcommand):
         feedstock_directory = args.feedstock_directory.format(
             package=argparse.Namespace(name=meta.name())
         )
-        msg = "Initial feedstock commit with conda-smithy {}.".format(
-            __version__
-        )
+        msg = dedent(
+            """\
+            Initial feedstock commit
+
+            * conda-smithy {}
+            """
+        ).format(__version__)
 
         os.makedirs(feedstock_directory)
         subprocess.check_call(["git", "init"], cwd=feedstock_directory)

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1637,14 +1637,20 @@ def check_version_uptodate(name, installed_version, error_on_warn):
 
 
 def commit_changes(forge_file_directory, commit, cs_ver, cfp_ver, cb_ver):
+    msg = textwrap.dedent(
+        """\
+        MNT: Re-rendered
+
+        * conda-build {}
+        * conda-smithy {}
+        """
+    ).format(cb_ver, cs_ver)
     if cfp_ver:
-        msg = "Re-rendered with conda-build {}, conda-smithy {}, and conda-forge-pinning {}".format(
-            cb_ver, cs_ver, cfp_ver
-        )
-    else:
-        msg = "Re-rendered with conda-build {} and conda-smithy {}".format(
-            cb_ver, cs_ver
-        )
+        msg += textwrap.dedent(
+            """\
+            * conda-forge-pinning {}
+            """
+        ).format(cfp_ver)
     logger.info(msg)
 
     is_git_repo = os.path.exists(os.path.join(forge_file_directory, ".git"))
@@ -1655,7 +1661,7 @@ def commit_changes(forge_file_directory, commit, cs_ver, cfp_ver, cb_ver):
         )
         if has_staged_changes:
             if commit:
-                git_args = ["git", "commit", "-m", "MNT: {}".format(msg)]
+                git_args = ["git", "commit", "-m", msg]
                 if commit == "edit":
                     git_args += ["--edit", "--status", "--verbose"]
                 subprocess.check_call(git_args, cwd=forge_file_directory)
@@ -1663,7 +1669,7 @@ def commit_changes(forge_file_directory, commit, cs_ver, cfp_ver, cb_ver):
             else:
                 logger.info(
                     "You can commit the changes with:\n\n"
-                    '    git commit -m "MNT: {}"\n'.format(msg)
+                    '    git commit -m "MNT: Re-rendered"\n'
                 )
             logger.info("These changes need to be pushed to github!\n")
         else:

--- a/news/follow_50_72_git_commit_msg.rst
+++ b/news/follow_50_72_git_commit_msg.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Use 50/72 rule with conda-smithy's commit messages
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
Updates conda-smithy's commit messages and recommended commit messages to follow the recommended 50/72 rule. Namely it keeps the subject line to 50 characters and the body of the commit to 72 characters per line (wrapping when exceeding that length) with a blank line between. GitHub also uses this rule when displaying commit messages by effectively hiding anything over 50 characters in the subject line and hiding the body of the commit message.

https://www.git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines
https://chris.beams.io/posts/git-commit/

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
