### PR TITLE
Shorten config & job names

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -41,14 +41,6 @@ logger = logging.getLogger(__name__)
 def package_key(config, used_loop_vars, subdir):
     build_vars = {key: str(config[key][0]) for key in used_loop_vars}
 
-    # Target platform determines a lot of output behavior, but may not be explicitly listed in the recipe.
-    tp = config.get("target_platform")
-    if tp:
-        if isinstance(tp, list):
-            tp = tp[0]
-        if tp != subdir and "target_platform" not in build_vars:
-            build_vars["target_platform"] = tp
-
     # Sort values by keys and simplify them
     build_vars = [
         build_vars[key].replace(".*", "") for key in sorted(build_vars)

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1153,8 +1153,11 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
         if not data["platform"].startswith(platform):
             continue
 
-        config_name_without_job_name = re.sub(
-            "^{0}_".format(re.escape(platform)), "", data["config_name"]
+        config_name_without_job_name = (
+            re.sub(
+                "^{0}_".format(re.escape(platform)), "", data["config_name"]
+            )
+            or "build"
         )
 
         config_rendered = OrderedDict(

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -391,7 +391,7 @@ def dump_subspace_config_files(
     # the value of python_impl can usually be determined by looking at the
     # value of python, so we can shorten some file names by dropping the former.
     for var in sorted(
-        top_level_loop_vars,
+        set(top_level_loop_vars).intersection(forge_config["silenced_vars"]),
         # Prefer short values
         key=lambda v: (-len(max([str(config[v]) for config in configs])), v),
     ):
@@ -1505,6 +1505,7 @@ def _load_forge_config(forge_dir, exclusive_config_file):
         "conda_forge_output_validation": False,
         "private_upload": False,
         "secrets": [],
+        "silenced_vars": ["python_impl"],
     }
 
     forge_yml = os.path.join(forge_dir, "conda-forge.yml")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,7 +79,7 @@ def test_init_multiple_output_matrix(testing_workdir):
     # though - loops within outputs are contained in those top-level configs.
     matrix_dir_len = len(os.listdir(matrix_dir))
     assert matrix_dir_len == 13
-    linux_libpng16 = os.path.join(matrix_dir, "linux_libpng1.6libpq9.5.yaml")
+    linux_libpng16 = os.path.join(matrix_dir, "linux_1.6_9.5.yaml")
     assert os.path.isfile(linux_libpng16)
     with open(linux_libpng16) as f:
         config = yaml.load(f)
@@ -131,7 +131,7 @@ def test_init_cuda_docker_images(testing_workdir):
     matrix_dir_len = len(os.listdir(matrix_dir))
     assert matrix_dir_len == 5
     for v in [None, "9.2", "10.0", "10.1"]:
-        fn = os.path.join(matrix_dir, f"linux_cuda_compiler_version{v}.yaml")
+        fn = os.path.join(matrix_dir, f"linux_{v}.yaml")
         assert os.path.isfile(fn)
         with open(fn) as fh:
             config = yaml.load(fh)

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -624,12 +624,11 @@ def test_migrator_compiler_version_recipe(
     rendered_variants = os.listdir(
         os.path.join(recipe_migration_win_compiled.recipe, ".ci_support")
     )
-    print(rendered_variants)
 
-    assert "win_2.7_win32.yaml" in rendered_variants
-    assert "win_2.7_win64.yaml" in rendered_variants
-    assert "win_3.5_win32.yaml" in rendered_variants
-    assert "win_3.5_win64.yaml" in rendered_variants
+    assert "win_2.7_vs2008_win32.yaml" in rendered_variants
+    assert "win_2.7_vs2008_win64.yaml" in rendered_variants
+    assert "win_3.5_vs2017_win32.yaml" in rendered_variants
+    assert "win_3.5_vs2017_win64.yaml" in rendered_variants
 
 
 def test_files_skip_render(render_skipped_recipe, jinja_env):

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -495,9 +495,7 @@ def test_migrator_recipe(recipe_migration_cfep9, jinja_env):
 
     with open(
         os.path.join(
-            recipe_migration_cfep9.recipe,
-            ".ci_support",
-            "linux_python2.7.yaml",
+            recipe_migration_cfep9.recipe, ".ci_support", "linux_2.7.yaml",
         )
     ) as fo:
         variant = yaml.safe_load(fo)
@@ -528,9 +526,7 @@ def test_migrator_cfp_override(recipe_migration_cfep9, jinja_env):
 
     with open(
         os.path.join(
-            recipe_migration_cfep9.recipe,
-            ".ci_support",
-            "linux_python2.7.yaml",
+            recipe_migration_cfep9.recipe, ".ci_support", "linux_2.7.yaml",
         )
     ) as fo:
         variant = yaml.safe_load(fo)
@@ -594,7 +590,7 @@ def test_migrator_downgrade_recipe(
         os.path.join(
             recipe_migration_cfep9_downgrade.recipe,
             ".ci_support",
-            "linux_python2.7.yaml",
+            "linux_2.7.yaml",
         )
     ) as fo:
         variant = yaml.safe_load(fo)
@@ -628,23 +624,12 @@ def test_migrator_compiler_version_recipe(
     rendered_variants = os.listdir(
         os.path.join(recipe_migration_win_compiled.recipe, ".ci_support")
     )
+    print(rendered_variants)
 
-    assert (
-        "win_c_compilervs2008python2.7target_platformwin-32.yaml"
-        in rendered_variants
-    )
-    assert (
-        "win_c_compilervs2008python2.7target_platformwin-64.yaml"
-        in rendered_variants
-    )
-    assert (
-        "win_c_compilervs2017python3.5target_platformwin-32.yaml"
-        in rendered_variants
-    )
-    assert (
-        "win_c_compilervs2017python3.5target_platformwin-64.yaml"
-        in rendered_variants
-    )
+    assert "win_2.7_win32.yaml" in rendered_variants
+    assert "win_2.7_win64.yaml" in rendered_variants
+    assert "win_3.5_win32.yaml" in rendered_variants
+    assert "win_3.5_win64.yaml" in rendered_variants
 
 
 def test_files_skip_render(render_skipped_recipe, jinja_env):


### PR DESCRIPTION
I found the names that are generated for CI jobs a bit difficult to parse, e.g., here:

![image](https://user-images.githubusercontent.com/373765/85857576-6dabd800-b7ba-11ea-9419-8a1ea414271e.png)

with this change, they look a bit nicer to me:

![image](https://user-images.githubusercontent.com/373765/85857658-8c11d380-b7ba-11ea-8413-d31e9ff75ace.png)

TODO:

* [ ] Bring back platform-target
* [ ] Write NEWS
* [ ] More tests