### PR TITLE
Mention 'strict' channel priority in feedstock READMEs

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -183,6 +183,7 @@ Installing `{{ package_name }}` from the `{{ channel_name }}` channel can be ach
 
 ```
 conda config --add channels {{ channel_name }}
+conda config --set channel_priority strict
 ```
 
 Once the `{{ channel_name }}` channel has been enabled, `{{ ', '.join(outputs) }}` can be installed with:

--- a/news/mention-strict-channel-priority.rst
+++ b/news/mention-strict-channel-priority.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Add instructions to feedstock README template for configuring strict channel priority.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes https://github.com/conda-forge/conda-smithy/issues/1348
<!--
Please add any other relevant info below:
-->
Bring the README template for feedstocks in line with the [conda-forge
documentation][1] by mentioning how to configure 'strict' channel
priority after adding the `{{ channel_name }}` channel.

[1]: https://conda-forge.org/docs/user/introduction.html#how-can-i-install-packages-from-conda-forge


