### PR TITLE
Pass CPU_COUNT to the docker container

### DIFF
--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -73,6 +73,7 @@ export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
            -e UPLOAD_ON_BRANCH \
            -e CI \
            -e FEEDSTOCK_NAME \
+           -e CPU_COUNT \
 {%- for secret in secrets %}
            -e {{ secret }} \
 {%- endfor %}

--- a/news/pass-cpu-count-to-docker.rst
+++ b/news/pass-cpu-count-to-docker.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* Pass ``CPU_COUNT`` from the host environment to the docker build.
+  (Convenient when building locally.)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
Many recipes use `make -j${CPU_COUNT}`.  When running `build-locally.py`, it's convenient to be able to specify the `CPU_COUNT` environment variable manually.  This PR passes that variable from the host environment to the docker container.

---

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
