### PR TITLE
Propagate CPU_COUNT variable to the docker build

### DIFF
--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -73,6 +73,7 @@ export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
            -e UPLOAD_ON_BRANCH \
            -e CI \
            -e FEEDSTOCK_NAME \
+           -e CPU_COUNT \
 {%- for secret in secrets %}
            -e {{ secret }} \
 {%- endfor %}

--- a/news/cpu_count.rst
+++ b/news/cpu_count.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* The CPU_COUNT environment variable can now be set externally and propogated to docker based Linux builds
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

In combination with https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/107 this makes it easier to debug locally on many core machines by setting the variable instead of modifying the recipe.