### PR TITLE
Clone all return

### DIFF
--- a/conda_smithy/feedstocks.py
+++ b/conda_smithy/feedstocks.py
@@ -107,10 +107,11 @@ def clone_all(gh_org, feedstocks_dir):
         pool.apply_async(clone_feedstock, args=(repo, feedstocks_dir))
     pool.close()
     pool.join()
+    return feedstocks
 
 
 def feedstocks_clone_all_handle_args(args):
-    return clone_all(args.organization, args.feedstocks_directory)
+    clone_all(args.organization, args.feedstocks_directory)
 
 
 def feedstocks_list_cloned_handle_args(args):

--- a/news/clone_all_return_repos.rst
+++ b/news/clone_all_return_repos.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Return type of ``feedstocks.clone_all()`` from ``None`` to list of repositories
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Changed return type of `feedstocks.clone_all()` from `None` to the list of repositories cloned.
I also changed `feedstocks_clone_all_handle_args` so it does not print the list of Repository objects when using the entry point.