### PR TITLE
Publish conda build artifacts on Azure as pipeline artifacts.

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1442,6 +1442,8 @@ def _load_forge_config(forge_dir, exclusive_config_file):
             "project_id": "84710dde-1620-425b-80d0-4cf5baca359d",
             # Set timeout for all platforms at once.
             "timeout_minutes": None,
+            # Toggle creating pipeline artifacts for conda build_artifacts dir
+            "store_build_artifacts": False,
         },
         "provider": {
             "linux": "azure",

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -36,6 +36,7 @@ jobs:
       {{ secret }}: $({{ secret }})
 {%- endfor %}
 
+{%- if azure.store_build_artifacts %}
   - script: |
         if [ -d build_artifacts ]; then
           echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"
@@ -46,3 +47,4 @@ jobs:
   - publish: build_artifacts/
     artifact: conda_artifacts_$(CONFIG)_$(system.JobId)
     condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')
+{%- endif %}

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -44,5 +44,5 @@ jobs:
     condition: succeededOrFailed()
 
   - publish: build_artifacts/
-    artifact: conda_artifacts_$(CONFIG)
+    artifact: conda_artifacts_$(CONFIG)_$(system.JobId)
     condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -35,3 +35,14 @@ jobs:
 {%- for secret in secrets %}
       {{ secret }}: $({{ secret }})
 {%- endfor %}
+
+  - script: |
+        if [ -d build_artifacts ]; then
+          echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"
+        fi
+    displayName: Check for conda build artifacts
+    condition: succeededOrFailed()
+
+  - publish: build_artifacts/
+    artifact: conda_artifacts_$(CONFIG)
+    condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -30,5 +30,5 @@ jobs:
     condition: succeededOrFailed()
 
   - publish: /Users/runner/miniforge3/conda-bld/
-    artifact: conda_artifacts_$(CONFIG)
+    artifact: conda_artifacts_$(CONFIG)_$(system.JobId)
     condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -22,6 +22,7 @@ jobs:
       {{ secret }}: $({{ secret }})
 {%- endfor %}
 
+{%- if azure.store_build_artifacts %}
   - script: |
         if [ -d /Users/runner/miniforge3/conda-bld/ ]; then
           echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"
@@ -32,3 +33,4 @@ jobs:
   - publish: /Users/runner/miniforge3/conda-bld/
     artifact: conda_artifacts_$(CONFIG)_$(system.JobId)
     condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')
+{%- endif %}

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -21,3 +21,14 @@ jobs:
 {%- for secret in secrets %}
       {{ secret }}: $({{ secret }})
 {%- endfor %}
+
+  - script: |
+        if [ -d /Users/runner/miniforge3/conda-bld/ ]; then
+          echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"
+        fi
+    displayName: Check for conda build artifacts
+    condition: succeededOrFailed()
+
+  - publish: /Users/runner/miniforge3/conda-bld/
+    artifact: conda_artifacts_$(CONFIG)
+    condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -87,6 +87,17 @@ jobs:
         PYTHONUNBUFFERED: 1
       condition: not(contains(variables['CONFIG'], 'vs2008'))
 
+    - script: |
+        if exist $(CONDA_BLD_PATH)\\ (
+          echo ##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true
+        )
+      displayName: Check for conda build artifacts
+      condition: succeededOrFailed()
+
+    - publish: $(CONDA_BLD_PATH)\\
+      artifact: conda_artifacts_$(CONFIG)
+      condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')
+
 {%- if conda_forge_output_validation %}
     - script: |
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -95,7 +95,7 @@ jobs:
       condition: succeededOrFailed()
 
     - publish: $(CONDA_BLD_PATH)\\
-      artifact: conda_artifacts_$(CONFIG)
+      artifact: conda_artifacts_$(CONFIG)_$(system.JobId)
       condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')
 
 {%- if conda_forge_output_validation %}

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -87,6 +87,7 @@ jobs:
         PYTHONUNBUFFERED: 1
       condition: not(contains(variables['CONFIG'], 'vs2008'))
 
+{%- if azure.store_build_artifacts %}
     - script: |
         if exist $(CONDA_BLD_PATH)\\ (
           echo ##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true
@@ -97,6 +98,7 @@ jobs:
     - publish: $(CONDA_BLD_PATH)\\
       artifact: conda_artifacts_$(CONFIG)_$(system.JobId)
       condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')
+{%- endif %}
 
 {%- if conda_forge_output_validation %}
     - script: |

--- a/news/azure_artifacts_conda_pkgs.rst
+++ b/news/azure_artifacts_conda_pkgs.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Publish conda build artifacts on Azure as pipeline artifacts.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+

--- a/news/azure_artifacts_conda_pkgs.rst
+++ b/news/azure_artifacts_conda_pkgs.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Publish conda build artifacts on Azure as pipeline artifacts.
+* Publish conda build artifacts on Azure as pipeline artifacts when azure.store_build_artifacts flag is True in conda-forge.yml. The default is False.
 
 **Changed:**
 

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -207,11 +207,11 @@ def test_upload_on_branch_azure(upload_on_branch_recipe, jinja_env):
         content_osx = yaml.load(fp)
     assert (
         'UPLOAD_ON_BRANCH="foo-branch"'
-        in content_osx["jobs"][0]["steps"][-1]["script"]
+        in content_osx["jobs"][0]["steps"][0]["script"]
     )
     assert (
         "BUILD_SOURCEBRANCHNAME"
-        in content_osx["jobs"][0]["steps"][-1]["script"]
+        in content_osx["jobs"][0]["steps"][0]["script"]
     )
 
     with open(


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This adds steps to the Azure pipeline templates that save the conda build output directory as an Azure pipeline artifact. This is useful for inspecting the build result and testing built packages before they are published. I think I've set it up so that the artifact publishing won't run if the directory doesn't exist, and also that it will still run even if the build fails (making the work directory available, for example). I tested this on one recipe, https://github.com/conda-forge/soapysdr-module-rtlsdr-feedstock/pull/1, and it works at least when the builds succeed. Wider testing would probably be wise.

This is an evolution of a similar feature that has already been implemented for conda-forge/staged-recipes (https://github.com/conda-forge/staged-recipes/pull/11827, https://github.com/conda-forge/staged-recipes/pull/11832).

I don't know if there need to be considerations for the size of the published artifacts, or how long they are kept around. As far as I can tell, the artifacts will exist for as long as Microsoft allows the pipeline to keep them around.