### PR TITLE
ci_register.py: Guard against KeyError from empty travis_get_repo_info

### DIFF
--- a/conda_smithy/ci_register.py
+++ b/conda_smithy/ci_register.py
@@ -465,6 +465,14 @@ def travis_configure(user, project):
     headers = travis_headers()
 
     repo_info = travis_get_repo_info(user, project)
+
+    if not repo_info:
+        msg = (
+            "Unable to retrieve repo info from Travis\n"
+            '(Is it down? Is the "{}/{}" name spelt correctly? [note: case sensitive])'
+        )
+        raise RuntimeError(msg.format(user, project))
+
     repo_id = repo_info["id"]
 
     if repo_info["active"] is not True:
@@ -494,6 +502,14 @@ def add_token_to_travis(user, project):
     headers = travis_headers()
 
     repo_info = travis_get_repo_info(user, project)
+
+    if not repo_info:
+        msg = (
+            "Unable to retrieve repo info from Travis\n"
+            '(Is it down? Is the "{}/{}" name spelt correctly? [note: case sensitive])'
+        )
+        raise RuntimeError(msg.format(user, project))
+
     repo_id = repo_info["id"]
 
     r = requests.get(

--- a/news/prevent_travis_get_repo_info_keyerror.rst
+++ b/news/prevent_travis_get_repo_info_keyerror.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Raise RuntimeError on empty travis repo_info requests, to guard against later KeyErrors
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
Snippet modified from deprecated add_project_to_travis func
