### PR TITLE
conda-forge.yml: Re-add idle_timeout_minutes support for Travis

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -47,8 +47,8 @@ script:
   - export UPLOAD_ON_BRANCH="{{ upload_on_branch }}"
 {%- endif %}
 {% if 'osx' in platformset %}
-  - if [[ ${PLATFORM} =~ .*osx.* ]]; then ./.scripts/run_osx_build.sh; fi
+  - if [[ ${PLATFORM} =~ .*osx.* ]]; then {%- if idle_timeout_minutes %} travis_wait {{ idle_timeout_minutes }}{% endif %} ./.scripts/run_osx_build.sh; fi
 {%- endif %}
 {% if 'linux' in platformset %}
-  - if [[ ${PLATFORM} =~ .*linux.* ]]; then ./.scripts/run_docker_build.sh; fi
+  - if [[ ${PLATFORM} =~ .*linux.* ]]; then {%- if idle_timeout_minutes %} travis_wait {{ idle_timeout_minutes }}{% endif %} ./.scripts/run_docker_build.sh; fi
 {%- endif %}

--- a/news/idle_timeout_minutes_travis.rst
+++ b/news/idle_timeout_minutes_travis.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Re add travis_wait support via idle_timeout_minutes
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
This is for #1363 

As it's re-adding already claimed config then I'm not sure it deserves a NEWS entry?
