### PR TITLE
configure_feedstock.py: Re-add per provider parsing of upload_packages

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -939,7 +939,11 @@ def _get_platforms_of_provider(provider, forge_config):
                 keep_noarchs.append(True)
             else:
                 keep_noarchs.append(False)
-            upload_packages.append(True)
+            # Allow config to disable package uploads on a per provider basis,
+            # default to True if not set explicitly set to False by config entry.
+            upload_packages.append(
+                (forge_config.get(provider, {}).get("upload_packages", True))
+            )
         elif (
             provider == "azure"
             and forge_config["azure"]["force"]
@@ -1466,8 +1470,6 @@ def _load_forge_config(forge_dir, exclusive_config_file):
                 "strategy": {"maxParallel": 4},
                 "variables": {"CONDA_BLD_PATH": r"D:\\bld\\"},
             },
-            # disallow publication of azure artifacts for now.
-            "upload_packages": False,
             # Force building all supported providers.
             "force": False,
             # name and id of azure project that the build pipeline is in

--- a/news/upload_packages_config.rst
+++ b/news/upload_packages_config.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* Unparsed `"upload_packages": False` from default conda-forge.yml, as not parsed & no longer reflective of defaults
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* re-enabled `upload_packages` per provider to conda-forge.yml, which when set to False overrides default upload logic
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
Re-enable upload_packages to be set to False on a per provider basis
to override default upload logic. Also remove the non parsed
default entry for Azure.

This will need an accompanying update to the docs website. I'm not sure if makes sense keeping the config option as `upload_packages` and requiring the user to set it `False` to opt-out,  maybe replacing it with `disable_upload` and requiring an explicit `True` is a better opt-in.

Also as this configurability was seemingly lost, maybe adding a test is worthwhile.

https://github.com/conda-forge/conda-smithy/issues/1371  