### PR TITLE
Add lint for deleting staged_recipes example meta.yaml

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -742,6 +742,13 @@ def run_conda_forge_specific(meta, recipe_dir, lints, hints):
             "into its own dir."
         )
 
+    # 4: Do not delete example recipe
+    if is_staged_recipes and not os.path.exists("recipes/example/meta.yaml"):
+        lints.append(
+            "Please do not delete the example recipe found in "
+            "(recipes/example/meta.yaml)"
+        )
+
 
 def is_selector_line(line):
     # Using the same pattern defined in conda-build (metadata.py),


### PR DESCRIPTION
This adds a lint for staged recipes to warn when `recipes/example/meta.yaml` has been removed. I see this not infrequently when reviewing PRs there.

I'm not super familiar with the linting code, so I'm not 100% sure that I've done this correctly. Feedback appreciated. 