### PR TITLE
[DO NOT MERGE] Avoid install & uninstall of setup package if local_ci_setup set

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -46,10 +46,9 @@ install:
     - cmd: set PYTHONUNBUFFERED=1
 
     # Configure the VM.
-    # Tell conda we want an updated version of conda-forge-ci-setup and conda-build
-    - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=3 conda-build pip
+    # Tell conda we want an updated version of {%- if not local_ci_setup %} conda-forge-ci-setup=3 and{% endif %} conda-build
+    - cmd: conda.exe install -n root -c conda-forge --quiet --yes {%- if not local_ci_setup %} conda-forge-ci-setup=3{% endif %} conda-build
     {%- if local_ci_setup %}
-    - cmd: conda.exe uninstall --quiet --yes --force conda-forge-ci-setup
     - cmd: pip install --no-deps .\{{ recipe_dir }}\.
     {%- endif %}
     - cmd: setup_conda_rc .\ .\{{ recipe_dir }} .\.ci_support\%CONFIG%.yaml

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -42,7 +42,7 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=3 pip' # Optional
+        packageSpecs: 'python=3.6 conda-build conda {%- if not local_ci_setup %} conda-forge::conda-forge-ci-setup=3{% endif %}' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment
@@ -54,7 +54,6 @@ jobs:
     - script: |
         call activate base
         {%- if local_ci_setup %}
-        conda.exe uninstall --quiet --yes --force conda-forge-ci-setup
         pip install --no-deps ".\{{ recipe_dir }}\."
         {%- endif %}
         setup_conda_rc .\ ".\{{ recipe_dir }}" .\.ci_support\%CONFIG%.yaml

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -19,9 +19,8 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge-ci-setup=3 conda-build pip -c conda-forge
+conda install --yes --quiet {%- if not local_ci_setup %} conda-forge-ci-setup=3{% endif %} conda-build -c conda-forge
 {% if local_ci_setup %}
-conda uninstall --quiet --yes --force conda-forge-ci-setup
 pip install --no-deps ${RECIPE_ROOT}/.
 {%- endif %}
 # set up the condarc

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -22,11 +22,10 @@ fi
 source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
-echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+echo -e "\n\nInstalling {%- if not local_ci_setup %} conda-forge-ci-setup=3 and{% endif %} conda-build."
+conda install -n base --quiet --yes {%- if not local_ci_setup %} conda-forge-ci-setup=3{% endif %} conda-build
 
 {% if local_ci_setup %}
-conda uninstall --quiet --yes --force conda-forge-ci-setup
 pip install --no-deps {{ recipe_dir }}/.
 {%- endif %}
 

--- a/news/avoid_setup_package_uninstall
+++ b/news/avoid_setup_package_uninstall
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Build templates no longer install & then uninstall `conda-forge-ci-setup` package if configured for local_ci_setup
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* Removed pip from `conda install` list in build templates as already a transient dependency from conda-build
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
Also remove pip from `conda install` list in build templates
as already a transient dependency from conda-build.

This should remove some redundant time in certain pipeline configurations.