### PR TITLE
Fix lint for deleting staged_recipes example meta.yaml

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -743,11 +743,17 @@ def run_conda_forge_specific(meta, recipe_dir, lints, hints):
         )
 
     # 4: Do not delete example recipe
-    if is_staged_recipes and not os.path.exists("recipes/example/meta.yaml"):
-        lints.append(
-            "Please do not delete the example recipe found in "
-            "(recipes/example/meta.yaml)"
+    if is_staged_recipes and recipe_dir is not None:
+
+        example_meta_fname = os.path.abspath(
+            os.path.join(recipe_dir, "..", "example", "meta.yaml")
         )
+
+        if not os.path.exists(example_meta_fname):
+            lints.append(
+                "Please do not delete the example recipe found in "
+                "`recipes/example/meta.yaml`"
+            )
 
 
 def is_selector_line(line):

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -750,10 +750,11 @@ def run_conda_forge_specific(meta, recipe_dir, lints, hints):
         )
 
         if not os.path.exists(example_meta_fname):
-            lints.append(
-                "Please do not delete the example recipe found in "
-                "`recipes/example/meta.yaml`"
-            )
+            msg = "Please do not delete the example recipe found in " \
+                "`recipes/example/meta.yaml`."
+
+            if msg not in lints:
+                lints.append(msg)
 
 
 def is_selector_line(line):

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -750,8 +750,10 @@ def run_conda_forge_specific(meta, recipe_dir, lints, hints):
         )
 
         if not os.path.exists(example_meta_fname):
-            msg = "Please do not delete the example recipe found in " \
+            msg = (
+                "Please do not delete the example recipe found in "
                 "`recipes/example/meta.yaml`."
+            )
 
             if msg not in lints:
                 lints.append(msg)

--- a/news/fix_delete_example_recipe_lint.rst
+++ b/news/fix_delete_example_recipe_lint.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Error with linting check for deletion of `recipes/example/meta.yaml` in `staged-recipes`
+
+**Security:**
+
+* <news item>
+

--- a/news/fix_delete_example_recipe_lint.rst
+++ b/news/fix_delete_example_recipe_lint.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Error with linting check for deletion of `recipes/example/meta.yaml` in `staged-recipes`
+* Error with linting check for deletion of ``recipes/example/meta.yaml`` in staged-recipes
 
 **Security:**
 


### PR DESCRIPTION
I believe this will fix the incorrect linting that was merged in #1381 and is shown to not work in https://github.com/conda-forge/staged-recipes/pull/12364#issuecomment-672339382

This is not tested (as was the previous PR obviously), but looking at https://github.com/conda-forge/conda-smithy/blob/0baf80c2a3284ed91b3045591b0b1cea4cc10ed3/conda_smithy/lint_recipe.py#L570-L572

it seems like this will work. The originally hard-coded path assumed that the working directory was inside the repo, but I think it is probably above the repo (so `staged-recipes/recipes/example/meta.yaml` would have worked). 

Two questions:
- Is there are way to easily test this?
- Will the back ticks around the file path in the lint message render correctly? The parentheses in the original PR seem strange in retrospect. 