### PR TITLE
cli.py: Remove unneeded set_default() for --without-$CI args

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -216,8 +216,6 @@ class RegisterCI(Subcommand):
                 action="store_false",
                 help="If set, {} will be not registered".format(ci),
             )
-            default = {ci.lower(): True}
-            scp.set_defaults(**default)
 
     def __call__(self, args):
         from conda_smithy import ci_register
@@ -681,8 +679,6 @@ class RegisterFeedstockToken(Subcommand):
                 action="store_false",
                 help="If set, {} will be not registered".format(ci),
             )
-            default = {ci.lower(): True}
-            scp.set_defaults(**default)
 
     def __call__(self, args):
         from conda_smithy.feedstock_tokens import (
@@ -774,8 +770,6 @@ class UpdateAnacondaToken(Subcommand):
                 action="store_false",
                 help="If set, the token on {} will be not changed.".format(ci),
             )
-            default = {ci.lower(): True}
-            scp.set_defaults(**default)
 
     def __call__(self, args):
         from conda_smithy.anaconda_token_rotation import rotate_anaconda_token

--- a/news/remove_unneeded_default.rst
+++ b/news/remove_unneeded_default.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* Remove unneeded set_defaults() for --without-$CI args, ``action="store_false"`` already defaults to True if not given
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
`action="store_false"` already defaults to True if not given