### PR TITLE
cli.py: Add `--without-anaconda-token` option to register-ci command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ the feedstock or after.
 3. **Register the feedstock with CI services:**
 `conda smithy register-ci --organization conda-forge --feedstock_directory ./foo-feedstock`.
 This requires tokens for the CI services. You can give the name of a user instead
-of organization with `--user github_user_name`.
+of organization with `--user github_user_name`. By default this command requires an Anaconda/Binstar token
+to be available in `~/.conda-smithy/anaconda.token`, or as BINSTAR_TOKEN in the environment. This can be opted
+out of by specifying `--without-anaconda-token`, as such execpted package uploads will not be attempted.
      * For Azure, you will have to create a service connection with the same name as your github user or org
         `https://dev.azure.com/YOUR_ORG/feedstock-builds/_settings/adminservices`
      * For Azure builds, you will have to export the environment variable `AZURE_ORG_OR_USER` to point to your Azure org

--- a/conda_smithy/ci_register.py
+++ b/conda_smithy/ci_register.py
@@ -635,6 +635,7 @@ def _get_anaconda_token():
     except NameError:
         raise RuntimeError(
             "You must have the anaconda token defined to do CI registration"
+            "This requirement can be overriden by specifying `--without-anaconda-token`"
         )
 
 

--- a/news/optional_anaconda_token.rst
+++ b/news/optional_anaconda_token.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Add ``--without-anaconda-token`` option to register-ci command, keep default behaviour of requiring the token
+
+**Changed:**
+
+* Added note about behaviour to README.md
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
The default behaviour of register-ci requires an Anaconda/Binstar
token to be provided. Allow this to be overridden & warn of the
consequences. update-anaconda-token & upload_package in
conda-forge-ci-setup already handle BINSTAR_TOKEN not being set
on the provider.

This is for issue https://github.com/conda-forge/conda-smithy/issues/1373