### PR TITLE
Only install dependencies of ci-setup package if local_ci_setup is set

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -46,10 +46,9 @@ install:
     - cmd: set PYTHONUNBUFFERED=1
 
     # Configure the VM.
-    # Tell conda we want an updated version of conda-forge-ci-setup and conda-build
-    - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=3 conda-build pip
+    # Tell conda we want an updated version of conda-forge-ci-setup=3 {%- if local_ci_setup %} dependencies{% endif %}
+    - cmd: conda.exe install -n root -c conda-forge --quiet --yes {%- if local_ci_setup %} --only-deps{% endif %} conda-forge-ci-setup=3
     {%- if local_ci_setup %}
-    - cmd: conda.exe uninstall --quiet --yes --force conda-forge-ci-setup
     - cmd: pip install --no-deps .\{{ recipe_dir }}\.
     {%- endif %}
     - cmd: setup_conda_rc .\ .\{{ recipe_dir }} .\.ci_support\%CONFIG%.yaml

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -42,10 +42,10 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=3 pip' # Optional
-        installOptions: "-c conda-forge"
+        packageSpecs: 'conda-forge::conda-forge-ci-setup=3' # Optional
+        installOptions: "-c conda-forge {%- if local_ci_setup %} --only-deps{% endif %}"
         updateConda: true
-      displayName: Install conda-build and activate environment
+      displayName: Install conda-forge-ci-setup and activate environment
 
     - script: set PYTHONUNBUFFERED=1
       displayName: Set PYTHONUNBUFFERED
@@ -54,7 +54,6 @@ jobs:
     - script: |
         call activate base
         {%- if local_ci_setup %}
-        conda.exe uninstall --quiet --yes --force conda-forge-ci-setup
         pip install --no-deps ".\{{ recipe_dir }}\."
         {%- endif %}
         setup_conda_rc .\ ".\{{ recipe_dir }}" .\.ci_support\%CONFIG%.yaml

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -19,9 +19,8 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge-ci-setup=3 conda-build pip -c conda-forge
+conda install --yes --quiet {%- if local_ci_setup %} --only--deps{% endif %} conda-forge-ci-setup -c conda-forge
 {% if local_ci_setup %}
-conda uninstall --quiet --yes --force conda-forge-ci-setup
 pip install --no-deps ${RECIPE_ROOT}/.
 {%- endif %}
 # set up the condarc

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -22,11 +22,10 @@ fi
 source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
-echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+echo -e "\n\nInstalling conda-forge-ci-setup=3 {%- if local_ci_setup %} dependencies{% endif %}."
+conda install -n base --quiet --yes {%- if local_ci_setup %} --only-deps{% endif %} conda-forge-ci-setup=3
 
 {% if local_ci_setup %}
-conda uninstall --quiet --yes --force conda-forge-ci-setup
 pip install --no-deps {{ recipe_dir }}/.
 {%- endif %}
 

--- a/news/avoid_setup_package_uninstall.rst
+++ b/news/avoid_setup_package_uninstall.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Build templates only install dependencies of ``conda-forge-ci-setup`` package if ``local_ci_setup``, removing the need to uninstall it forcefully,
+  which does not behave as documented https://github.com/conda/conda/issues/10148
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* ``conda install`` in build templates only needs to resolve ``conda-forge-ci-setup`` as this provides the explict required CI dependencies
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
This removes the need to uninstall it forcefully. Also also only
install conda-forge-ci-setup in templates as it provides the
explicit required CI dependencies.

This is part of https://github.com/conda-forge/conda-smithy/issues/1366 and looks to work around the reported issues (including the forceful uninstall behaviour https://github.com/conda/conda/issues/10148) with the previous PR