### PR TITLE
configure_feedstock.py: Add remote_ci_setup field to default config

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1527,6 +1527,8 @@ def _load_forge_config(forge_dir, exclusive_config_file):
         "conda_forge_output_validation": False,
         "private_upload": False,
         "secrets": [],
+        # Specific channel for package can be given with `${url or channel_alias}::package_name`, defaults to conda-forge channel_alias
+        "remote_ci_setup": "conda-forge-ci-setup=3",
     }
 
     forge_yml = os.path.join(forge_dir, "conda-forge.yml")

--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -46,10 +46,10 @@ install:
     - cmd: set PYTHONUNBUFFERED=1
 
     # Configure the VM.
-    # Tell conda we want an updated version of conda-forge-ci-setup and conda-build
-    - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=3 conda-build pip
+    # Tell conda we want an updated version of {{ remote_ci_setup }} and conda-build
+    - cmd: conda.exe install -n root -c conda-forge --quiet --yes "{{ remote_ci_setup }}" conda-build pip
     {%- if local_ci_setup %}
-    - cmd: conda.exe uninstall --quiet --yes --force conda-forge-ci-setup
+    - cmd: conda.exe uninstall --quiet --yes --force "{{ remote_ci_setup }}"
     - cmd: pip install --no-deps .\{{ recipe_dir }}\.
     {%- endif %}
     - cmd: setup_conda_rc .\ .\{{ recipe_dir }} .\.ci_support\%CONFIG%.yaml

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -42,7 +42,7 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=3 pip' # Optional
+        packageSpecs: 'python=3.6 conda-build conda "{{ remote_ci_setup }}" pip' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment
@@ -54,7 +54,7 @@ jobs:
     - script: |
         call activate base
         {%- if local_ci_setup %}
-        conda.exe uninstall --quiet --yes --force conda-forge-ci-setup
+        conda.exe uninstall --quiet --yes --force "{{ remote_ci_setup }}"
         pip install --no-deps ".\{{ recipe_dir }}\."
         {%- endif %}
         setup_conda_rc .\ ".\{{ recipe_dir }}" .\.ci_support\%CONFIG%.yaml

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -19,9 +19,9 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge-ci-setup=3 conda-build pip -c conda-forge
+conda install --yes --quiet "{{ remote_ci_setup }}" conda-build pip -c conda-forge
 {% if local_ci_setup %}
-conda uninstall --quiet --yes --force conda-forge-ci-setup
+conda uninstall --quiet --yes --force "{{ remote_ci_setup }}"
 pip install --no-deps ${RECIPE_ROOT}/.
 {%- endif %}
 # set up the condarc

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -22,11 +22,11 @@ fi
 source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
-echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+echo -e "\n\nInstalling {{ remote_ci_setup }} and conda-build."
+conda install -n base --quiet --yes "{{ remote_ci_setup }}" conda-build pip
 
 {% if local_ci_setup %}
-conda uninstall --quiet --yes --force conda-forge-ci-setup
+conda uninstall --quiet --yes --force "{{ remote_ci_setup }}"
 pip install --no-deps {{ recipe_dir }}/.
 {%- endif %}
 

--- a/news/remote_ci_setup.rst
+++ b/news/remote_ci_setup.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* ``remote_ci_setup`` field in conda-forge.yml, which defaults to ``conda-forge-ci-setup=3`` allowing the user to override
+
+**Changed:**
+
+* CI templates now expand ``remote_ci_setup`` string from config for the ci setup package
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
Default to `conda-forge-ci-setup=3` and expand string in CI
templates. Value can be overriden by user to install & resolve
dependencies of an alternative remote setup package. This should
not change the default behaviour of `local_ci_setup`

I'm happy to change the variable name or append `conda-forge::` to the default package if it's preferred to be explicit

This is part of https://github.com/conda-forge/conda-smithy/issues/1366

If this is merged then I'll also send a PR to the docs repo.
