### PR TITLE
Use build ID instead of job ID to name Azure artifacts.

### DIFF
--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -38,6 +38,9 @@ jobs:
 
 {%- if azure.store_build_artifacts %}
   - script: |
+        full_artifact_name="conda_artifacts_$(build.BuildId)_$(CONFIG)"
+        artifact_name=`echo "$full_artifact_name" | head -c 80`
+        echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
         if [ -d build_artifacts ]; then
           echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"
         fi
@@ -45,6 +48,6 @@ jobs:
     condition: succeededOrFailed()
 
   - publish: build_artifacts/
-    artifact: conda_artifacts_$(CONFIG)_$(system.JobId)
+    artifact: $(ARTIFACT_NAME)
     condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')
 {%- endif %}

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -24,6 +24,9 @@ jobs:
 
 {%- if azure.store_build_artifacts %}
   - script: |
+        full_artifact_name="conda_artifacts_$(build.BuildId)_$(CONFIG)"
+        artifact_name=`echo "$full_artifact_name" | head -c 80`
+        echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
         if [ -d /Users/runner/miniforge3/conda-bld/ ]; then
           echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"
         fi
@@ -31,6 +34,6 @@ jobs:
     condition: succeededOrFailed()
 
   - publish: /Users/runner/miniforge3/conda-bld/
-    artifact: conda_artifacts_$(CONFIG)_$(system.JobId)
+    artifact: $(ARTIFACT_NAME)
     condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')
 {%- endif %}

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -89,6 +89,9 @@ jobs:
 
 {%- if azure.store_build_artifacts %}
     - script: |
+        set full_artifact_name=conda_artifacts_$(build.BuildID)_$(CONFIG)
+        set artifact_name=%full_artifact_name:~0,80%
+        echo ##vso[task.setVariable variable=ARTIFACT_NAME]%artifact_name%
         if exist $(CONDA_BLD_PATH)\\ (
           echo ##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true
         )
@@ -96,7 +99,7 @@ jobs:
       condition: succeededOrFailed()
 
     - publish: $(CONDA_BLD_PATH)\\
-      artifact: conda_artifacts_$(CONFIG)_$(system.JobId)
+      artifact: $(ARTIFACT_NAME)
       condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')
 {%- endif %}
 

--- a/news/fix_too_long_azure_artifact_names.rst
+++ b/news/fix_too_long_azure_artifact_names.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Use the shorter build ID instead of job ID to name Azure artifacts when they are stored. This helps prevent the artifact name from being too long, which would result in being unable to download it.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>
+


### PR DESCRIPTION
The job ID is pretty long whereas the build ID is short, and if the artifact name is too long (~100 characters? I could not find docs) then it will not be downloadable. This helps, but does not prevent, that situation. I also like using the build ID better because it is the same for all of the artifacts of that build and I can move it to before the config string in the artifact name to aid in sorting and possible string truncation.

See the Linux and macOS artifacts at https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=202223&view=artifacts&type=publishedArtifacts versus the same with this change at https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=202325&view=artifacts&type=publishedArtifacts. The long names in the first instance lead to a "Bad Request - Invalid URL" 400 error, whereas the shorter-named artifacts can be downloaded successfully.

Shortening the config name as in #1347 would also help prevent this error from cropping up.

If anyone knows of a good way to truncate the string length to some maximum number of characters, that would prevent this from happening completely.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
