### PR TITLE
Up the maximum number of builds on linux

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+    -   id: black

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1158,7 +1158,8 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
     template_files = platform_templates.get(platform, [])
 
     azure_settings = deepcopy(forge_config["azure"][f"settings_{platform}"])
-    azure_settings["strategy"]["matrix"] = {}
+    azure_settings.setdefault("strategy", {})
+    azure_settings["strategy"].setdefault("matrix", {})
     for data in forge_config["configs"]:
         if not data["build_platform"].startswith(platform):
             continue

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1447,7 +1447,7 @@ def _load_forge_config(forge_dir, exclusive_config_file):
                     "vmImage": "ubuntu-16.04",
                 },
                 "timeoutInMinutes": 360,
-                "strategy": {"maxParallel": 8},
+                "strategy": {"maxParallel": 16},
             },
             "settings_osx": {
                 "pool": {

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1447,21 +1447,18 @@ def _load_forge_config(forge_dir, exclusive_config_file):
                     "vmImage": "ubuntu-16.04",
                 },
                 "timeoutInMinutes": 360,
-                "strategy": {"maxParallel": 16},
             },
             "settings_osx": {
                 "pool": {
                     "vmImage": "macOS-10.15",
                 },
                 "timeoutInMinutes": 360,
-                "strategy": {"maxParallel": 8},
             },
             "settings_win": {
                 "pool": {
                     "vmImage": "vs2017-win2016",
                 },
                 "timeoutInMinutes": 360,
-                "strategy": {"maxParallel": 4},
                 "variables": {"CONDA_BLD_PATH": r"D:\\bld\\"},
             },
             # Force building all supported providers.

--- a/news/concurrency.rst
+++ b/news/concurrency.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Removed the default concurrency limits for azure
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/concurrency.rst
+++ b/news/concurrency.rst
@@ -21,3 +21,4 @@
 **Security:**
 
 * <news item>
+mam

--- a/news/concurrency.rst
+++ b/news/concurrency.rst
@@ -21,4 +21,3 @@
 **Security:**
 
 * <news item>
-mam


### PR DESCRIPTION
Increase the number of concurrent builds on linux to account for emulated builds and the increased python matrix