### PR TITLE
ENH make sure each compiler version gets a CI job

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -290,8 +290,16 @@ def _collapse_subpackage_variants(
         force_top_level=True
     )
     top_level_vars = list_of_metas[0].get_used_vars(force_top_level=True)
-    if "target_platform" in all_used_vars:
-        top_level_loop_vars.add("target_platform")
+    for key in [
+        "target_platform",
+        "c_compiler_version",
+        "cxx_compiler_version",
+        "fortran_compiler_version",
+        "cuda_compiler_version",
+        ""
+    ]:
+        if key in all_used_vars:
+            top_level_loop_vars.add(key)
 
     # this is the initial collection of all variants before we discard any.  "Squishing"
     #     them is necessary because the input form is already broken out into one matrix

--- a/news/TEMPLATE.rst
+++ b/news/TEMPLATE.rst
@@ -16,9 +16,8 @@
 
 **Fixed:**
 
-* <news item>
+* Fixed rendering to make sure CI jobs are generated for each compiler version.
 
 **Security:**
 
 * <news item>
-

--- a/news/comprend.rst
+++ b/news/comprend.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* <news item>
+* Fixed rendering to make sure CI jobs are generated for each compiler version.
 
 **Security:**
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This change appears to be needed to ensure that smithy generates a new CI job for each compiler variant. Normally, compilers appear in build so if you have more than one compiler variant in a single CI job, conda build will not make all of the outputs. 

This is happening in https://github.com/conda-forge/mpich-feedstock/pull/47