### PR TITLE
# is not a comment symbol on Windows

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -797,7 +797,7 @@ def _get_build_setup_line(forge_dir, platform, forge_config):
         elif platform == "win":
             build_setup += textwrap.dedent(
                 """\
-                # Overriding global run_conda_forge_build_setup_win with local copy.
+                :: Overriding global run_conda_forge_build_setup_win with local copy.
                 {recipe_dir}\\run_conda_forge_build_setup_win
             """.format(
                     recipe_dir=forge_config["recipe_dir"]

--- a/news/windows-comments.rst
+++ b/news/windows-comments.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``#`` is not a valid comment symbol on Windows and using it as part of a pipeline Batch step will cause a (harmless) error in the logs. It has been replaced by ``::`` instead.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

[This harmless error in the logs](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=235346&view=logs&j=a120d53e-9902-50f5-2ab9-d17061711ef5&t=921e1dd2-e1cc-500e-c406-a0376d4b804b&l=12) is due to this non-supported comment syntax on [this other line](https://github.com/jaimergp/conda-forge-ci-setup-feedstock/blob/cuda-windows/.azure-pipelines/azure-pipelines-win.yml#L132).