### PR TITLE
Don't remove files that don't exist

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1608,7 +1608,9 @@ def _load_forge_config(forge_dir, exclusive_config_file):
     for old_file in old_files:
         if old_file.replace(os.sep, "/") in config["skip_render"]:
             continue
-        remove_file_or_dir(os.path.join(forge_dir, old_file))
+        file_with_path = os.path.join(forge_dir, old_file)
+        if os.path.exists(file_with_path):
+            remove_file_or_dir(file_with_path)
 
     # Set some more azure defaults
     config["azure"].setdefault("user_or_org", config["github"]["user_or_org"])


### PR DESCRIPTION
I think this is causing an issue with the ci-skeleton feature where it is trying to delete `__pycache__` but the folder doesn't exist.


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->