### PR TITLE
 Fix running ./build-locally.py --debug with cross-compilation 

### DIFF
--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -48,7 +48,7 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 {% if test_on_native_only %}
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
      EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
 fi
 {% endif %}

--- a/news/cross-debug.rst
+++ b/news/cross-debug.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix running ``./build-locally.py --debug`` with cross-compilation
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Without this you get an error like:

```
+ conda debug /home/conda/recipe_root -m /home/conda/feedstock_root/.ci_support/linux_ppc64le_.yaml --no-test --clobber-file /home/conda/feedstock_root/.ci_support/clobber_linux_ppc64le_.yaml
usage: conda-debug [-h] [-V] [-n] [--python PYTHON] [--perl PERL] [--numpy NUMPY] [--R R_BASE] [--lua LUA] [--append-file APPEND_SECTIONS_FILE]
                   [--clobber-file CLOBBER_SECTIONS_FILE] [-m VARIANT_CONFIG_FILES] [-e EXCLUSIVE_CONFIG_FILES] [--use-channeldata] [--variants VARIANTS]
                   [-c CHANNEL] [--use-local] [--override-channels] [--repodata-fn REPODATA_FNS] [-p PATH] [-o OUTPUT_ID] [-a]
                   recipe_or_package_file_path
conda-debug: error: unrecognized arguments: --no-test
```