### PR TITLE
migrator_ts was removed in favour of migration_ts

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1814,7 +1814,7 @@ def get_migrations_in_dir(migrations_root):
                 yaml.load(contents, Loader=yaml.loader.BaseLoader) or {}
             )
             # Use a object as timestamp to not delete it
-            ts = migration_yaml.get("migrator_ts", object())
+            ts = migration_yaml.get("migration_ts", object())
             migration_number = migration_yaml.get("__migrator", {}).get(
                 "migration_number", 1
             )

--- a/news/ts.rst
+++ b/news/ts.rst
@@ -1,0 +1,21 @@
+
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* migrator_ts and migration_ts were both used in conda-smithy and migrator_ts was removed in favour of migration_ts
+
+**Security:**
+
+* <news item>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -256,7 +256,7 @@ about:
     ) as fh:
         fh.write(
             """
-migrator_ts: 1
+migration_ts: 1
 zlib:
     - 1000
 """

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -514,7 +514,7 @@ def test_migrator_cfp_override(recipe_migration_cfep9, jinja_env):
         f.write(
             textwrap.dedent(
                 """
-                migrator_ts: 1
+                migration_ts: 1
                 zlib:
                    - 1001
                 """


### PR DESCRIPTION
migrator_ts and migration_ts were both used in conda-smithy

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
