### PR TITLE
Support `os_version` in `conda-forge.yml`

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1499,6 +1499,20 @@ def _load_forge_config(forge_dir, exclusive_config_file):
             "win_64": "win_64",
             "osx_64": "osx_64",
         },
+        "os_version": {
+            "linux_64": "cos6",
+            "osx_64": None,
+            "win_64": None,
+            # Following platforms are disabled by default
+            "linux_aarch64": None,
+            "linux_ppc64le": None,
+            "linux_armv7l": None,
+            "linux_s390x": None,
+            # Following platforms are aliases of x86_64,
+            "linux": "cos6",
+            "osx": None,
+            "win": None,
+        },
         "test_on_native_only": False,
         "choco": [],
         # Configurable idle timeout.  Used for packages that don't have chatty enough builds
@@ -1645,6 +1659,11 @@ def _load_forge_config(forge_dir, exclusive_config_file):
     os.environ["CF_MAX_PY_VER"] = config["max_py_ver"]
     os.environ["CF_MIN_R_VER"] = config["min_r_ver"]
     os.environ["CF_MAX_R_VER"] = config["max_r_ver"]
+    # set the environment variable for OS version
+    # currently we only care about cos6/cos7 for linux64, but it might be extended in the future
+    for k, v in config["os_version"].items():
+        if v is not None:
+            os.environ[k] = v
 
     config["package"] = os.path.basename(forge_dir)
     if not config["github"]["repo_name"]:

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1507,8 +1507,6 @@ def _load_forge_config(forge_dir, exclusive_config_file):
         },
         "os_version": {
             "linux_64": None,
-            "osx_64": None,
-            "win_64": None,
             "linux_aarch64": None,
             "linux_ppc64le": None,
             "linux_armv7l": None,

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -591,6 +591,13 @@ def _render_ci_provider(
             f"{platform}_{arch}"
         ].replace("_", "-")
 
+        # set the environment variable for OS version
+        # currently we only care about cos6/cos7 for linux64, but it might be extended in the future
+        if f"{platform}_{arch}" == "linux_64":
+            ver = forge_config["os_version"]["linux_64"]
+            if ver:
+                os.environ["DEFAULT_LINUX_VERSION"] = ver
+
         config = conda_build.config.get_or_merge_config(
             None,
             exclusive_config_file=forge_config["exclusive_config_file"],
@@ -1655,11 +1662,6 @@ def _load_forge_config(forge_dir, exclusive_config_file):
     os.environ["CF_MAX_PY_VER"] = config["max_py_ver"]
     os.environ["CF_MIN_R_VER"] = config["min_r_ver"]
     os.environ["CF_MAX_R_VER"] = config["max_r_ver"]
-    # set the environment variable for OS version
-    # currently we only care about cos6/cos7 for linux64, but it might be extended in the future
-    for k, v in config["os_version"].items():
-        if k == "linux_64" and v is not None:
-            os.environ["DEFAULT_LINUX_VERSION"] = v
 
     config["package"] = os.path.basename(forge_dir)
     if not config["github"]["repo_name"]:

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -592,9 +592,8 @@ def _render_ci_provider(
         ].replace("_", "-")
 
         # set the environment variable for OS version
-        # currently we only care about cos6/cos7 for linux64, but it might be extended in the future
-        if f"{platform}_{arch}" == "linux_64":
-            ver = forge_config["os_version"]["linux_64"]
+        if platform == "linux":
+            ver = forge_config["os_version"][f"{platform}_{arch}"]
             if ver:
                 os.environ["DEFAULT_LINUX_VERSION"] = ver
 
@@ -1507,10 +1506,9 @@ def _load_forge_config(forge_dir, exclusive_config_file):
             "osx_64": "osx_64",
         },
         "os_version": {
-            "linux_64": "cos6",
+            "linux_64": None,
             "osx_64": None,
             "win_64": None,
-            # Following platforms are disabled by default
             "linux_aarch64": None,
             "linux_ppc64le": None,
             "linux_armv7l": None,

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1662,8 +1662,8 @@ def _load_forge_config(forge_dir, exclusive_config_file):
     # set the environment variable for OS version
     # currently we only care about cos6/cos7 for linux64, but it might be extended in the future
     for k, v in config["os_version"].items():
-        if v is not None:
-            os.environ[k] = v
+        if k in ('linux_64', 'linux') and v is not None:
+            os.environ['DEFAULT_LINUX_VERSION'] = v
 
     config["package"] = os.path.basename(forge_dir)
     if not config["github"]["repo_name"]:

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1508,10 +1508,6 @@ def _load_forge_config(forge_dir, exclusive_config_file):
             "linux_ppc64le": None,
             "linux_armv7l": None,
             "linux_s390x": None,
-            # Following platforms are aliases of x86_64,
-            "linux": "cos6",
-            "osx": None,
-            "win": None,
         },
         "test_on_native_only": False,
         "choco": [],
@@ -1662,8 +1658,8 @@ def _load_forge_config(forge_dir, exclusive_config_file):
     # set the environment variable for OS version
     # currently we only care about cos6/cos7 for linux64, but it might be extended in the future
     for k, v in config["os_version"].items():
-        if k in ('linux_64', 'linux') and v is not None:
-            os.environ['DEFAULT_LINUX_VERSION'] = v
+        if k == "linux_64" and v is not None:
+            os.environ["DEFAULT_LINUX_VERSION"] = v
 
     config["package"] = os.path.basename(forge_dir)
     if not config["github"]["repo_name"]:

--- a/news/os_version.rst
+++ b/news/os_version.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Support `os_version` in `conda-forge.yml`
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -748,6 +748,7 @@ def test_cos7_env_render(py_recipe, jinja_env):
         del os.environ["DEFAULT_LINUX_VERSION"]
 
     try:
+        assert "DEFAULT_LINUX_VERSION" not in os.environ
         cnfgr_fdstk.render_azure(
             jinja_env=jinja_env,
             forge_config=forge_config,

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -717,7 +717,7 @@ def test_automerge_action_exists(py_recipe, jinja_env):
 
 
 def test_conda_forge_yaml_empty(config_yaml):
-    load_forge_config = lambda: cnfgr_fdstk._load_forge_config(
+    load_forge_config = lambda: cnfgr_fdstk._load_forge_config(  # noqa
         config_yaml,
         exclusive_config_file=os.path.join(
             config_yaml, "recipe", "default_config.yaml"
@@ -737,3 +737,34 @@ def test_conda_forge_yaml_empty(config_yaml):
     assert ["conda-forge", "main"] in load_forge_config()["channels"][
         "targets"
     ]
+
+
+def test_cos7_env_render(py_recipe, jinja_env):
+    forge_config = copy.deepcopy(py_recipe.config)
+    forge_config["os_version"] = {"linux_64": "cos7"}
+    has_env = "DEFAULT_LINUX_VERSION" in os.environ
+    if has_env:
+        old_val = os.environ["DEFAULT_LINUX_VERSION"]
+        del os.environ["DEFAULT_LINUX_VERSION"]
+
+    try:
+        cnfgr_fdstk.render_azure(
+            jinja_env=jinja_env,
+            forge_config=forge_config,
+            forge_dir=py_recipe.recipe,
+        )
+        assert os.environ["DEFAULT_LINUX_VERSION"] == "cos7"
+
+        # this configuration should be run
+        assert forge_config["azure"]["enabled"]
+        matrix_dir = os.path.join(py_recipe.recipe, ".ci_support")
+        assert os.path.isdir(matrix_dir)
+        # single matrix entry - readme is generated later in main function
+        assert len(os.listdir(matrix_dir)) == 8
+
+    finally:
+        if has_env:
+            os.environ["DEFAULT_LINUX_VERSION"] = old_val
+        else:
+            if "DEFAULT_LINUX_VERSION" in os.environ:
+                del os.environ["DEFAULT_LINUX_VERSION"]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

As per requested by @isuruf, this PR makes `os_version` in `conda-forge.yml` recognized by Conda-Smithy. Currently it is used to distinguish `cos6`/`cos7`:
```yaml
os_version:
  linux_64: cos7
```

~~Currently tested with the cudnn-feedstock, with the cuda_111_112 migrator manually added. The rerendering is done without error, but it generates a ton of extra files on Windows, which shouldn't be there. Am I missing something here, or should I also copy over the cuda windows migrator?~~
**UPDATE**: fixed this silly mistake in 936cf8a. 

Another thing: where should the test go?

cc: @beckermr 