### PR TITLE
ENH add multiple variants in key_add

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -17,7 +17,7 @@ import requests
 # by `requests`.
 try:
     import simplejson as json
-except:
+except ImportError:
     import json
 
 import conda_build.api
@@ -332,7 +332,6 @@ def _collapse_subpackage_variants(
         "BUILD",
     }
 
-    target_platform = f"{platform}-{arch}"
     if not is_noarch:
         always_keep_keys.add("target_platform")
 
@@ -371,8 +370,8 @@ def _collapse_subpackage_variants(
     _trim_unused_zip_keys(used_key_values)
     _trim_unused_pin_run_as_build(used_key_values)
 
-    logger.debug("top_level_loop_vars {}".format(top_level_loop_vars))
-    logger.debug("used_key_values {}".format(used_key_values))
+    logger.info("top_level_loop_vars {}".format(top_level_loop_vars))
+    logger.info("used_key_values {}".format(used_key_values))
 
     return (
         break_up_top_level_values(top_level_loop_vars, used_key_values),
@@ -615,17 +614,32 @@ def _render_ci_provider(
             forge_config,
         )
 
-        metas = conda_build.api.render(
-            os.path.join(forge_dir, forge_config["recipe_dir"]),
-            platform=platform,
-            arch=arch,
-            ignore_system_variants=True,
-            variants=migrated_combined_variant_spec,
-            permit_undefined_jinja=True,
-            finalize=False,
-            bypass_env_check=True,
-            channel_urls=forge_config.get("channels", {}).get("sources", []),
-        )
+        # AFAIK there is no way to get conda build to ignore the CBC yaml
+        # in the recipe. This one can mess up migrators applied to local
+        # CBC yaml files, so we move it out of the way.
+        try:
+            _recipe_cbc = os.path.join(
+                forge_dir,
+                forge_config["recipe_dir"],
+                "conda_build_config.yaml",
+            )
+            if os.path.exists(_recipe_cbc):
+                os.rename(_recipe_cbc, _recipe_cbc+".conda.smithy.bak")
+
+            metas = conda_build.api.render(
+                os.path.join(forge_dir, forge_config["recipe_dir"]),
+                platform=platform,
+                arch=arch,
+                ignore_system_variants=True,
+                variants=migrated_combined_variant_spec,
+                permit_undefined_jinja=True,
+                finalize=False,
+                bypass_env_check=True,
+                channel_urls=forge_config.get("channels", {}).get("sources", []),
+            )
+        finally:
+            if os.path.exists(_recipe_cbc+".conda.smithy.bak"):
+                os.rename(_recipe_cbc+".conda.smithy.bak", _recipe_cbc)
 
         # render returns some download & reparsing info that we don't care about
         metas = [m for m, _, _ in metas]
@@ -960,8 +974,8 @@ def render_circle(jinja_env, forge_config, forge_dir, return_metadata=False):
         """\
             {get_fast_finish_script} | \\
                  python - -v --ci "circle" "${{CIRCLE_PROJECT_USERNAME}}/${{CIRCLE_PROJECT_REPONAME}}" "${{CIRCLE_BUILD_NUM}}" "${{CIRCLE_PR_NUMBER}}"
-        """
-    )  # NOQA
+        """  # noqa
+    )
     extra_platform_files = {
         "common": [
             os.path.join(forge_dir, ".circleci", "checkout_merge_commit.sh"),
@@ -1109,7 +1123,7 @@ def render_appveyor(jinja_env, forge_config, forge_dir, return_metadata=False):
         """\
             {get_fast_finish_script}
             "%CONDA_INSTALL_LOCN%\\python.exe" {fast_finish_script}.py -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
-        """
+        """  # noqa
     )
     template_filename = "appveyor.yml.tmpl"
 
@@ -1529,7 +1543,8 @@ def _load_forge_config(forge_dir, exclusive_config_file):
         "private_upload": False,
         "secrets": [],
         "build_with_mambabuild": False,
-        # Specific channel for package can be given with `${url or channel_alias}::package_name`, defaults to conda-forge channel_alias
+        # Specific channel for package can be given with
+        # `${url or channel_alias}::package_name`, defaults to conda-forge channel_alias
         "remote_ci_setup": "conda-forge-ci-setup=3",
     }
 
@@ -1576,7 +1591,8 @@ def _load_forge_config(forge_dir, exclusive_config_file):
         for plat in ["linux", "osx", "win"]:
             if config["azure"]["timeout_minutes"] is not None:
                 # fmt: off
-                config["azure"][f"settings_{plat}"]["timeoutInMinutes"] = config["azure"]["timeout_minutes"]
+                config["azure"][f"settings_{plat}"]["timeoutInMinutes"] \
+                    = config["azure"]["timeout_minutes"]
                 # fmt: on
             if "name" in config["azure"][f"settings_{plat}"]["pool"]:
                 del config["azure"][f"settings_{plat}"]["pool"]["vmImage"]
@@ -1887,7 +1903,6 @@ def main(
     check=False,
     temporary_directory=None,
 ):
-    import logging
 
     loglevel = os.environ.get("CONDA_SMITHY_LOGLEVEL", "INFO").upper()
     logger.setLevel(loglevel)

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -618,6 +618,7 @@ def _render_ci_provider(
         # in the recipe. This one can mess up migrators applied with local
         # CBC yaml files where variants in the migrators are not in the CBC.
         # Thus we move it out of the way.
+        # TODO: upstream this as a flag in conda-build
         try:
             _recipe_cbc = os.path.join(
                 forge_dir,

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -626,7 +626,7 @@ def _render_ci_provider(
                 "conda_build_config.yaml",
             )
             if os.path.exists(_recipe_cbc):
-                os.rename(_recipe_cbc, _recipe_cbc+".conda.smithy.bak")
+                os.rename(_recipe_cbc, _recipe_cbc + ".conda.smithy.bak")
 
             metas = conda_build.api.render(
                 os.path.join(forge_dir, forge_config["recipe_dir"]),
@@ -637,11 +637,13 @@ def _render_ci_provider(
                 permit_undefined_jinja=True,
                 finalize=False,
                 bypass_env_check=True,
-                channel_urls=forge_config.get("channels", {}).get("sources", []),
+                channel_urls=forge_config.get("channels", {}).get(
+                    "sources", []
+                ),
             )
         finally:
-            if os.path.exists(_recipe_cbc+".conda.smithy.bak"):
-                os.rename(_recipe_cbc+".conda.smithy.bak", _recipe_cbc)
+            if os.path.exists(_recipe_cbc + ".conda.smithy.bak"):
+                os.rename(_recipe_cbc + ".conda.smithy.bak", _recipe_cbc)
 
         # render returns some download & reparsing info that we don't care about
         metas = [m for m, _, _ in metas]

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -615,8 +615,9 @@ def _render_ci_provider(
         )
 
         # AFAIK there is no way to get conda build to ignore the CBC yaml
-        # in the recipe. This one can mess up migrators applied to local
-        # CBC yaml files, so we move it out of the way.
+        # in the recipe. This one can mess up migrators applied with local
+        # CBC yaml files where variants in the migrators are not in the CBC.
+        # Thus we move it out of the way.
         try:
             _recipe_cbc = os.path.join(
                 forge_dir,

--- a/news/key_add.rst
+++ b/news/key_add.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Enabled multiple entries for ``key_add`` operations.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed rendering error where the recipe's ``conda_build_config.yaml`` is
+  applied again, removing some variants.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR does two things. First, it allows key_add migrators to add more than one key. Second, it fixes a bug where smithy is applying the recipe's CBC on top of the global pinning file + recipe CBC + migration. Sometimes this causes the changes from the migration to be removed when rerendering happens. 
