### PR TITLE
Fix "File name too long" error for many zip keys

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -441,17 +441,20 @@ def dump_subspace_config_files(
             f"{platform}_{arch}",
             package_key(config, top_level_loop_vars, metas[0].config.subdir),
         )
+        short_config_name = config_name
+        if len(short_config_name) >= 49:
+            h = hashlib.sha256(config_name.encode("utf-8")).hexdigest()[:10]
+            short_config_name = config_name[:35] + "_h" + h
+        if len(config_name + ".yaml") >= 250:
+            # Shorten file name length to avoid hitting maximum filename limits.
+            config_name = short_config_name
+
         out_folder = os.path.join(root_path, ".ci_support")
         out_path = os.path.join(out_folder, config_name) + ".yaml"
         if not os.path.isdir(out_folder):
             os.makedirs(out_folder)
 
         config = finalize_config(config, platform, arch, forge_config)
-
-        short_config_name = config_name
-        if len(short_config_name) >= 49:
-            h = hashlib.sha256(config_name.encode("utf-8")).hexdigest()[:10]
-            short_config_name = config_name[:35] + "_h" + h
 
         with write_file(out_path) as f:
             yaml.dump(config, f, default_flow_style=False)

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -47,24 +47,13 @@ logger = logging.getLogger(__name__)
 
 def package_key(config, used_loop_vars, subdir):
     # get the build string from whatever conda-build makes of the configuration
-    build_vars = "".join(
+    key = "".join(
         [
             k + str(config[k][0])
             for k in sorted(list(used_loop_vars))
             if k != "target_platform"
         ]
     )
-    key = []
-    # kind of a special case.  Target platform determines a lot of output behavior, but may not be
-    #    explicitly listed in the recipe.
-    tp = config.get("target_platform")
-    if tp and isinstance(tp, list):
-        tp = tp[0]
-    if tp and tp != subdir:
-        build_vars += "target_platform" + tp
-    if build_vars:
-        key.append(build_vars)
-    key = "-".join(key)
     return key.replace("*", "_").replace(" ", "_")
 
 

--- a/news/avoid-too-long-filenames.rst
+++ b/news/avoid-too-long-filenames.rst
@@ -4,7 +4,8 @@
 
 **Changed:**
 
-* <news item>
+* To cross compile for  ``win-32`` from ``win-64``, using ``target_platform``
+  is no longer supported. Use ``build_platform: win_32: win64`` in ``conda-forge.yml``.
 
 **Deprecated:**
 

--- a/news/avoid-too-long-filenames.rst
+++ b/news/avoid-too-long-filenames.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix "File name too long" error for many zip keys
+  Replace config filenames by their short versions if filesystem limits
+  are approached.
+
+**Security:**
+
+* <news item>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,9 +69,6 @@ def config_yaml(testing_workdir, recipe_dirname):
         f.write(
             dedent(
                 """\
-        target_platform:
-        - win-64        # [win]
-        - win-32        # [win]
         c_compiler:     # [win]
         - vs2008        # [win]
         - vs2015        # [win]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -208,24 +208,6 @@ def test_regenerate(py_recipe, testing_workdir):
     # original rendering was with py27, 36, no target_platform
     assert len(os.listdir(matrix_folder)) == 7
 
-    # Ignore conda-forge-pinning for this test, as the test relies on conda-forge-pinning
-    # not being present
-    args = RegenerateArgs(
-        feedstock_directory=dest_dir,
-        commit=False,
-        no_check_uptodate=True,
-        exclusive_config_file=os.path.join(
-            recipe, "recipe", "default_config.yaml"
-        ),
-        check=False,
-        temporary_directory=os.path.join(dest_dir, "temp"),
-    )
-
-    regen_obj(args)
-
-    # should add 2, as the config.yaml adds in target_platform
-    assert len(os.listdir(matrix_folder)) == 9
-
     # reduce the python matrix and make sure the matrix files reflect the change
     args = RegenerateArgs(
         feedstock_directory=dest_dir,

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -134,9 +134,9 @@ def test_py_matrix_appveyor(py_recipe, jinja_env):
     assert py_recipe.config["appveyor"]["enabled"]
     matrix_dir = os.path.join(py_recipe.recipe, ".ci_support")
     assert os.path.isdir(matrix_dir)
-    # 2 python versions, 2 target_platforms.  Recipe uses c_compiler, but this is a zipped key
+    # 2 python versions. Recipe uses c_compiler, but this is a zipped key
     #     and shouldn't add extra configurations
-    assert len(os.listdir(matrix_dir)) == 4
+    assert len(os.listdir(matrix_dir)) == 2
 
 
 @pytest.mark.legacy_travis
@@ -184,7 +184,7 @@ def test_py_matrix_on_azure(py_recipe, jinja_env):
     matrix_dir = os.path.join(py_recipe.recipe, ".ci_support")
     assert os.path.isdir(matrix_dir)
     # single matrix entry - readme is generated later in main function
-    assert len(os.listdir(matrix_dir)) == 8
+    assert len(os.listdir(matrix_dir)) == 6
 
 
 def test_upload_on_branch_azure(upload_on_branch_recipe, jinja_env):
@@ -629,16 +629,7 @@ def test_migrator_compiler_version_recipe(
         os.path.join(recipe_migration_win_compiled.recipe, ".ci_support")
     )
 
-    # TODO: remove multiple target_platform entries
-    assert (
-        "win_64_c_compilervs2008python2.7target_platformwin-32.yaml"
-        in rendered_variants
-    )
     assert "win_64_c_compilervs2008python2.7.yaml" in rendered_variants
-    assert (
-        "win_64_c_compilervs2017python3.5target_platformwin-32.yaml"
-        in rendered_variants
-    )
     assert "win_64_c_compilervs2017python3.5.yaml" in rendered_variants
 
 


### PR DESCRIPTION
Replace config filenames by their short versions if filesystem limits
are approached.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

In https://github.com/conda-forge/rust-activation-feedstock/pull/8 we added additional keys to a `zip_keys` group which broke re-rendering since the config filenames grew to big.