### PR TITLE
Fix upload for Windows packages using github_actions provider

### DIFF
--- a/conda_smithy/templates/github-actions.tmpl
+++ b/conda_smithy/templates/github-actions.tmpl
@@ -117,12 +117,12 @@ jobs:
         if errorlevel 1 exit 1
         {%- endif %}
         set "FEEDSTOCK_NAME=%GITHUB_REPOSITORY:*/=%"
-        set "GIT_BRANCH=%GITHUB_REF:*/=%"
+        set "GIT_BRANCH=%GITHUB_REF:refs/heads/=%"
         {%- if conda_forge_output_validation %}
         validate_recipe_outputs "%FEEDSTOCK_NAME%"
         if errorlevel 1 exit 1
         {%- endif %}
-        if %UPLOAD_PACKAGES% == "True" (
+        if /i "%UPLOAD_PACKAGES%" == "true" (
           upload_package {% if conda_forge_output_validation %}--validate --feedstock-name="%FEEDSTOCK_NAME%"{% endif %}{% if private_upload %} --private{% endif %} .\ ".\{{ recipe_dir }}" .ci_support\%CONFIG%.yaml
         )
       env:


### PR DESCRIPTION
With `set "GIT_BRANCH=%GITHUB_REF:*/=%"`, GIT_BRANCH was coming out as "heads/<branchname>". The "refs/heads/" prefix is a constant according to https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context. It seems safe to just strip that instead.

The `if %UPLOAD_PACKAGES% == "True"` statement was failing for two reasons: 1) Case sensitivity with "%UPLOAD_PACKAGES%" evaluating to "true", and 2) Use of quotation marks needing to match on both sides of the equals (either included or not). This fixes the case and makes the match insensitive to boot, and adds quotation marks to the left side.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I can add a news entry if desired, although it is a fix for an unreleased feature.