### PR TITLE
Fix too long filenames for build done canary files

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -434,7 +434,7 @@ def dump_subspace_config_files(
         if len(short_config_name) >= 49:
             h = hashlib.sha256(config_name.encode("utf-8")).hexdigest()[:10]
             short_config_name = config_name[:35] + "_h" + h
-        if len(config_name + ".yaml") >= 250:
+        if len("conda-forge-build-done-" + config_name) >= 250:
             # Shorten file name length to avoid hitting maximum filename limits.
             config_name = short_config_name
 

--- a/news/shorter-config-name.rst
+++ b/news/shorter-config-name.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix too long filenames for build done canary files.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Would fix issue in https://github.com/conda-forge/rust-activation-feedstock/pull/8.

<!--
Please add any other relevant info below:
-->

`run_docker_build.sh`/`build_steps.sh` create `"$ARTIFACTS/conda-forge-build-done-${CONFIG}"` files. We checked for max filename length with `+ ".yaml"` before, but we also have to consider the longer `"conda-forge-build-done-"` prefix.