### PR TITLE
Add option to use different path for feedstock config yaml

### DIFF
--- a/conda_smithy/anaconda_token_rotation.py
+++ b/conda_smithy/anaconda_token_rotation.py
@@ -32,7 +32,7 @@ def _get_anaconda_token():
 def rotate_anaconda_token(
     user,
     project,
-    feedstock_directory,
+    feedstock_config_path,
     drone=True,
     circle=True,
     travis=True,
@@ -107,7 +107,7 @@ def rotate_anaconda_token(
                         rotate_token_in_travis(
                             user,
                             project,
-                            feedstock_directory,
+                            feedstock_config_path,
                             anaconda_token,
                             token_name,
                         )
@@ -140,7 +140,7 @@ def rotate_anaconda_token(
                 if appveyor:
                     try:
                         rotate_token_in_appveyor(
-                            feedstock_directory, anaconda_token, token_name
+                            feedstock_config_path, anaconda_token, token_name
                         )
                     except Exception as e:
                         if "DEBUG_ANACONDA_TOKENS" in os.environ:
@@ -247,7 +247,7 @@ def rotate_token_in_drone(user, project, binstar_token, token_name):
 
 
 def rotate_token_in_travis(
-    user, project, feedstock_directory, binstar_token, token_name
+    user, project, feedstock_config_path, binstar_token, token_name
 ):
     """update the binstar token in travis."""
     from .ci_register import (
@@ -305,7 +305,7 @@ def rotate_token_in_travis(
 
     # we remove the token in the conda-forge.yml since on travis the
     # encrypted values override any value we put in the API
-    with update_conda_forge_config(feedstock_directory) as code:
+    with update_conda_forge_config(feedstock_config_path) as code:
         if (
             "travis" in code
             and "secure" in code["travis"]
@@ -375,7 +375,7 @@ def rotate_token_in_azure(user, project, binstar_token, token_name):
     )
 
 
-def rotate_token_in_appveyor(feedstock_directory, binstar_token, token_name):
+def rotate_token_in_appveyor(feedstock_config_path, binstar_token, token_name):
     from .ci_register import appveyor_token
 
     headers = {"Authorization": "Bearer {}".format(appveyor_token)}
@@ -386,7 +386,7 @@ def rotate_token_in_appveyor(feedstock_directory, binstar_token, token_name):
     if response.status_code != 200:
         raise ValueError(response)
 
-    with update_conda_forge_config(feedstock_directory) as code:
+    with update_conda_forge_config(feedstock_config_path) as code:
         code.setdefault("appveyor", {}).setdefault("secure", {})[
             token_name
         ] = response.content.decode("utf-8")

--- a/conda_smithy/ci_register.py
+++ b/conda_smithy/ci_register.py
@@ -265,7 +265,7 @@ def add_project_to_appveyor(user, project):
         print(" * {}/{} has been enabled on appveyor".format(user, project))
 
 
-def appveyor_encrypt_binstar_token(feedstock_directory, user, project):
+def appveyor_encrypt_binstar_token(feedstock_config_path, user, project):
     anaconda_token = _get_anaconda_token()
     headers = {"Authorization": "Bearer {}".format(appveyor_token)}
     url = "https://ci.appveyor.com/api/account/encrypt"
@@ -275,7 +275,7 @@ def appveyor_encrypt_binstar_token(feedstock_directory, user, project):
     if response.status_code != 200:
         raise ValueError(response)
 
-    with update_conda_forge_config(feedstock_directory) as code:
+    with update_conda_forge_config(feedstock_config_path) as code:
         code.setdefault("appveyor", {}).setdefault("secure", {})[
             "BINSTAR_TOKEN"
         ] = response.content.decode("utf-8")
@@ -421,12 +421,14 @@ def add_project_to_travis(user, project):
         print(" * {}/{} registered on travis-ci".format(user, project))
 
 
-def travis_token_update_conda_forge_config(feedstock_directory, user, project):
+def travis_token_update_conda_forge_config(
+    feedstock_config_path, user, project
+):
     anaconda_token = _get_anaconda_token()
     item = 'BINSTAR_TOKEN="{}"'.format(anaconda_token)
     slug = "{}%2F{}".format(user, project)
 
-    with update_conda_forge_config(feedstock_directory) as code:
+    with update_conda_forge_config(feedstock_config_path) as code:
         code.setdefault("travis", {}).setdefault("secure", {})[
             "BINSTAR_TOKEN"
         ] = travis_encrypt_binstar_token(slug, item)
@@ -652,8 +654,8 @@ if __name__ == "__main__":
     #    add_project_to_circle(args.user, args.project)
     #    add_project_to_appveyor(args.user, args.project)
     #    add_project_to_travis(args.user, args.project)
-    #    appveyor_encrypt_binstar_token('../udunits-delme-feedstock', args.user, args.project)
+    #    appveyor_encrypt_binstar_token('../udunits-delme-feedstock/conda-forge.yml', args.user, args.project)
     #    appveyor_configure('conda-forge', 'glpk-feedstock')
-    #    travis_token_update_conda_forge_config('../udunits-delme-feedstock', args.user, args.project)
+    #    travis_token_update_conda_forge_config('../udunits-delme-feedstock/conda-forge.yml', args.user, args.project)
     add_conda_forge_webservice_hooks(args.user, args.project)
     print("Done")

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1529,7 +1529,7 @@ def _update_dict_within_dict(items, config):
     return config
 
 
-def _load_forge_config(forge_dir, exclusive_config_file):
+def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
     config = {
         "docker": {
             "executable": "docker",
@@ -1639,10 +1639,12 @@ def _load_forge_config(forge_dir, exclusive_config_file):
         "remote_ci_setup": "conda-forge-ci-setup=3",
     }
 
-    forge_yml = os.path.join(forge_dir, "conda-forge.yml")
+    if forge_yml is None:
+        forge_yml = os.path.join(forge_dir, "conda-forge.yml")
+
     if not os.path.exists(forge_yml):
         raise RuntimeError(
-            f"Could not find `conda-forge.yml` in {forge_dir}."
+            f"Could not find config file {forge_yml}."
             " Either you are not rerendering inside the feedstock root (likely)"
             " or there's no `conda-forge.yml` in the feedstock root (unlikely)."
             " Add an empty `conda-forge.yml` file in"
@@ -1999,6 +2001,7 @@ def set_migration_fns(forge_dir, forge_config):
 
 def main(
     forge_file_directory,
+    forge_yml=None,
     no_check_uptodate=False,
     commit=False,
     exclusive_config_file=None,
@@ -2029,7 +2032,7 @@ def main(
             temporary_directory
         )
 
-    config = _load_forge_config(forge_dir, exclusive_config_file)
+    config = _load_forge_config(forge_dir, exclusive_config_file, forge_yml)
     config["feedstock_name"] = os.path.basename(forge_dir)
 
     for each_ci in [

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -84,14 +84,13 @@ def render_meta_yaml(text):
 
 
 @contextmanager
-def update_conda_forge_config(feedstock_directory):
+def update_conda_forge_config(forge_yaml):
     """Utility method used to update conda forge configuration files
 
     Uage:
     >>> with update_conda_forge_config(somepath) as cfg:
     ...     cfg['foo'] = 'bar'
     """
-    forge_yaml = os.path.join(feedstock_directory, "conda-forge.yml")
     if os.path.exists(forge_yaml):
         with open(forge_yaml, "r") as fh:
             code = get_yaml().load(fh)

--- a/news/forge_yml_alternate.rst
+++ b/news/forge_yml_alternate.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add a "--feedstock_config" option to the regenerate/rerender, update-anaconda-token, azure-buildid subcommands for providing an alternative path to the feedstock configuration file (normally "conda-forge.yml"). This allows different names or to put the configuration outside the feedstock root.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_anaconda_token_rotation.py
+++ b/tests/test_anaconda_token_rotation.py
@@ -35,10 +35,12 @@ def test_rotate_anaconda_token(
     anaconda_token = "abc123"
     get_ac_token.return_value = anaconda_token
 
+    feedstock_config_path = "abc/conda-forge.yml"
+
     rotate_anaconda_token(
         user,
         project,
-        "abc",
+        feedstock_config_path,
         drone=drone,
         circle=circle,
         travis=travis,
@@ -63,7 +65,11 @@ def test_rotate_anaconda_token(
 
     if travis:
         travis_mock.assert_called_once_with(
-            user, project, "abc", anaconda_token, "MY_FANCY_TOKEN"
+            user,
+            project,
+            feedstock_config_path,
+            anaconda_token,
+            "MY_FANCY_TOKEN",
         )
     else:
         travis_mock.assert_not_called()
@@ -77,7 +83,7 @@ def test_rotate_anaconda_token(
 
     if appveyor:
         appveyor_mock.assert_called_once_with(
-            "abc", anaconda_token, "MY_FANCY_TOKEN"
+            feedstock_config_path, anaconda_token, "MY_FANCY_TOKEN"
         )
     else:
         appveyor_mock.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,7 @@ RegenerateArgs = collections.namedtuple(
     (
         "commit",
         "feedstock_directory",
+        "feedstock_config",
         "no_check_uptodate",
         "exclusive_config_file",
         "check",
@@ -65,6 +66,7 @@ def test_init_multiple_output_matrix(testing_workdir):
     # not being present
     args = RegenerateArgs(
         feedstock_directory=feedstock_dir,
+        feedstock_config=None,
         commit=False,
         no_check_uptodate=True,
         exclusive_config_file="recipe/conda_build_config.yaml",
@@ -117,6 +119,7 @@ def test_init_cuda_docker_images(testing_workdir):
     # conda-forge-pinning not being present
     args = RegenerateArgs(
         feedstock_directory=feedstock_dir,
+        feedstock_config=None,
         commit=False,
         no_check_uptodate=True,
         exclusive_config_file="recipe/conda_build_config.yaml",
@@ -170,6 +173,7 @@ def test_init_multiple_docker_images(testing_workdir):
     # conda-forge-pinning not being present
     args = RegenerateArgs(
         feedstock_directory=feedstock_dir,
+        feedstock_config=None,
         commit=False,
         no_check_uptodate=True,
         exclusive_config_file="recipe/conda_build_config.yaml",
@@ -211,6 +215,7 @@ def test_regenerate(py_recipe, testing_workdir):
     # reduce the python matrix and make sure the matrix files reflect the change
     args = RegenerateArgs(
         feedstock_directory=dest_dir,
+        feedstock_config=None,
         commit=False,
         no_check_uptodate=True,
         exclusive_config_file=os.path.join(

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -751,6 +751,33 @@ def test_conda_forge_yaml_empty(config_yaml):
     ]
 
 
+def test_forge_yml_alt_path(config_yaml):
+    load_forge_config = (
+        lambda forge_yml: cnfgr_fdstk._load_forge_config(  # noqa
+            config_yaml,
+            exclusive_config_file=os.path.join(
+                config_yaml, "recipe", "default_config.yaml"
+            ),
+            forge_yml=forge_yml,
+        )
+    )
+
+    forge_yml = os.path.join(config_yaml, "conda-forge.yml")
+    forge_yml_alt = os.path.join(
+        config_yaml, ".config", "feedstock-config.yml"
+    )
+
+    os.mkdir(os.path.dirname(forge_yml_alt))
+    os.rename(forge_yml, forge_yml_alt)
+
+    with pytest.raises(RuntimeError):
+        load_forge_config(None)
+
+    assert ["conda-forge", "main"] in load_forge_config(forge_yml_alt)[
+        "channels"
+    ]["targets"]
+
+
 def test_cos7_env_render(py_recipe, jinja_env):
     forge_config = copy.deepcopy(py_recipe.config)
     forge_config["os_version"] = {"linux_64": "cos7"}


### PR DESCRIPTION
This makes it possible to specify the feedstock configuration in a file that is named/located at something other than "conda-forge.yml". Feedstock init and ci-skeleton still use the default name, but if a user decides to manually move/rename the config file, there is now a "--feedstock_config" option for appropriate smithy subcommands so that they can point to the alternate path. Clearly this is not useful for conda-forge itself, but it could be used for personal feedstocks and I have a CI application (below).

One test has been added for configure_feedstock to ensure that the configuration can be loaded from an alternative path.

The reason I'd like to see this get merged (or something that accomplishes the same) is that I'm trying to set up some CI that uses conda-smithy (i.e. the ci-skeleton route) and getting a little pushback from the project developers about needing to have a "conda-forge.yml" file at the top level in the repository. Making it be a hidden file like ".conda-forge.yml" might be enough for them, but even better would be the ability to put it in a separate directory. It's already possible to move the recipe directory around, and all of the generated files (at least for ci-skeleton's purposes, sans README and whatnot) live in hidden directories, so the feedstock configuration file is the only thing remaining that sticks out.

I tried to be thorough and go for minimum impact, but I'm happy to make changes if at least the basic idea is acceptable.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
