### PR TITLE
Shorten artifact name length by using config_short_name in azure.store_build_artifacts

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1273,6 +1273,8 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
         # fmt: off
         if "docker_image" in data["config"] and platform == "linux":
             config_rendered["DOCKER_IMAGE"] = data["config"]["docker_image"][-1]
+        if forge_config["azure"]["store_build_artifacts"]:
+            config_rendered["SHORT_CONFIG_NAME"] = data["short_config_name"]
         azure_settings["strategy"]["matrix"][data["config_name"]] = config_rendered
         # fmt: on
 

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1520,7 +1520,7 @@ def copy_feedstock_content(forge_config, forge_dir):
 
 
 def _update_dict_within_dict(items, config):
-    """ recursively update dict within dict, if any """
+    """recursively update dict within dict, if any"""
     for key, value in items:
         if isinstance(value, dict):
             config[key] = _update_dict_within_dict(

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -42,8 +42,7 @@ jobs:
 
 {%- if azure.store_build_artifacts %}
   - script: |
-        full_artifact_name="conda_artifacts_$(build.BuildId)_$(CONFIG)"
-        artifact_name=`echo "$full_artifact_name" | head -c 80`
+        artifact_name="conda_artifacts_$(build.BuildId)_$(SHORT_CONFIG_NAME)"
         echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
         if [ -d build_artifacts ]; then
           echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -28,8 +28,7 @@ jobs:
 
 {%- if azure.store_build_artifacts %}
   - script: |
-        full_artifact_name="conda_artifacts_$(build.BuildId)_$(CONFIG)"
-        artifact_name=`echo "$full_artifact_name" | head -c 80`
+        artifact_name="conda_artifacts_$(build.BuildId)_$(SHORT_CONFIG_NAME)"
         echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
         if [ -d /Users/runner/miniforge3/conda-bld/ ]; then
           echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -103,8 +103,7 @@ jobs:
 
 {%- if azure.store_build_artifacts %}
     - script: |
-        set full_artifact_name=conda_artifacts_$(build.BuildID)_$(CONFIG)
-        set artifact_name=%full_artifact_name:~0,80%
+        set artifact_name=conda_artifacts_$(build.BuildID)_$(SHORT_CONFIG_NAME)
         echo ##vso[task.setVariable variable=ARTIFACT_NAME]%artifact_name%
         if exist $(CONDA_BLD_PATH)\\ (
           echo ##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true

--- a/news/azure__use_short_config_name_at_artifact_upload.rst
+++ b/news/azure__use_short_config_name_at_artifact_upload.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* `short_config_name` is used at azure pipelines artifact publishing step.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
This resolves issue #1477 describing failing builds for feedstocks with long artifact names due to a lot of build variants for e.g. python, numpy and arrow like `snowflake-connector-python`. Failing build due to non unique artifact name at artifact upload: https://github.com/conda-forge/snowflake-connector-python-feedstock/runs/2476458561

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
