### PR TITLE
Build artifacts fixes and improvements

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1663,6 +1663,9 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         },
         "github_actions": {
             "self_hosted": False,
+            # Toggle creating artifacts for conda build_artifacts dir
+            "store_build_artifacts": False,
+            "artifact_retention_days": 14,
         },
         "recipe_dir": "recipe",
         "skip_render": [],

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1294,7 +1294,7 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
         if "docker_image" in data["config"] and platform == "linux":
             config_rendered["DOCKER_IMAGE"] = data["config"]["docker_image"][-1]
         if forge_config["azure"]["store_build_artifacts"]:
-            config_rendered["SHORT_CONFIG_NAME"] = data["short_config_name"]
+            config_rendered["SHORT_CONFIG"] = data["short_config_name"]
         azure_settings["strategy"]["matrix"][data["config_name"]] = config_rendered
         # fmt: on
 

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1188,7 +1188,11 @@ def _github_actions_specific_setup(
         "osx": [
             ".scripts/run_osx_build.sh",
         ],
+        "win": [],
     }
+    if forge_config["github_actions"]["store_build_artifacts"]:
+        for tmpls in platform_templates.values():
+            tmpls.append(".scripts/create_conda_build_artifacts.sh")
     template_files = platform_templates.get(platform, [])
 
     _render_template_exe_files(
@@ -1259,6 +1263,16 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
         ],
         "win": [".azure-pipelines/azure-pipelines-win.yml"],
     }
+    if forge_config["azure"]["store_build_artifacts"]:
+        platform_templates["linux"].append(
+            ".scripts/create_conda_build_artifacts.sh"
+        )
+        platform_templates["osx"].append(
+            ".scripts/create_conda_build_artifacts.sh"
+        )
+        platform_templates["win"].append(
+            ".scripts/create_conda_build_artifacts.bat"
+        )
     template_files = platform_templates.get(platform, [])
 
     azure_settings = deepcopy(forge_config["azure"][f"settings_{platform}"])
@@ -1927,6 +1941,8 @@ def get_common_scripts(forge_dir):
         "run_docker_build.sh",
         "build_steps.sh",
         "run_osx_build.sh",
+        "create_conda_build_artifacts.bat",
+        "create_conda_build_artifacts.sh",
     ]:
         yield os.path.join(forge_dir, ".scripts", old_file)
 
@@ -1943,6 +1959,8 @@ def clear_scripts(forge_dir):
             "run_docker_build.sh",
             "build_steps.sh",
             "run_osx_build.sh",
+            "create_conda_build_artifacts.bat",
+            "create_conda_build_artifacts.sh",
         ]:
             remove_file(os.path.join(forge_dir, folder, old_file))
 

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -54,11 +54,20 @@ jobs:
         echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
         if [ -d build_artifacts ]; then
           echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"
+          # remove caches to save some artifact space
+          rm -rf build_artifacts/git_cache
+          rm -rf build_artifacts/pip_cache
+          rm -rf build_artifacts/src_cache
+          # delete broken symlinks so that artifact publishing doesn't fail
+          find build_artifacts -type l -exec test ! -e {} \; -delete
         fi
     displayName: Check for conda build artifacts
     condition: succeededOrFailed()
 
-  - publish: build_artifacts/
-    artifact: $(ARTIFACT_NAME)
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build artifacts
     condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')
+    inputs:
+      targetPath: build_artifacts/
+      artifactName: $(ARTIFACT_NAME)
 {%- endif %}

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -47,51 +47,18 @@ jobs:
 
 {%- if azure.store_build_artifacts %}
   - script: |
-        # Set the artifact name, specialized for this particular job run.
-        ARTIFACT_UNIQUE_ID="$(build.BuildNumber).$(system.JobAttempt)_$(CONFIG)"
-        if [[ {% raw %}${#ARTIFACT_UNIQUE_ID}{% endraw %} -gt 80 ]]; then
-          ARTIFACT_UNIQUE_ID="$(build.BuildNumber).$(system.JobAttempt)_$(SHORT_CONFIG)"
+        export CI=azure
+        export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+        export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+        export CONDA_BLD_DIR=build_artifacts
+        export ARTIFACT_STAGING_DIR="$(Build.ArtifactStagingDirectory)"
+        # Archive everything in CONDA_BLD_DIR except environments
+        export BLD_ARTIFACT_PREFIX=conda_artifacts
+        if [[ "$AGENT_JOBSTATUS" == "Failed" ]]; then
+          # Archive the CONDA_BLD_DIR environments only when the job fails
+          export ENV_ARTIFACT_PREFIX=conda_envs
         fi
-        # prefix should be < 20 characters so the artifact name doesn't exceed 100
-        BLD_ARTIFACT_PREFIX="conda_artifacts"
-        BLD_ARTIFACT_NAME="${BLD_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
-        echo "##vso[task.setVariable variable=BLD_ARTIFACT_NAME]$BLD_ARTIFACT_NAME"
-        echo "BLD_ARTIFACT_NAME: $BLD_ARTIFACT_NAME"
-
-        # Check that the conda-build directory exists for archiving.
-        BLD_ARTIFACT_DIR=build_artifacts
-        if [ -d "$BLD_ARTIFACT_DIR" ]; then
-          # remove caches to save some artifact space
-          rm -rf $BLD_ARTIFACT_DIR/git_cache
-          rm -rf $BLD_ARTIFACT_DIR/pip_cache
-          rm -rf $BLD_ARTIFACT_DIR/src_cache
-          # delete broken symlinks so that artifact publishing doesn't fail
-          find $BLD_ARTIFACT_DIR -type l -exec test ! -e {} \; -delete
-        else
-          echo "##vso[task.logissue type=error]conda-build directory does not exist"
-          exit 1
-        fi
-        echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_DIR"
-        echo "BLD_ARTIFACT_DIR: $BLD_ARTIFACT_DIR"
-
-        if [ $AGENT_JOBSTATUS == "Failed" ]; then
-          # Create a zip archive to use as the conda build artifact.
-          BLD_ARTIFACT_ZIP="$(Build.ArtifactStagingDirectory)/${BLD_ARTIFACT_NAME}.zip"
-          cd "$BLD_ARTIFACT_DIR"
-          zip -r -y -q "$BLD_ARTIFACT_ZIP" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
-          echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_ZIP"
-          echo "BLD_ARTIFACT_ZIP: $BLD_ARTIFACT_ZIP"
-
-          # Create a zip archive to use as the conda env artifact
-          ENV_ARTIFACT_PREFIX="conda_envs"
-          ENV_ARTIFACT_NAME="${ENV_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
-          echo "##vso[task.setVariable variable=ENV_ARTIFACT_NAME]$ENV_ARTIFACT_NAME"
-          echo "ENV_ARTIFACT_NAME: $ENV_ARTIFACT_NAME"
-          ENV_ARTIFACT_ZIP="$(Build.ArtifactStagingDirectory)/${ENV_ARTIFACT_NAME}.zip"
-          zip -r -y -q "$ENV_ARTIFACT_ZIP" . -i '*_*_env*/*'
-          echo "##vso[task.setVariable variable=ENV_ARTIFACT_PATH]$ENV_ARTIFACT_ZIP"
-          echo "ENV_ARTIFACT_ZIP: $ENV_ARTIFACT_ZIP"
-        fi
+        ./.scripts/create_conda_build_artifacts.sh
     displayName: Prepare conda build artifacts
     condition: succeededOrFailed()
 

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -70,6 +70,15 @@ jobs:
         fi
         echo "##vso[task.setVariable variable=ARTIFACT_PATH]$ARTIFACT_DIR"
         echo "ARTIFACT_DIR: $ARTIFACT_DIR"
+
+        if [ $AGENT_JOBSTATUS == "Failed" ]; then
+          # Create a zip archive to use as the artifact.
+          ARTIFACT_ZIP="$(Build.ArtifactStagingDirectory)/${ARTIFACT_NAME}.zip"
+          cd "$ARTIFACT_DIR"
+          zip -r -y -q "$ARTIFACT_ZIP" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
+          echo "##vso[task.setVariable variable=ARTIFACT_PATH]$ARTIFACT_ZIP"
+          echo "ARTIFACT_ZIP: $ARTIFACT_ZIP"
+        fi
     displayName: Prepare conda build artifacts
     condition: succeededOrFailed()
 

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -47,27 +47,36 @@ jobs:
 
 {%- if azure.store_build_artifacts %}
   - script: |
-        artifact_name="conda_artifacts_$(build.BuildId)_$(CONFIG)"
-        if [[ {% raw %}${#artifact_name}{% endraw %} -gt 80 ]]; then
-          artifact_name="conda_artifacts_$(build.BuildId)_$(SHORT_CONFIG)"
+        # Set the artifact name, specialized for this particular job run.
+        ARTIFACT_NAME="conda_artifacts_$(build.BuildNumber).$(system.JobAttempt)_$(CONFIG)"
+        if [[ {% raw %}${#ARTIFACT_NAME}{% endraw %} -gt 80 ]]; then
+          ARTIFACT_NAME="conda_artifacts_$(build.BuildNumber).$(system.JobAttempt)_$(SHORT_CONFIG)"
         fi
-        echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
-        if [ -d build_artifacts ]; then
-          echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"
+        echo "##vso[task.setVariable variable=ARTIFACT_NAME]$ARTIFACT_NAME"
+        echo "ARTIFACT_NAME: $ARTIFACT_NAME"
+
+        # Check that the conda-build directory exists for archiving.
+        ARTIFACT_DIR=build_artifacts
+        if [ -d "$ARTIFACT_DIR" ]; then
           # remove caches to save some artifact space
-          rm -rf build_artifacts/git_cache
-          rm -rf build_artifacts/pip_cache
-          rm -rf build_artifacts/src_cache
+          rm -rf $ARTIFACT_DIR/git_cache
+          rm -rf $ARTIFACT_DIR/pip_cache
+          rm -rf $ARTIFACT_DIR/src_cache
           # delete broken symlinks so that artifact publishing doesn't fail
-          find build_artifacts -type l -exec test ! -e {} \; -delete
+          find $ARTIFACT_DIR -type l -exec test ! -e {} \; -delete
+        else
+          echo "##vso[task.logissue type=error]conda-build directory does not exist"
+          exit 1
         fi
-    displayName: Check for conda build artifacts
+        echo "##vso[task.setVariable variable=ARTIFACT_PATH]$ARTIFACT_DIR"
+        echo "ARTIFACT_DIR: $ARTIFACT_DIR"
+    displayName: Prepare conda build artifacts
     condition: succeededOrFailed()
 
   - task: PublishPipelineArtifact@1
     displayName: Store conda build artifacts
-    condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')
+    condition: not(eq(variables.ARTIFACT_PATH, ''))
     inputs:
-      targetPath: build_artifacts/
+      targetPath: $(ARTIFACT_PATH)
       artifactName: $(ARTIFACT_NAME)
 {%- endif %}

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -48,44 +48,64 @@ jobs:
 {%- if azure.store_build_artifacts %}
   - script: |
         # Set the artifact name, specialized for this particular job run.
-        ARTIFACT_NAME="conda_artifacts_$(build.BuildNumber).$(system.JobAttempt)_$(CONFIG)"
-        if [[ {% raw %}${#ARTIFACT_NAME}{% endraw %} -gt 80 ]]; then
-          ARTIFACT_NAME="conda_artifacts_$(build.BuildNumber).$(system.JobAttempt)_$(SHORT_CONFIG)"
+        ARTIFACT_UNIQUE_ID="$(build.BuildNumber).$(system.JobAttempt)_$(CONFIG)"
+        if [[ {% raw %}${#ARTIFACT_UNIQUE_ID}{% endraw %} -gt 80 ]]; then
+          ARTIFACT_UNIQUE_ID="$(build.BuildNumber).$(system.JobAttempt)_$(SHORT_CONFIG)"
         fi
-        echo "##vso[task.setVariable variable=ARTIFACT_NAME]$ARTIFACT_NAME"
-        echo "ARTIFACT_NAME: $ARTIFACT_NAME"
+        # prefix should be < 20 characters so the artifact name doesn't exceed 100
+        BLD_ARTIFACT_PREFIX="conda_artifacts"
+        BLD_ARTIFACT_NAME="${BLD_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+        echo "##vso[task.setVariable variable=BLD_ARTIFACT_NAME]$BLD_ARTIFACT_NAME"
+        echo "BLD_ARTIFACT_NAME: $BLD_ARTIFACT_NAME"
 
         # Check that the conda-build directory exists for archiving.
-        ARTIFACT_DIR=build_artifacts
-        if [ -d "$ARTIFACT_DIR" ]; then
+        BLD_ARTIFACT_DIR=build_artifacts
+        if [ -d "$BLD_ARTIFACT_DIR" ]; then
           # remove caches to save some artifact space
-          rm -rf $ARTIFACT_DIR/git_cache
-          rm -rf $ARTIFACT_DIR/pip_cache
-          rm -rf $ARTIFACT_DIR/src_cache
+          rm -rf $BLD_ARTIFACT_DIR/git_cache
+          rm -rf $BLD_ARTIFACT_DIR/pip_cache
+          rm -rf $BLD_ARTIFACT_DIR/src_cache
           # delete broken symlinks so that artifact publishing doesn't fail
-          find $ARTIFACT_DIR -type l -exec test ! -e {} \; -delete
+          find $BLD_ARTIFACT_DIR -type l -exec test ! -e {} \; -delete
         else
           echo "##vso[task.logissue type=error]conda-build directory does not exist"
           exit 1
         fi
-        echo "##vso[task.setVariable variable=ARTIFACT_PATH]$ARTIFACT_DIR"
-        echo "ARTIFACT_DIR: $ARTIFACT_DIR"
+        echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_DIR"
+        echo "BLD_ARTIFACT_DIR: $BLD_ARTIFACT_DIR"
 
         if [ $AGENT_JOBSTATUS == "Failed" ]; then
-          # Create a zip archive to use as the artifact.
-          ARTIFACT_ZIP="$(Build.ArtifactStagingDirectory)/${ARTIFACT_NAME}.zip"
-          cd "$ARTIFACT_DIR"
-          zip -r -y -q "$ARTIFACT_ZIP" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
-          echo "##vso[task.setVariable variable=ARTIFACT_PATH]$ARTIFACT_ZIP"
-          echo "ARTIFACT_ZIP: $ARTIFACT_ZIP"
+          # Create a zip archive to use as the conda build artifact.
+          BLD_ARTIFACT_ZIP="$(Build.ArtifactStagingDirectory)/${BLD_ARTIFACT_NAME}.zip"
+          cd "$BLD_ARTIFACT_DIR"
+          zip -r -y -q "$BLD_ARTIFACT_ZIP" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
+          echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_ZIP"
+          echo "BLD_ARTIFACT_ZIP: $BLD_ARTIFACT_ZIP"
+
+          # Create a zip archive to use as the conda env artifact
+          ENV_ARTIFACT_PREFIX="conda_envs"
+          ENV_ARTIFACT_NAME="${ENV_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+          echo "##vso[task.setVariable variable=ENV_ARTIFACT_NAME]$ENV_ARTIFACT_NAME"
+          echo "ENV_ARTIFACT_NAME: $ENV_ARTIFACT_NAME"
+          ENV_ARTIFACT_ZIP="$(Build.ArtifactStagingDirectory)/${ENV_ARTIFACT_NAME}.zip"
+          zip -r -y -q "$ENV_ARTIFACT_ZIP" . -i '*_*_env*/*'
+          echo "##vso[task.setVariable variable=ENV_ARTIFACT_PATH]$ENV_ARTIFACT_ZIP"
+          echo "ENV_ARTIFACT_ZIP: $ENV_ARTIFACT_ZIP"
         fi
     displayName: Prepare conda build artifacts
     condition: succeededOrFailed()
 
   - task: PublishPipelineArtifact@1
     displayName: Store conda build artifacts
-    condition: not(eq(variables.ARTIFACT_PATH, ''))
+    condition: not(eq(variables.BLD_ARTIFACT_PATH, ''))
     inputs:
-      targetPath: $(ARTIFACT_PATH)
-      artifactName: $(ARTIFACT_NAME)
+      targetPath: $(BLD_ARTIFACT_PATH)
+      artifactName: $(BLD_ARTIFACT_NAME)
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build environment artifacts
+    condition: not(eq(variables.ENV_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(ENV_ARTIFACT_PATH)
+      artifactName: $(ENV_ARTIFACT_NAME)
 {%- endif %}

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -47,7 +47,10 @@ jobs:
 
 {%- if azure.store_build_artifacts %}
   - script: |
-        artifact_name="conda_artifacts_$(build.BuildId)_$(SHORT_CONFIG_NAME)"
+        artifact_name="conda_artifacts_$(build.BuildId)_$(CONFIG)"
+        if [[ {% raw %}${#artifact_name}{% endraw %} -gt 80 ]]; then
+          artifact_name="conda_artifacts_$(build.BuildId)_$(SHORT_CONFIG)"
+        fi
         echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
         if [ -d build_artifacts ]; then
           echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -33,51 +33,18 @@ jobs:
 
 {%- if azure.store_build_artifacts %}
   - script: |
-        # Set the artifact name, specialized for this particular job run.
-        ARTIFACT_UNIQUE_ID="$(build.BuildNumber).$(system.JobAttempt)_$(CONFIG)"
-        if [[ {% raw %}${#ARTIFACT_UNIQUE_ID}{% endraw %} -gt 80 ]]; then
-          ARTIFACT_UNIQUE_ID="$(build.BuildNumber).$(system.JobAttempt)_$(SHORT_CONFIG)"
-        fi
-        # prefix should be < 20 characters so the artifact name doesn't exceed 100
-        BLD_ARTIFACT_PREFIX="conda_artifacts"
-        BLD_ARTIFACT_NAME="${BLD_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
-        echo "##vso[task.setVariable variable=BLD_ARTIFACT_NAME]$BLD_ARTIFACT_NAME"
-        echo "BLD_ARTIFACT_NAME: $BLD_ARTIFACT_NAME"
-
-        # Check that the conda-build directory exists for archiving.
-        BLD_ARTIFACT_DIR=/Users/runner/miniforge3/conda-bld/
-        if [ -d "$BLD_ARTIFACT_DIR" ]; then
-          # remove caches to save some artifact space
-          rm -rf $BLD_ARTIFACT_DIR/git_cache
-          rm -rf $BLD_ARTIFACT_DIR/pip_cache
-          rm -rf $BLD_ARTIFACT_DIR/src_cache
-          # delete broken symlinks so that artifact publishing doesn't fail
-          find $BLD_ARTIFACT_DIR -type l -exec test ! -e {} \; -delete
-        else
-          echo "##vso[task.logissue type=error]conda-build directory does not exist"
-          exit 1
-        fi
-        echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_DIR"
-        echo "BLD_ARTIFACT_DIR: $BLD_ARTIFACT_DIR"
-
-        if [ $AGENT_JOBSTATUS == "Failed" ]; then
-          # Create a zip archive to use as the conda build artifact.
-          BLD_ARTIFACT_ZIP="$(Build.ArtifactStagingDirectory)/${BLD_ARTIFACT_NAME}.zip"
-          cd "$BLD_ARTIFACT_DIR"
-          zip -r -y -q "$BLD_ARTIFACT_ZIP" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
-          echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_ZIP"
-          echo "BLD_ARTIFACT_ZIP: $BLD_ARTIFACT_ZIP"
-
-          # Create a zip archive to use as the conda env artifact
-          ENV_ARTIFACT_PREFIX="conda_envs"
-          ENV_ARTIFACT_NAME="${ENV_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
-          echo "##vso[task.setVariable variable=ENV_ARTIFACT_NAME]$ENV_ARTIFACT_NAME"
-          echo "ENV_ARTIFACT_NAME: $ENV_ARTIFACT_NAME"
-          ENV_ARTIFACT_ZIP="$(Build.ArtifactStagingDirectory)/${ENV_ARTIFACT_NAME}.zip"
-          zip -r -y -q "$ENV_ARTIFACT_ZIP" . -i '*_*_env*/*'
-          echo "##vso[task.setVariable variable=ENV_ARTIFACT_PATH]$ENV_ARTIFACT_ZIP"
-          echo "ENV_ARTIFACT_ZIP: $ENV_ARTIFACT_ZIP"
-        fi
+      export CI=azure
+      export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      export CONDA_BLD_DIR=/Users/runner/miniforge3/conda-bld
+      export ARTIFACT_STAGING_DIR="$(Build.ArtifactStagingDirectory)"
+      # Archive everything in CONDA_BLD_DIR except environments
+      export BLD_ARTIFACT_PREFIX=conda_artifacts
+      if [[ "$AGENT_JOBSTATUS" == "Failed" ]]; then
+        # Archive the CONDA_BLD_DIR environments only when the job fails
+        export ENV_ARTIFACT_PREFIX=conda_envs
+      fi
+      ./.scripts/create_conda_build_artifacts.sh
     displayName: Prepare conda build artifacts
     condition: succeededOrFailed()
 

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -34,44 +34,64 @@ jobs:
 {%- if azure.store_build_artifacts %}
   - script: |
         # Set the artifact name, specialized for this particular job run.
-        ARTIFACT_NAME="conda_artifacts_$(build.BuildNumber).$(system.JobAttempt)_$(CONFIG)"
-        if [[ {% raw %}${#ARTIFACT_NAME}{% endraw %} -gt 80 ]]; then
-          ARTIFACT_NAME="conda_artifacts_$(build.BuildNumber).$(system.JobAttempt)_$(SHORT_CONFIG)"
+        ARTIFACT_UNIQUE_ID="$(build.BuildNumber).$(system.JobAttempt)_$(CONFIG)"
+        if [[ {% raw %}${#ARTIFACT_UNIQUE_ID}{% endraw %} -gt 80 ]]; then
+          ARTIFACT_UNIQUE_ID="$(build.BuildNumber).$(system.JobAttempt)_$(SHORT_CONFIG)"
         fi
-        echo "##vso[task.setVariable variable=ARTIFACT_NAME]$ARTIFACT_NAME"
-        echo "ARTIFACT_NAME: $ARTIFACT_NAME"
+        # prefix should be < 20 characters so the artifact name doesn't exceed 100
+        BLD_ARTIFACT_PREFIX="conda_artifacts"
+        BLD_ARTIFACT_NAME="${BLD_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+        echo "##vso[task.setVariable variable=BLD_ARTIFACT_NAME]$BLD_ARTIFACT_NAME"
+        echo "BLD_ARTIFACT_NAME: $BLD_ARTIFACT_NAME"
 
         # Check that the conda-build directory exists for archiving.
-        ARTIFACT_DIR=/Users/runner/miniforge3/conda-bld/
-        if [ -d "$ARTIFACT_DIR" ]; then
+        BLD_ARTIFACT_DIR=/Users/runner/miniforge3/conda-bld/
+        if [ -d "$BLD_ARTIFACT_DIR" ]; then
           # remove caches to save some artifact space
-          rm -rf $ARTIFACT_DIR/git_cache
-          rm -rf $ARTIFACT_DIR/pip_cache
-          rm -rf $ARTIFACT_DIR/src_cache
+          rm -rf $BLD_ARTIFACT_DIR/git_cache
+          rm -rf $BLD_ARTIFACT_DIR/pip_cache
+          rm -rf $BLD_ARTIFACT_DIR/src_cache
           # delete broken symlinks so that artifact publishing doesn't fail
-          find $ARTIFACT_DIR -type l -exec test ! -e {} \; -delete
+          find $BLD_ARTIFACT_DIR -type l -exec test ! -e {} \; -delete
         else
           echo "##vso[task.logissue type=error]conda-build directory does not exist"
           exit 1
         fi
-        echo "##vso[task.setVariable variable=ARTIFACT_PATH]$ARTIFACT_DIR"
-        echo "ARTIFACT_DIR: $ARTIFACT_DIR"
+        echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_DIR"
+        echo "BLD_ARTIFACT_DIR: $BLD_ARTIFACT_DIR"
 
         if [ $AGENT_JOBSTATUS == "Failed" ]; then
-          # Create a zip archive to use as the artifact.
-          ARTIFACT_ZIP="$(Build.ArtifactStagingDirectory)/${ARTIFACT_NAME}.zip"
-          cd "$ARTIFACT_DIR"
-          zip -r -y -q "$ARTIFACT_ZIP" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
-          echo "##vso[task.setVariable variable=ARTIFACT_PATH]$ARTIFACT_ZIP"
-          echo "ARTIFACT_ZIP: $ARTIFACT_ZIP"
+          # Create a zip archive to use as the conda build artifact.
+          BLD_ARTIFACT_ZIP="$(Build.ArtifactStagingDirectory)/${BLD_ARTIFACT_NAME}.zip"
+          cd "$BLD_ARTIFACT_DIR"
+          zip -r -y -q "$BLD_ARTIFACT_ZIP" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
+          echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_ZIP"
+          echo "BLD_ARTIFACT_ZIP: $BLD_ARTIFACT_ZIP"
+
+          # Create a zip archive to use as the conda env artifact
+          ENV_ARTIFACT_PREFIX="conda_envs"
+          ENV_ARTIFACT_NAME="${ENV_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+          echo "##vso[task.setVariable variable=ENV_ARTIFACT_NAME]$ENV_ARTIFACT_NAME"
+          echo "ENV_ARTIFACT_NAME: $ENV_ARTIFACT_NAME"
+          ENV_ARTIFACT_ZIP="$(Build.ArtifactStagingDirectory)/${ENV_ARTIFACT_NAME}.zip"
+          zip -r -y -q "$ENV_ARTIFACT_ZIP" . -i '*_*_env*/*'
+          echo "##vso[task.setVariable variable=ENV_ARTIFACT_PATH]$ENV_ARTIFACT_ZIP"
+          echo "ENV_ARTIFACT_ZIP: $ENV_ARTIFACT_ZIP"
         fi
     displayName: Prepare conda build artifacts
     condition: succeededOrFailed()
 
   - task: PublishPipelineArtifact@1
     displayName: Store conda build artifacts
-    condition: not(eq(variables.ARTIFACT_PATH, ''))
+    condition: not(eq(variables.BLD_ARTIFACT_PATH, ''))
     inputs:
-      targetPath: $(ARTIFACT_PATH)
-      artifactName: $(ARTIFACT_NAME)
+      targetPath: $(BLD_ARTIFACT_PATH)
+      artifactName: $(BLD_ARTIFACT_NAME)
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build environment artifacts
+    condition: not(eq(variables.ENV_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(ENV_ARTIFACT_PATH)
+      artifactName: $(ENV_ARTIFACT_NAME)
 {%- endif %}

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -33,27 +33,36 @@ jobs:
 
 {%- if azure.store_build_artifacts %}
   - script: |
-        artifact_name="conda_artifacts_$(build.BuildId)_$(CONFIG)"
-        if [[ {% raw %}${#artifact_name}{% endraw %} -gt 80 ]]; then
-          artifact_name="conda_artifacts_$(build.BuildId)_$(SHORT_CONFIG)"
+        # Set the artifact name, specialized for this particular job run.
+        ARTIFACT_NAME="conda_artifacts_$(build.BuildNumber).$(system.JobAttempt)_$(CONFIG)"
+        if [[ {% raw %}${#ARTIFACT_NAME}{% endraw %} -gt 80 ]]; then
+          ARTIFACT_NAME="conda_artifacts_$(build.BuildNumber).$(system.JobAttempt)_$(SHORT_CONFIG)"
         fi
-        echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
-        if [ -d /Users/runner/miniforge3/conda-bld/ ]; then
-          echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"
+        echo "##vso[task.setVariable variable=ARTIFACT_NAME]$ARTIFACT_NAME"
+        echo "ARTIFACT_NAME: $ARTIFACT_NAME"
+
+        # Check that the conda-build directory exists for archiving.
+        ARTIFACT_DIR=/Users/runner/miniforge3/conda-bld/
+        if [ -d "$ARTIFACT_DIR" ]; then
           # remove caches to save some artifact space
-          rm -rf /Users/runner/miniforge3/conda-bld/git_cache
-          rm -rf /Users/runner/miniforge3/conda-bld/pip_cache
-          rm -rf /Users/runner/miniforge3/conda-bld/src_cache
+          rm -rf $ARTIFACT_DIR/git_cache
+          rm -rf $ARTIFACT_DIR/pip_cache
+          rm -rf $ARTIFACT_DIR/src_cache
           # delete broken symlinks so that artifact publishing doesn't fail
-          find /Users/runner/miniforge3/conda-bld -type l -exec test ! -e {} \; -delete
+          find $ARTIFACT_DIR -type l -exec test ! -e {} \; -delete
+        else
+          echo "##vso[task.logissue type=error]conda-build directory does not exist"
+          exit 1
         fi
-    displayName: Check for conda build artifacts
+        echo "##vso[task.setVariable variable=ARTIFACT_PATH]$ARTIFACT_DIR"
+        echo "ARTIFACT_DIR: $ARTIFACT_DIR"
+    displayName: Prepare conda build artifacts
     condition: succeededOrFailed()
 
   - task: PublishPipelineArtifact@1
     displayName: Store conda build artifacts
-    condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')
+    condition: not(eq(variables.ARTIFACT_PATH, ''))
     inputs:
-      targetPath: /Users/runner/miniforge3/conda-bld/
+      targetPath: $(ARTIFACT_PATH)
       artifactName: $(ARTIFACT_NAME)
 {%- endif %}

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -33,7 +33,10 @@ jobs:
 
 {%- if azure.store_build_artifacts %}
   - script: |
-        artifact_name="conda_artifacts_$(build.BuildId)_$(SHORT_CONFIG_NAME)"
+        artifact_name="conda_artifacts_$(build.BuildId)_$(CONFIG)"
+        if [[ {% raw %}${#artifact_name}{% endraw %} -gt 80 ]]; then
+          artifact_name="conda_artifacts_$(build.BuildId)_$(SHORT_CONFIG)"
+        fi
         echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
         if [ -d /Users/runner/miniforge3/conda-bld/ ]; then
           echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -56,6 +56,15 @@ jobs:
         fi
         echo "##vso[task.setVariable variable=ARTIFACT_PATH]$ARTIFACT_DIR"
         echo "ARTIFACT_DIR: $ARTIFACT_DIR"
+
+        if [ $AGENT_JOBSTATUS == "Failed" ]; then
+          # Create a zip archive to use as the artifact.
+          ARTIFACT_ZIP="$(Build.ArtifactStagingDirectory)/${ARTIFACT_NAME}.zip"
+          cd "$ARTIFACT_DIR"
+          zip -r -y -q "$ARTIFACT_ZIP" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
+          echo "##vso[task.setVariable variable=ARTIFACT_PATH]$ARTIFACT_ZIP"
+          echo "ARTIFACT_ZIP: $ARTIFACT_ZIP"
+        fi
     displayName: Prepare conda build artifacts
     condition: succeededOrFailed()
 

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -40,11 +40,20 @@ jobs:
         echo "##vso[task.setVariable variable=ARTIFACT_NAME]$artifact_name"
         if [ -d /Users/runner/miniforge3/conda-bld/ ]; then
           echo "##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true"
+          # remove caches to save some artifact space
+          rm -rf /Users/runner/miniforge3/conda-bld/git_cache
+          rm -rf /Users/runner/miniforge3/conda-bld/pip_cache
+          rm -rf /Users/runner/miniforge3/conda-bld/src_cache
+          # delete broken symlinks so that artifact publishing doesn't fail
+          find /Users/runner/miniforge3/conda-bld -type l -exec test ! -e {} \; -delete
         fi
     displayName: Check for conda build artifacts
     condition: succeededOrFailed()
 
-  - publish: /Users/runner/miniforge3/conda-bld/
-    artifact: $(ARTIFACT_NAME)
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build artifacts
     condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')
+    inputs:
+      targetPath: /Users/runner/miniforge3/conda-bld/
+      artifactName: $(ARTIFACT_NAME)
 {%- endif %}

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -123,6 +123,13 @@ jobs:
         )
         echo ##vso[task.setVariable variable=ARTIFACT_PATH]%ARTIFACT_DIR%
         echo ARTIFACT_DIR: %ARTIFACT_DIR%
+
+        if "%AGENT_JOBSTATUS%" == "Failed" (
+          set ARTIFACT_ZIP=$(Build.ArtifactStagingDirectory)\%ARTIFACT_NAME%.zip
+          7z a "!ARTIFACT_ZIP!" "%ARTIFACT_DIR%" '-xr!.git/' '-xr!_*_env*/' '-xr!*_cache/'
+          echo ##vso[task.setVariable variable=ARTIFACT_PATH]!ARTIFACT_ZIP!
+          echo ARTIFACT_ZIP: !ARTIFACT_ZIP!
+        )
       displayName: Prepare conda build artifacts
       condition: succeededOrFailed()
 

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -110,13 +110,19 @@ jobs:
         echo ##vso[task.setVariable variable=ARTIFACT_NAME]%artifact_name%
         if exist $(CONDA_BLD_PATH)\\ (
           echo ##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true
+          if exist $(CONDA_BLD_PATH)\\git_cache ( rmdir /s /q $(CONDA_BLD_PATH)\\git_cache )
+          if exist $(CONDA_BLD_PATH)\\pip_cache ( rmdir /s /q $(CONDA_BLD_PATH)\\pip_cache )
+          if exist $(CONDA_BLD_PATH)\\src_cache ( rmdir /s /q $(CONDA_BLD_PATH)\\src_cache )
         )
       displayName: Check for conda build artifacts
       condition: succeededOrFailed()
 
-    - publish: $(CONDA_BLD_PATH)\\
-      artifact: $(ARTIFACT_NAME)
+    - task: PublishPipelineArtifact@1
+      displayName: Store conda build artifacts
       condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')
+      inputs:
+        targetPath: $(CONDA_BLD_PATH)/
+        artifactName: $(ARTIFACT_NAME)
 {%- endif %}
 
 {%- if conda_forge_output_validation %}

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -105,40 +105,58 @@ jobs:
     - script: |
         setlocal EnableDelayedExpansion
 
-        set ARTIFACT_NAME=conda_artifacts_$(build.BuildNumber).$(system.JobAttempt)_$(CONFIG)
-        if not "%ARTIFACT_NAME%" == "%ARTIFACT_NAME:~0,80%" (
-          set ARTIFACT_NAME=conda_artifacts_$(build.BuildNumber).$(system.JobAttempt)_$(SHORT_CONFIG)
+        set ARTIFACT_UNIQUE_ID=$(build.BuildNumber).$(system.JobAttempt)_$(CONFIG)
+        if not "%ARTIFACT_UNIQUE_ID%" == "%ARTIFACT_UNIQUE_ID:~0,80%" (
+          set ARTIFACT_UNIQUE_ID=$(build.BuildNumber).$(system.JobAttempt)_$(SHORT_CONFIG)
         )
-        echo ##vso[task.setVariable variable=ARTIFACT_NAME]%ARTIFACT_NAME%
-        echo ARTIFACT_NAME: %ARTIFACT_NAME%
+        set BLD_ARTIFACT_PREFIX=conda_artifacts
+        set BLD_ARTIFACT_NAME=%BLD_ARTIFACT_PREFIX%_%ARTIFACT_UNIQUE_ID%
+        echo ##vso[task.setVariable variable=BLD_ARTIFACT_NAME]%BLD_ARTIFACT_NAME%
+        echo BLD_ARTIFACT_NAME: %BLD_ARTIFACT_NAME%
 
-        set ARTIFACT_DIR=$(CONDA_BLD_PATH)
-        if exist %ARTIFACT_DIR% (
-          if exist %ARTIFACT_DIR%\\git_cache ( rmdir /s /q %ARTIFACT_DIR%\\git_cache )
-          if exist %ARTIFACT_DIR%\\pip_cache ( rmdir /s /q %ARTIFACT_DIR%\\pip_cache )
-          if exist %ARTIFACT_DIR%\\src_cache ( rmdir /s /q %ARTIFACT_DIR%\\src_cache )
+        set BLD_ARTIFACT_DIR=$(CONDA_BLD_PATH)
+        if exist %BLD_ARTIFACT_DIR% (
+          if exist %BLD_ARTIFACT_DIR%\\git_cache ( rmdir /s /q %BLD_ARTIFACT_DIR%\\git_cache )
+          if exist %BLD_ARTIFACT_DIR%\\pip_cache ( rmdir /s /q %BLD_ARTIFACT_DIR%\\pip_cache )
+          if exist %BLD_ARTIFACT_DIR%\\src_cache ( rmdir /s /q %BLD_ARTIFACT_DIR%\\src_cache )
         ) else (
           echo ##vso[task.logissue type=error]conda-build directory does not exist
           exit 1
         )
-        echo ##vso[task.setVariable variable=ARTIFACT_PATH]%ARTIFACT_DIR%
-        echo ARTIFACT_DIR: %ARTIFACT_DIR%
+        echo ##vso[task.setVariable variable=BLD_ARTIFACT_PATH]%BLD_ARTIFACT_DIR%
+        echo BLD_ARTIFACT_DIR: %BLD_ARTIFACT_DIR%
 
         if "%AGENT_JOBSTATUS%" == "Failed" (
-          set ARTIFACT_ZIP=$(Build.ArtifactStagingDirectory)\%ARTIFACT_NAME%.zip
-          7z a "!ARTIFACT_ZIP!" "%ARTIFACT_DIR%" '-xr!.git/' '-xr!_*_env*/' '-xr!*_cache/'
-          echo ##vso[task.setVariable variable=ARTIFACT_PATH]!ARTIFACT_ZIP!
-          echo ARTIFACT_ZIP: !ARTIFACT_ZIP!
+          set BLD_ARTIFACT_ZIP=$(Build.ArtifactStagingDirectory)\%BLD_ARTIFACT_NAME%.zip
+          7z a "!BLD_ARTIFACT_ZIP!" "%BLD_ARTIFACT_DIR%" -xr^^!.git/ -xr^^!_*_env*/ -xr^^!*_cache/
+          echo ##vso[task.setVariable variable=BLD_ARTIFACT_PATH]!BLD_ARTIFACT_ZIP!
+          echo BLD_ARTIFACT_ZIP: !BLD_ARTIFACT_ZIP!
+
+          set ENV_ARTIFACT_PREFIX=conda_envs
+          set ENV_ARTIFACT_NAME=!ENV_ARTIFACT_PREFIX!_%ARTIFACT_UNIQUE_ID%
+          echo ##vso[task.setVariable variable=ENV_ARTIFACT_NAME]!ENV_ARTIFACT_NAME!
+          echo ENV_ARTIFACT_NAME: !ENV_ARTIFACT_NAME!
+          set ENV_ARTIFACT_ZIP=$(Build.ArtifactStagingDirectory)\!ENV_ARTIFACT_NAME!.zip
+          7z a "!ENV_ARTIFACT_ZIP!" -r "%BLD_ARTIFACT_DIR%"/_*_env*/
+          echo ##vso[task.setVariable variable=ENV_ARTIFACT_PATH]!ENV_ARTIFACT_ZIP!
+          echo ENV_ARTIFACT_ZIP: !ENV_ARTIFACT_ZIP!
         )
       displayName: Prepare conda build artifacts
       condition: succeededOrFailed()
 
     - task: PublishPipelineArtifact@1
       displayName: Store conda build artifacts
-      condition: not(eq(variables.ARTIFACT_PATH, ''))
+      condition: not(eq(variables.BLD_ARTIFACT_PATH, ''))
       inputs:
-        targetPath: $(ARTIFACT_PATH)
-        artifactName: $(ARTIFACT_NAME)
+        targetPath: $(BLD_ARTIFACT_PATH)
+        artifactName: $(BLD_ARTIFACT_NAME)
+
+    - task: PublishPipelineArtifact@1
+      displayName: Store conda build environment artifacts
+      condition: not(eq(variables.ENV_ARTIFACT_PATH, ''))
+      inputs:
+        targetPath: $(ENV_ARTIFACT_PATH)
+        artifactName: $(ENV_ARTIFACT_NAME)
 {%- endif %}
 
 {%- if conda_forge_output_validation %}

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -103,7 +103,10 @@ jobs:
 
 {%- if azure.store_build_artifacts %}
     - script: |
-        set artifact_name=conda_artifacts_$(build.BuildID)_$(SHORT_CONFIG_NAME)
+        set artifact_name=conda_artifacts_$(build.BuildID)_$(CONFIG)
+        if not "%artifact_name%" == "%artifact_name:~0,80%" (
+          set artifact_name=conda_artifacts_$(build.BuildID)_$(SHORT_CONFIG)
+        )
         echo ##vso[task.setVariable variable=ARTIFACT_NAME]%artifact_name%
         if exist $(CONDA_BLD_PATH)\\ (
           echo ##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -103,44 +103,16 @@ jobs:
 
 {%- if azure.store_build_artifacts %}
     - script: |
-        setlocal EnableDelayedExpansion
-
-        set ARTIFACT_UNIQUE_ID=$(build.BuildNumber).$(system.JobAttempt)_$(CONFIG)
-        if not "%ARTIFACT_UNIQUE_ID%" == "%ARTIFACT_UNIQUE_ID:~0,80%" (
-          set ARTIFACT_UNIQUE_ID=$(build.BuildNumber).$(system.JobAttempt)_$(SHORT_CONFIG)
-        )
+        set CI=azure
+        set CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+        set FEEDSTOCK_NAME=$(build.Repository.Name)
+        set ARTIFACT_STAGING_DIR=$(Build.ArtifactStagingDirectory)
+        set CONDA_BLD_DIR=$(CONDA_BLD_PATH)
         set BLD_ARTIFACT_PREFIX=conda_artifacts
-        set BLD_ARTIFACT_NAME=%BLD_ARTIFACT_PREFIX%_%ARTIFACT_UNIQUE_ID%
-        echo ##vso[task.setVariable variable=BLD_ARTIFACT_NAME]%BLD_ARTIFACT_NAME%
-        echo BLD_ARTIFACT_NAME: %BLD_ARTIFACT_NAME%
-
-        set BLD_ARTIFACT_DIR=$(CONDA_BLD_PATH)
-        if exist %BLD_ARTIFACT_DIR% (
-          if exist %BLD_ARTIFACT_DIR%\\git_cache ( rmdir /s /q %BLD_ARTIFACT_DIR%\\git_cache )
-          if exist %BLD_ARTIFACT_DIR%\\pip_cache ( rmdir /s /q %BLD_ARTIFACT_DIR%\\pip_cache )
-          if exist %BLD_ARTIFACT_DIR%\\src_cache ( rmdir /s /q %BLD_ARTIFACT_DIR%\\src_cache )
-        ) else (
-          echo ##vso[task.logissue type=error]conda-build directory does not exist
-          exit 1
-        )
-        echo ##vso[task.setVariable variable=BLD_ARTIFACT_PATH]%BLD_ARTIFACT_DIR%
-        echo BLD_ARTIFACT_DIR: %BLD_ARTIFACT_DIR%
-
         if "%AGENT_JOBSTATUS%" == "Failed" (
-          set BLD_ARTIFACT_ZIP=$(Build.ArtifactStagingDirectory)\%BLD_ARTIFACT_NAME%.zip
-          7z a "!BLD_ARTIFACT_ZIP!" "%BLD_ARTIFACT_DIR%" -xr^^!.git/ -xr^^!_*_env*/ -xr^^!*_cache/
-          echo ##vso[task.setVariable variable=BLD_ARTIFACT_PATH]!BLD_ARTIFACT_ZIP!
-          echo BLD_ARTIFACT_ZIP: !BLD_ARTIFACT_ZIP!
-
-          set ENV_ARTIFACT_PREFIX=conda_envs
-          set ENV_ARTIFACT_NAME=!ENV_ARTIFACT_PREFIX!_%ARTIFACT_UNIQUE_ID%
-          echo ##vso[task.setVariable variable=ENV_ARTIFACT_NAME]!ENV_ARTIFACT_NAME!
-          echo ENV_ARTIFACT_NAME: !ENV_ARTIFACT_NAME!
-          set ENV_ARTIFACT_ZIP=$(Build.ArtifactStagingDirectory)\!ENV_ARTIFACT_NAME!.zip
-          7z a "!ENV_ARTIFACT_ZIP!" -r "%BLD_ARTIFACT_DIR%"/_*_env*/
-          echo ##vso[task.setVariable variable=ENV_ARTIFACT_PATH]!ENV_ARTIFACT_ZIP!
-          echo ENV_ARTIFACT_ZIP: !ENV_ARTIFACT_ZIP!
+            set ENV_ARTIFACT_PREFIX=conda_envs
         )
+        call ".scripts\create_conda_build_artifacts.bat"
       displayName: Prepare conda build artifacts
       condition: succeededOrFailed()
 

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -103,25 +103,34 @@ jobs:
 
 {%- if azure.store_build_artifacts %}
     - script: |
-        set artifact_name=conda_artifacts_$(build.BuildID)_$(CONFIG)
-        if not "%artifact_name%" == "%artifact_name:~0,80%" (
-          set artifact_name=conda_artifacts_$(build.BuildID)_$(SHORT_CONFIG)
+        setlocal EnableDelayedExpansion
+
+        set ARTIFACT_NAME=conda_artifacts_$(build.BuildNumber).$(system.JobAttempt)_$(CONFIG)
+        if not "%ARTIFACT_NAME%" == "%ARTIFACT_NAME:~0,80%" (
+          set ARTIFACT_NAME=conda_artifacts_$(build.BuildNumber).$(system.JobAttempt)_$(SHORT_CONFIG)
         )
-        echo ##vso[task.setVariable variable=ARTIFACT_NAME]%artifact_name%
-        if exist $(CONDA_BLD_PATH)\\ (
-          echo ##vso[task.setVariable variable=CONDA_BLD_DIR_EXISTS]true
-          if exist $(CONDA_BLD_PATH)\\git_cache ( rmdir /s /q $(CONDA_BLD_PATH)\\git_cache )
-          if exist $(CONDA_BLD_PATH)\\pip_cache ( rmdir /s /q $(CONDA_BLD_PATH)\\pip_cache )
-          if exist $(CONDA_BLD_PATH)\\src_cache ( rmdir /s /q $(CONDA_BLD_PATH)\\src_cache )
+        echo ##vso[task.setVariable variable=ARTIFACT_NAME]%ARTIFACT_NAME%
+        echo ARTIFACT_NAME: %ARTIFACT_NAME%
+
+        set ARTIFACT_DIR=$(CONDA_BLD_PATH)
+        if exist %ARTIFACT_DIR% (
+          if exist %ARTIFACT_DIR%\\git_cache ( rmdir /s /q %ARTIFACT_DIR%\\git_cache )
+          if exist %ARTIFACT_DIR%\\pip_cache ( rmdir /s /q %ARTIFACT_DIR%\\pip_cache )
+          if exist %ARTIFACT_DIR%\\src_cache ( rmdir /s /q %ARTIFACT_DIR%\\src_cache )
+        ) else (
+          echo ##vso[task.logissue type=error]conda-build directory does not exist
+          exit 1
         )
-      displayName: Check for conda build artifacts
+        echo ##vso[task.setVariable variable=ARTIFACT_PATH]%ARTIFACT_DIR%
+        echo ARTIFACT_DIR: %ARTIFACT_DIR%
+      displayName: Prepare conda build artifacts
       condition: succeededOrFailed()
 
     - task: PublishPipelineArtifact@1
       displayName: Store conda build artifacts
-      condition: eq(variables.CONDA_BLD_DIR_EXISTS, 'true')
+      condition: not(eq(variables.ARTIFACT_PATH, ''))
       inputs:
-        targetPath: $(CONDA_BLD_PATH)/
+        targetPath: $(ARTIFACT_PATH)
         artifactName: $(ARTIFACT_NAME)
 {%- endif %}
 

--- a/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
@@ -1,0 +1,80 @@
+setlocal enableextensions enabledelayedexpansion
+
+rem INPUTS (environment variables that need to be set before calling this script):
+rem
+rem CI (azure/github_actions/UNSET)
+rem CI_RUN_ID (unique identifier for the CI job run)
+rem FEEDSTOCK_NAME
+rem CONFIG (build matrix configuration string)
+rem SHORT_CONFIG (uniquely-shortened configuration string)
+rem CONDA_BLD_DIR (path to the conda-bld directory)
+rem ARTIFACT_STAGING_DIR (use working directory if unset)
+rem BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
+rem ENV_ARTIFACT_PREFIX (prefix for the conda build environments artifact name, skip if unset)
+
+rem OUTPUTS
+rem
+rem BLD_ARTIFACT_NAME
+rem BLD_ARTIFACT_PATH
+rem ENV_ARTIFACT_NAME
+rem ENV_ARTIFACT_PATH
+
+rem Check that the conda-build directory exists
+if not exist %CONDA_BLD_DIR% (
+    echo conda-build directory does not exist
+    exit 1
+)
+
+if not defined ARTIFACT_STAGING_DIR (
+    rem Set staging dir to the working dir
+    set ARTIFACT_STAGING_DIR=%cd%
+)
+
+rem Set a unique ID for the artifact(s), specialized for this particular job run
+set ARTIFACT_UNIQUE_ID=%CI_RUN_ID%_%CONFIG%
+if not "%ARTIFACT_UNIQUE_ID%" == "%ARTIFACT_UNIQUE_ID:~0,80%" (
+    set ARTIFACT_UNIQUE_ID=%CI_RUN_ID%_%SHORT_CONFIG%
+)
+
+rem Set a descriptive ID for the archive(s), specialized for this particular job run
+set ARCHIVE_UNIQUE_ID=%CI_RUN_ID%_%CONFIG%
+
+rem Make the build artifact zip
+if defined BLD_ARTIFACT_PREFIX (
+    set BLD_ARTIFACT_NAME=%BLD_ARTIFACT_PREFIX%_%ARTIFACT_UNIQUE_ID%
+    echo BLD_ARTIFACT_NAME: !BLD_ARTIFACT_NAME!
+
+    set "BLD_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%BLD_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.zip"
+    7z a "!BLD_ARTIFACT_PATH!" "%CONDA_BLD_DIR%" -xr^^!.git/ -xr^^!_*_env*/ -xr^^!*_cache/ -bb
+    if errorlevel 1 exit 1
+    echo BLD_ARTIFACT_PATH: !BLD_ARTIFACT_PATH!
+
+    if "%CI%" == "azure" (
+        echo ##vso[task.setVariable variable=BLD_ARTIFACT_NAME]!BLD_ARTIFACT_NAME!
+        echo ##vso[task.setVariable variable=BLD_ARTIFACT_PATH]!BLD_ARTIFACT_PATH!
+    )
+    if "%CI%" == "github_actions" (
+        echo ::set-output name=BLD_ARTIFACT_NAME::!BLD_ARTIFACT_NAME!
+        echo ::set-output name=BLD_ARTIFACT_PATH::!BLD_ARTIFACT_PATH!
+    )
+)
+
+rem Make the environments artifact zip
+if defined ENV_ARTIFACT_PREFIX (
+    set ENV_ARTIFACT_NAME=!ENV_ARTIFACT_PREFIX!_%ARTIFACT_UNIQUE_ID%
+    echo ENV_ARTIFACT_NAME: !ENV_ARTIFACT_NAME!
+
+    set "ENV_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%ENV_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.zip"
+    7z a "!ENV_ARTIFACT_PATH!" -r "%CONDA_BLD_DIR%"/_*_env*/ -bb
+    if errorlevel 1 exit 1
+    echo ENV_ARTIFACT_PATH: !ENV_ARTIFACT_PATH!
+
+    if "%CI%" == "azure" (
+        echo ##vso[task.setVariable variable=ENV_ARTIFACT_NAME]!ENV_ARTIFACT_NAME!
+        echo ##vso[task.setVariable variable=ENV_ARTIFACT_PATH]!ENV_ARTIFACT_PATH!
+    )
+    if "%CI%" == "github_actions" (
+        echo ::set-output name=ENV_ARTIFACT_NAME::!ENV_ARTIFACT_NAME!
+        echo ::set-output name=ENV_ARTIFACT_PATH::!ENV_ARTIFACT_PATH!
+    )
+)

--- a/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+# INPUTS (environment variables that need to be set before calling this script):
+#
+# CI (azure/github_actions/UNSET)
+# CI_RUN_ID (unique identifier for the CI job run)
+# FEEDSTOCK_NAME
+# CONFIG (build matrix configuration string)
+# SHORT_CONFIG (uniquely-shortened configuration string)
+# CONDA_BLD_DIR (path to the conda-bld directory)
+# ARTIFACT_STAGING_DIR (use working directory if unset)
+# BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
+# ENV_ARTIFACT_PREFIX (prefix for the conda build environments artifact name, skip if unset)
+
+# OUTPUTS
+#
+# BLD_ARTIFACT_NAME
+# BLD_ARTIFACT_PATH
+# ENV_ARTIFACT_NAME
+# ENV_ARTIFACT_PATH
+
+source .scripts/logging_utils.sh
+
+# DON'T do set -x, because it results in double echo-ing pipeline commands
+# and that might end up inserting extraneous quotation marks in output variables
+set -e
+
+# Check that the conda-build directory exists
+if [ ! -d "$CONDA_BLD_DIR" ]; then
+    echo "conda-build directory does not exist"
+    exit 1
+fi
+
+# Set staging dir to the working dir, in Windows style if applicable
+if [[ -z "${ARTIFACT_STAGING_DIR}" ]]; then
+    if pwd -W; then
+        ARTIFACT_STAGING_DIR=$(pwd -W)
+    else
+        ARTIFACT_STAGING_DIR=$PWD
+    fi
+fi
+echo "ARTIFACT_STAGING_DIR: $ARTIFACT_STAGING_DIR"
+
+FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
+if [ -z ${FEEDSTOCK_NAME} ]; then
+    export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
+fi
+
+# Set a unique ID for the artifact(s), specialized for this particular job run
+ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${CONFIG}"
+if [[ {% raw %}${#ARTIFACT_UNIQUE_ID}{% endraw %} -gt 80 ]]; then
+    ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${SHORT_CONFIG}"
+fi
+echo "ARTIFACT_UNIQUE_ID: $ARTIFACT_UNIQUE_ID"
+
+# Set a descriptive ID for the archive(s), specialized for this particular job run
+ARCHIVE_UNIQUE_ID="${CI_RUN_ID}_${CONFIG}"
+
+# Make the build artifact zip
+if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
+    export BLD_ARTIFACT_NAME="${BLD_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+    export BLD_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${BLD_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.zip"
+
+    ( startgroup "Archive conda build directory" ) 2> /dev/null
+
+    # Try 7z and fall back to zip if it fails (for cross-platform use)
+    if ! 7z a "$BLD_ARTIFACT_PATH" "$CONDA_BLD_DIR" '-xr!.git/' '-xr!_*_env*/' '-xr!*_cache/' -bb; then
+        pushd "$CONDA_BLD_DIR"
+        zip -r -y -T "$BLD_ARTIFACT_PATH" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
+        popd
+    fi
+
+    ( endgroup "Archive conda build directory" ) 2> /dev/null
+
+    echo "BLD_ARTIFACT_NAME: $BLD_ARTIFACT_NAME"
+    echo "BLD_ARTIFACT_PATH: $BLD_ARTIFACT_PATH"
+
+    if [[ "$CI" == "azure" ]]; then
+        echo "##vso[task.setVariable variable=BLD_ARTIFACT_NAME]$BLD_ARTIFACT_NAME"
+        echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_PATH"
+    elif [[ "$CI" == "github_actions" ]]; then
+        echo "::set-output name=BLD_ARTIFACT_NAME::$BLD_ARTIFACT_NAME"
+        echo "::set-output name=BLD_ARTIFACT_PATH::$BLD_ARTIFACT_PATH"
+    fi
+fi
+
+# Make the environments artifact zip
+if [[ ! -z "$ENV_ARTIFACT_PREFIX" ]]; then
+    export ENV_ARTIFACT_NAME="${ENV_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+    export ENV_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${ENV_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.zip"
+
+    ( startgroup "Archive conda build environments" ) 2> /dev/null
+
+    # Try 7z and fall back to zip if it fails (for cross-platform use)
+    if ! 7z a "$ENV_ARTIFACT_PATH" -r "$CONDA_BLD_DIR"/'_*_env*/' -bb; then
+        pushd "$CONDA_BLD_DIR"
+        zip -r -y -T "$ENV_ARTIFACT_PATH" . -i '*_*_env*/*'
+        popd
+    fi
+
+    ( endgroup "Archive conda build environments" ) 2> /dev/null
+
+    echo "ENV_ARTIFACT_NAME: $ENV_ARTIFACT_NAME"
+    echo "ENV_ARTIFACT_PATH: $ENV_ARTIFACT_PATH"
+
+    if [[ "$CI" == "azure" ]]; then
+        echo "##vso[task.setVariable variable=ENV_ARTIFACT_NAME]$ENV_ARTIFACT_NAME"
+        echo "##vso[task.setVariable variable=ENV_ARTIFACT_PATH]$ENV_ARTIFACT_PATH"
+    elif [[ "$CI" == "github_actions" ]]; then
+        echo "::set-output name=ENV_ARTIFACT_NAME::$ENV_ARTIFACT_NAME"
+        echo "::set-output name=ENV_ARTIFACT_PATH::$ENV_ARTIFACT_PATH"
+    fi
+fi

--- a/conda_smithy/templates/github-actions.tmpl
+++ b/conda_smithy/templates/github-actions.tmpl
@@ -243,6 +243,20 @@ jobs:
           exit 1
         fi
         echo "::set-output name=ARTIFACT_PATH::$ARTIFACT_DIR"
+
+        if [ $JOB_STATUS == "failure" ]; then
+          # Create a zip archive to use as the artifact.
+          # (zip is not available on Windows container)
+          # (7z is not present on macOS, mangled as part of Homebrew)
+          ARTIFACT_ZIP="${ARTIFACT_NAME}.zip"
+          if [ $OS == "windows" ]; then
+            7z a "$ARTIFACT_ZIP" "$ARTIFACT_DIR" '-xr!.git/' '-xr!_*_env*/' '-xr!*_cache/'
+          else
+            cd "$ARTIFACT_DIR"
+            zip -r -y -q "$GITHUB_WORKSPACE/$ARTIFACT_ZIP" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
+          fi
+          echo "::set-output name=ARTIFACT_PATH::$ARTIFACT_ZIP"
+        fi
       continue-on-error: true
 
     - name: Store conda build artifacts

--- a/conda_smithy/templates/github-actions.tmpl
+++ b/conda_smithy/templates/github-actions.tmpl
@@ -209,29 +209,31 @@ jobs:
 
         # Use different prefix for successful and failed build artifacts
         # so random failures don't prevent rebuilds from creating artifacts.
+        # prefix should be < 20 characters so the artifact name doesn't exceed 100
         JOB_STATUS="{% raw %}${{ job.status }}{% endraw %}"
         if [ $JOB_STATUS == "failure" ]; then
-          ARTIFACT_PREFIX="conda_artifacts"
+          BLD_ARTIFACT_PREFIX="conda_artifacts"
         else
-          ARTIFACT_PREFIX="conda_pkgs"
+          BLD_ARTIFACT_PREFIX="conda_pkgs"
         fi
 
         # Set the artifact name, specialized for this particular job run.
-        ARTIFACT_NAME="${ARTIFACT_PREFIX}_${GITHUB_RUN_ID}_${CONFIG}"
-        if [[ {% raw %}${#ARTIFACT_NAME}{% endraw %} -gt 80 ]]; then
-          ARTIFACT_NAME="${ARTIFACT_PREFIX}_${GITHUB_RUN_ID}_${SHORT_CONFIG}"
+        ARTIFACT_UNIQUE_ID="${GITHUB_RUN_ID}_${CONFIG}"
+        if [[ {% raw %}${#ARTIFACT_UNIQUE_ID}{% endraw %} -gt 80 ]]; then
+          ARTIFACT_UNIQUE_ID="${GITHUB_RUN_ID}_${SHORT_CONFIG}"
         fi
-        echo "::set-output name=ARTIFACT_NAME::$ARTIFACT_NAME"
+        BLD_ARTIFACT_NAME="${BLD_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+        echo "::set-output name=BLD_ARTIFACT_NAME::$BLD_ARTIFACT_NAME"
 
         # Check that the conda-build directory exists for archiving.
         if [ $OS == "macos" ]; then
-          ARTIFACT_DIR="${MINIFORGE_HOME:-${HOME}/miniforge3}/conda-bld"
+          BLD_ARTIFACT_DIR="${MINIFORGE_HOME:-${HOME}/miniforge3}/conda-bld"
         elif [ $OS == "windows" ]; then
-          ARTIFACT_DIR="${CONDA//\\//}/conda-bld"
+          BLD_ARTIFACT_DIR="${CONDA//\\//}/conda-bld"
         else
-          ARTIFACT_DIR="build_artifacts"
+          BLD_ARTIFACT_DIR="build_artifacts"
         fi
-        if [ ! -d "$ARTIFACT_DIR" ]; then
+        if [ ! -d "$BLD_ARTIFACT_DIR" ]; then
           echo "conda-build directory does not exist" 1>&2
           exit 1
         fi
@@ -239,22 +241,48 @@ jobs:
         # Create a zip archive to use as the artifact.
         # (zip is not available on Windows container)
         # (7z is not present on macOS, mangled as part of Homebrew)
-        ARTIFACT_ZIP="${ARTIFACT_NAME}.zip"
+        BLD_ARTIFACT_ZIP="${BLD_ARTIFACT_NAME}.zip"
         if [ $OS == "windows" ]; then
-          7z a "$ARTIFACT_ZIP" "$ARTIFACT_DIR" '-xr!.git/' '-xr!_*_env*/' '-xr!*_cache/'
+          7z a "$BLD_ARTIFACT_ZIP" "$BLD_ARTIFACT_DIR" '-xr!.git/' '-xr!_*_env*/' '-xr!*_cache/'
         else
-          cd "$ARTIFACT_DIR"
-          zip -r -y -q "$GITHUB_WORKSPACE/$ARTIFACT_ZIP" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
+          pushd "$BLD_ARTIFACT_DIR"
+          zip -r -y -q "$GITHUB_WORKSPACE/$BLD_ARTIFACT_ZIP" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
+          popd
         fi
-        echo "::set-output name=ARTIFACT_PATH::$ARTIFACT_ZIP"
+        echo "::set-output name=BLD_ARTIFACT_PATH::$BLD_ARTIFACT_ZIP"
+
+        # If the build failed, create a second zip archive of the conda environments.
+        if [ $JOB_STATUS == "failure" ]; then
+          ENV_ARTIFACT_PREFIX="conda_envs"
+          ENV_ARTIFACT_NAME="${ENV_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+          echo "::set-output name=ENV_ARTIFACT_NAME::$ENV_ARTIFACT_NAME"
+          ENV_ARTIFACT_ZIP="${ENV_ARTIFACT_NAME}.zip"
+          if [ $OS == "windows" ]; then
+            7z a "$ENV_ARTIFACT_ZIP" -r "$BLD_ARTIFACT_DIR"/'_*_env*/'
+          else
+            pushd "$BLD_ARTIFACT_DIR"
+            zip -r -y -q "$GITHUB_WORKSPACE/$ENV_ARTIFACT_ZIP" . -i '*_*_env*/*'
+            popd
+          fi
+          echo "::set-output name=ENV_ARTIFACT_PATH::$ENV_ARTIFACT_ZIP"
+        fi
       continue-on-error: true
 
     - name: Store conda build artifacts
       uses: actions/upload-artifact@v2
       if: {% raw %}${{ always() && steps.prepare-artifacts.outcome == 'success' }}{% endraw %}
       with:
-        name: {% raw %}${{ steps.prepare-artifacts.outputs.ARTIFACT_NAME }}{% endraw %}
-        path: {% raw %}${{ steps.prepare-artifacts.outputs.ARTIFACT_PATH }}{% endraw %}
+        name: {% raw %}${{ steps.prepare-artifacts.outputs.BLD_ARTIFACT_NAME }}{% endraw %}
+        path: {% raw %}${{ steps.prepare-artifacts.outputs.BLD_ARTIFACT_PATH }}{% endraw %}
+        retention-days: {{ github_actions.artifact_retention_days }}
+      continue-on-error: true
+
+    - name: Store conda build environment artifacts
+      uses: actions/upload-artifact@v2
+      if: {% raw %}${{ failure() && steps.prepare-artifacts.outcome == 'success' }}{% endraw %}
+      with:
+        name: {% raw %}${{ steps.prepare-artifacts.outputs.ENV_ARTIFACT_NAME }}{% endraw %}
+        path: {% raw %}${{ steps.prepare-artifacts.outputs.ENV_ARTIFACT_PATH }}{% endraw %}
         retention-days: {{ github_actions.artifact_retention_days }}
       continue-on-error: true
 {%- endif %}

--- a/conda_smithy/templates/github-actions.tmpl
+++ b/conda_smithy/templates/github-actions.tmpl
@@ -31,6 +31,9 @@ jobs:
         include:
         {%- for data in configs %}
           - CONFIG: {{ data.config_name }}
+        {%- if github_actions.store_build_artifacts %}
+            SHORT_CONFIG: {{ data.short_config_name }}
+        {%- endif %}
             UPLOAD_PACKAGES: {{ data.upload }}
         {%- if data.build_platform.startswith("osx-64") %}
             os: macos
@@ -191,3 +194,63 @@ jobs:
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}
       if: matrix.os == 'windows'
+
+{%- if github_actions.store_build_artifacts %}
+    - name: Prepare conda build artifacts
+      id: prepare-artifacts
+      shell: bash
+      if: {% raw %}${{ always() }}{% endraw %}
+      env:
+        CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
+        SHORT_CONFIG: {% raw %}${{ matrix.SHORT_CONFIG }}{% endraw %}
+        OS: {% raw %}${{ matrix.os }}{% endraw %}
+      run: |
+        set -x
+
+        # Use different prefix for successful and failed build artifacts
+        # so random failures don't prevent rebuilds from creating artifacts.
+        JOB_STATUS="{% raw %}${{ job.status }}{% endraw %}"
+        if [ $JOB_STATUS == "failure" ]; then
+          ARTIFACT_PREFIX="conda_artifacts"
+        else
+          ARTIFACT_PREFIX="conda_pkgs"
+        fi
+
+        # Set the artifact name, specialized for this particular job run.
+        ARTIFACT_NAME="${ARTIFACT_PREFIX}_${GITHUB_RUN_ID}_${CONFIG}"
+        if [[ {% raw %}${#ARTIFACT_NAME}{% endraw %} -gt 80 ]]; then
+          ARTIFACT_NAME="${ARTIFACT_PREFIX}_${GITHUB_RUN_ID}_${SHORT_CONFIG}"
+        fi
+        echo "::set-output name=ARTIFACT_NAME::$ARTIFACT_NAME"
+
+        # Check that the conda-build directory exists for archiving.
+        if [ $OS == "macos" ]; then
+          ARTIFACT_DIR="${MINIFORGE_HOME:-${HOME}/miniforge3}/conda-bld"
+        elif [ $OS == "windows" ]; then
+          ARTIFACT_DIR="${CONDA//\\//}/conda-bld"
+        else
+          ARTIFACT_DIR="build_artifacts"
+        fi
+        if [ -d "$ARTIFACT_DIR" ]; then
+          # remove caches to save some artifact space
+          rm -rf "${ARTIFACT_DIR}/git_cache"
+          rm -rf "${ARTIFACT_DIR}/pip_cache"
+          rm -rf "${ARTIFACT_DIR}/src_cache"
+          # delete broken symlinks so that artifact publishing doesn't fail
+          find "${ARTIFACT_DIR}" -type l -exec test ! -e {} \; -delete
+        else
+          echo "conda-build directory does not exist" 1>&2
+          exit 1
+        fi
+        echo "::set-output name=ARTIFACT_PATH::$ARTIFACT_DIR"
+      continue-on-error: true
+
+    - name: Store conda build artifacts
+      uses: actions/upload-artifact@v2
+      if: {% raw %}${{ always() && steps.prepare-artifacts.outcome == 'success' }}{% endraw %}
+      with:
+        name: {% raw %}${{ steps.prepare-artifacts.outputs.ARTIFACT_NAME }}{% endraw %}
+        path: {% raw %}${{ steps.prepare-artifacts.outputs.ARTIFACT_PATH }}{% endraw %}
+        retention-days: {{ github_actions.artifact_retention_days }}
+      continue-on-error: true
+{%- endif %}

--- a/conda_smithy/templates/github-actions.tmpl
+++ b/conda_smithy/templates/github-actions.tmpl
@@ -205,67 +205,29 @@ jobs:
         SHORT_CONFIG: {% raw %}${{ matrix.SHORT_CONFIG }}{% endraw %}
         OS: {% raw %}${{ matrix.os }}{% endraw %}
       run: |
-        set -x
-
+        export CI=github_actions
+        export CI_RUN_ID=$GITHUB_RUN_ID
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export ARTIFACT_STAGING_DIR="$GITHUB_WORKSPACE"
+        if [ $OS == "macos" ]; then
+          export CONDA_BLD_DIR="${MINIFORGE_HOME:-${HOME}/miniforge3}/conda-bld"
+        elif [ $OS == "windows" ]; then
+          export CONDA_BLD_DIR="${CONDA//\\//}/conda-bld"
+        else
+          export CONDA_BLD_DIR="build_artifacts"
+        fi
+        # Archive everything in CONDA_BLD_DIR except environments
+        # Archive the CONDA_BLD_DIR environments only when the job fails
         # Use different prefix for successful and failed build artifacts
         # so random failures don't prevent rebuilds from creating artifacts.
-        # prefix should be < 20 characters so the artifact name doesn't exceed 100
         JOB_STATUS="{% raw %}${{ job.status }}{% endraw %}"
         if [ $JOB_STATUS == "failure" ]; then
-          BLD_ARTIFACT_PREFIX="conda_artifacts"
+          export BLD_ARTIFACT_PREFIX="conda_artifacts"
+          export ENV_ARTIFACT_PREFIX="conda_envs"
         else
-          BLD_ARTIFACT_PREFIX="conda_pkgs"
+          export BLD_ARTIFACT_PREFIX="conda_pkgs"
         fi
-
-        # Set the artifact name, specialized for this particular job run.
-        ARTIFACT_UNIQUE_ID="${GITHUB_RUN_ID}_${CONFIG}"
-        if [[ {% raw %}${#ARTIFACT_UNIQUE_ID}{% endraw %} -gt 80 ]]; then
-          ARTIFACT_UNIQUE_ID="${GITHUB_RUN_ID}_${SHORT_CONFIG}"
-        fi
-        BLD_ARTIFACT_NAME="${BLD_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
-        echo "::set-output name=BLD_ARTIFACT_NAME::$BLD_ARTIFACT_NAME"
-
-        # Check that the conda-build directory exists for archiving.
-        if [ $OS == "macos" ]; then
-          BLD_ARTIFACT_DIR="${MINIFORGE_HOME:-${HOME}/miniforge3}/conda-bld"
-        elif [ $OS == "windows" ]; then
-          BLD_ARTIFACT_DIR="${CONDA//\\//}/conda-bld"
-        else
-          BLD_ARTIFACT_DIR="build_artifacts"
-        fi
-        if [ ! -d "$BLD_ARTIFACT_DIR" ]; then
-          echo "conda-build directory does not exist" 1>&2
-          exit 1
-        fi
-
-        # Create a zip archive to use as the artifact.
-        # (zip is not available on Windows container)
-        # (7z is not present on macOS, mangled as part of Homebrew)
-        BLD_ARTIFACT_ZIP="${BLD_ARTIFACT_NAME}.zip"
-        if [ $OS == "windows" ]; then
-          7z a "$BLD_ARTIFACT_ZIP" "$BLD_ARTIFACT_DIR" '-xr!.git/' '-xr!_*_env*/' '-xr!*_cache/'
-        else
-          pushd "$BLD_ARTIFACT_DIR"
-          zip -r -y -q "$GITHUB_WORKSPACE/$BLD_ARTIFACT_ZIP" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
-          popd
-        fi
-        echo "::set-output name=BLD_ARTIFACT_PATH::$BLD_ARTIFACT_ZIP"
-
-        # If the build failed, create a second zip archive of the conda environments.
-        if [ $JOB_STATUS == "failure" ]; then
-          ENV_ARTIFACT_PREFIX="conda_envs"
-          ENV_ARTIFACT_NAME="${ENV_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
-          echo "::set-output name=ENV_ARTIFACT_NAME::$ENV_ARTIFACT_NAME"
-          ENV_ARTIFACT_ZIP="${ENV_ARTIFACT_NAME}.zip"
-          if [ $OS == "windows" ]; then
-            7z a "$ENV_ARTIFACT_ZIP" -r "$BLD_ARTIFACT_DIR"/'_*_env*/'
-          else
-            pushd "$BLD_ARTIFACT_DIR"
-            zip -r -y -q "$GITHUB_WORKSPACE/$ENV_ARTIFACT_ZIP" . -i '*_*_env*/*'
-            popd
-          fi
-          echo "::set-output name=ENV_ARTIFACT_PATH::$ENV_ARTIFACT_ZIP"
-        fi
+        ./.scripts/create_conda_build_artifacts.sh
       continue-on-error: true
 
     - name: Store conda build artifacts

--- a/conda_smithy/templates/github-actions.tmpl
+++ b/conda_smithy/templates/github-actions.tmpl
@@ -231,32 +231,22 @@ jobs:
         else
           ARTIFACT_DIR="build_artifacts"
         fi
-        if [ -d "$ARTIFACT_DIR" ]; then
-          # remove caches to save some artifact space
-          rm -rf "${ARTIFACT_DIR}/git_cache"
-          rm -rf "${ARTIFACT_DIR}/pip_cache"
-          rm -rf "${ARTIFACT_DIR}/src_cache"
-          # delete broken symlinks so that artifact publishing doesn't fail
-          find "${ARTIFACT_DIR}" -type l -exec test ! -e {} \; -delete
-        else
+        if [ ! -d "$ARTIFACT_DIR" ]; then
           echo "conda-build directory does not exist" 1>&2
           exit 1
         fi
-        echo "::set-output name=ARTIFACT_PATH::$ARTIFACT_DIR"
 
-        if [ $JOB_STATUS == "failure" ]; then
-          # Create a zip archive to use as the artifact.
-          # (zip is not available on Windows container)
-          # (7z is not present on macOS, mangled as part of Homebrew)
-          ARTIFACT_ZIP="${ARTIFACT_NAME}.zip"
-          if [ $OS == "windows" ]; then
-            7z a "$ARTIFACT_ZIP" "$ARTIFACT_DIR" '-xr!.git/' '-xr!_*_env*/' '-xr!*_cache/'
-          else
-            cd "$ARTIFACT_DIR"
-            zip -r -y -q "$GITHUB_WORKSPACE/$ARTIFACT_ZIP" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
-          fi
-          echo "::set-output name=ARTIFACT_PATH::$ARTIFACT_ZIP"
+        # Create a zip archive to use as the artifact.
+        # (zip is not available on Windows container)
+        # (7z is not present on macOS, mangled as part of Homebrew)
+        ARTIFACT_ZIP="${ARTIFACT_NAME}.zip"
+        if [ $OS == "windows" ]; then
+          7z a "$ARTIFACT_ZIP" "$ARTIFACT_DIR" '-xr!.git/' '-xr!_*_env*/' '-xr!*_cache/'
+        else
+          cd "$ARTIFACT_DIR"
+          zip -r -y -q "$GITHUB_WORKSPACE/$ARTIFACT_ZIP" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
         fi
+        echo "::set-output name=ARTIFACT_PATH::$ARTIFACT_ZIP"
       continue-on-error: true
 
     - name: Store conda build artifacts

--- a/news/build_artifacts.rst
+++ b/news/build_artifacts.rst
@@ -1,0 +1,26 @@
+**Added:**
+
+* Added the ability to store conda build artifacts using the Github Actions provider. To enable, set `github_actions: {store_build_artifacts: true}` in conda-forge.yml.
+* It is possible to set the lifetime of the Github Actions artifacts by setting the the `github_actions: {artifact_retention_days: 14}` setting in conda-forge.yml to the desired value. The default is 14 days.
+
+**Changed:**
+
+* Azure build artifacts for failed builds are now zipped before being uploaded, with some cache directories and the conda build/host/test environments removed, to make user download smaller and faster.
+* Azure artifact names are now only shortened (uniquely) when necessary to keep the name below 80 characters.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Azure artifact names are now unique when a job needs to be restarted (#1430).
+* Azure artifact uploads for failed builds that failed because of broken symbolic links have now been fixed.
+
+**Security:**
+
+* <news item>

--- a/news/build_artifacts.rst
+++ b/news/build_artifacts.rst
@@ -5,7 +5,8 @@
 
 **Changed:**
 
-* Azure build artifacts for failed builds are now zipped before being uploaded, with some cache directories and the conda build/host/test environments removed, to make user download smaller and faster.
+* Azure build artifacts are now zipped before being uploaded, with some cache directories and the conda build/host/test environments removed, to make user download smaller and faster.
+* A separate Azure build artifact, including only the conda build/host/test environments, is additionally created for failed builds.
 * Azure artifact names are now only shortened (uniquely) when necessary to keep the name below 80 characters.
 
 **Deprecated:**


### PR DESCRIPTION
This fixes some issues with the Azure artifacts and adds artifacts for the Github Actions provider.

1. It ensures artifact names are unique when a job needs to be restarted (#1430). This can happen because of infrastructure failures and so the artifacts may actually change despite the job being the exact same.
2. It fixes uploading artifacts for failed builds where currently the uploading step fails because of broken symbolic links.
3. When downloading an artifact, the zip file is generated by request; if the the artifact is large (such as currently when a build fails), then this can take a long time and, quite frequently, the download times out. Instead, this uses a zip file as the artifact in those cases, so that generation and download is much faster. The old behavior is maintained whenever the build succeeds. The drawback is that you end up with a zip inside a zip, but this seems a small price to pay to make those artifacts more useful. The zip artifact also excludes various cache directories and the build, host, and test environments, which take up a lot of space and are generally not necessary for debugging.
4. Finally, this adds artifact upload for Github Actions, while also considering all of the above.

I have tested this for all platforms with succeeding and failing builds [here](https://github.com/conda-forge/volk-feedstock/pull/25). The Github Actions portion was tested [here](https://github.com/ryanvolz/gnuradio/actions/runs/820673040).

Apologies to @fhoehle who fixed one of these bugs over at https://github.com/conda-forge/conda-smithy/pull/1478; I had that portion of this PR done before, but didn't get around to put everything together until after the work had been duplicated.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes #1430
Closes #1475

<!--
Please add any other relevant info below:
-->
