### PR TITLE
Validate noarch value

### DIFF
--- a/news/validate_noarch_value.rst
+++ b/news/validate_noarch_value.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Validate the value of ``noarch``. (Should be ``python`` or ``generic``.)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -98,6 +98,12 @@ class Test_linter(unittest.TestCase):
         expected_message = "The summary item is expected in the about section."
         self.assertIn(expected_message, lints)
 
+    def test_noarch_value(self):
+        meta = {"build": {"noarch": "true"}}
+        expected = "Invalid `noarch` value `true`. Should be one of"
+        lints, hints = linter.lintify(meta)
+        self.assertTrue(any(lint.startswith(expected) for lint in lints))
+
     def test_maintainers_section(self):
         expected_message = (
             "The recipe could do with some maintainers listed "


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

I don't see any documentation for ``news`` so I'm not sure what to do there...

In one of my recipes I accidentally put `noarch: true` instead of `noarch: python`, and I experienced strange behavior on WIndows where the package showed up in `conda list` but not `pip freeze`. I'm not sure whether or not the bad `noarch` value was to blame, but since the value was not being validated, I figured that it should be added to the linter.

In this commit, I refactored `build_section.get("noarch")` to have its own variable `noarch_value`. Then I verify that the value is either `"python"` or `"generic"`. I also add a test.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
