### PR TITLE
Add detection of output test scripts

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -187,6 +187,8 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
                     test_out = get_section(out, "test", lints)
                     if any(key in TEST_KEYS for key in test_out):
                         has_outputs_test = True
+                    elif test_out.get("script", "").endswith((".bat", ".sh")):
+                        has_outputs_test = True
                     else:
                         no_test_hints.append(
                             "It looks like the '{}' output doesn't "

--- a/news/output_test_scripts.rst
+++ b/news/output_test_scripts.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* correctly detect use of `test/script` in outputs
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -171,6 +171,19 @@ class Test_linter(unittest.TestCase):
             "It looks like the 'foobar' output doesn't have any tests.", hints
         )
 
+        lints, hints = linter.lintify(
+            {
+                "outputs": [
+                    {"name": "foo", "test": {"script": "test-foo.sh"}},
+                    {"name": "foobar", "test": {"script": "test-foobar.pl"}},
+                ]
+            }
+        )
+        self.assertNotIn(expected_message, lints)
+        self.assertIn(
+            "It looks like the 'foobar' output doesn't have any tests.", hints
+        )
+
     def test_test_section_with_recipe(self):
         # If we have a run_test.py file, we shouldn't need to provide
         # other tests.


### PR DESCRIPTION
This PR fixes #1485 by adding support for finding `test/script` in outputs.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
