### PR TITLE
Add --suppress-variables flag to Windows template

### DIFF
--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -91,10 +91,10 @@ jobs:
     - script: |
         call activate base
         {%- if build_with_mambabuild %}
-        conda.exe mambabuild "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml
+        conda.exe mambabuild "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables
         exit 1
         {%- else %}
-        conda.exe build "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml
+        conda.exe build "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables
         {%- endif %}
       displayName: Build recipe
       env:

--- a/news/fix-win-suppress-variables.rst
+++ b/news/fix-win-suppress-variables.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Add --suppress-variables flag to conda-build command in Windows template
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
I am playing around with the `secrets` option in `conda-forge.yml` in a recipe and I noticed that the environment variable is displayed on the Windows builds but are `<hidden>` in the macOS and linux builds.

This adds the `--suppress-variables` flag to the `conda-build` command in the Windows script template.

I tested this by manually adding the flag to my `.azure-pipelines/azure-pipelines-win.yml` file.

I also added the flag for `mambabuild`, but I did not test that.

Let me know if any changes are necessary. Thanks!
