### PR TITLE
Limit the amount of parallel jobs running at the same time

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1262,7 +1262,6 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
     azure_settings.setdefault("strategy", {})
     azure_settings["strategy"].setdefault("matrix", {})
 
-
     # Limit the amount of parallel jobs running at the same time
     # weighted by platform population
     max_parallel = forge_config["azure"]["max_parallel"]
@@ -1275,9 +1274,9 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
             ]
         )
         ratio = platform_counts[platform.split("-")[0]] / n_configs
-        azure_settings["strategy"]["maxParallel"] = \
-            max(1, round(max_parallel * ratio))
-
+        azure_settings["strategy"]["maxParallel"] = max(
+            1, round(max_parallel * ratio)
+        )
 
     for data in forge_config["configs"]:
         if not data["build_platform"].startswith(platform):

--- a/news/azure-max-parallel.rst
+++ b/news/azure-max-parallel.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* The maximum number of parallel jobs a feedstock can run at once will be limited
+  to ``50``. This will ensure that all projects have a fair access to CI resources
+  without job-hungry feedstocks hogging the build queue.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

As discussed in the last core call, and specially relevant to the CUDA matrix explosion, it would be beneficial to limit the amount of parallel jobs each feedstock adds to the queue (limited to 200 parallel jobs across conda-forge). For example, OpenMM adds 78 Azure jobs for every push 😬 

In this PR, I implemented a workaround based on the [`job.strategy.maxParallel` configuration key](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#define-a-single-job) (see the full example a bit later in that section). Smithy will add this key to the config if the number of configs exceeds the established threshold (50 by default), with a value proportional to the amount of configs found for that OS (Linux, MacOS, Windows).

This is the split for OpenMM:

```
linux = 40 / 78 = 0.51 -> 26
win = 24 / 78 = 0.31 -> 15
osx = 14 / 78 = 0.18 -> 9
```

<!--
Please add any other relevant info below:
-->
