### PR TITLE
Support using build-locally.py on osx-arm64

### DIFF
--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -9,7 +9,7 @@ MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
 ( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
 MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
-MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
+MINIFORGE_FILE="Miniforge3-MacOSX-$(uname -m).sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
 bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 

--- a/news/run_osx_build_arm64.rst
+++ b/news/run_osx_build_arm64.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Support using ``build-locally.py`` natively on ``osx-arm64``.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

Without this change, we would always cross-compile when doing a build using `./build-locally.py`. For `tensorflow` I actually need native compilation to get things working.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
