### PR TITLE
Bumps the `python` version on Windows to 3.8

### DIFF
--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -51,7 +51,7 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.8 conda-build conda "{{ remote_ci_setup }}" pip {{- ' boa' if build_with_mambabuild else '' }}' # Optional
+        packageSpecs: 'python=3.9 conda-build conda "{{ remote_ci_setup }}" pip {{- ' boa' if build_with_mambabuild else '' }}' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -51,7 +51,7 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build conda "{{ remote_ci_setup }}" pip {{- ' boa' if build_with_mambabuild else '' }}' # Optional
+        packageSpecs: 'python=3.8 conda-build conda "{{ remote_ci_setup }}" pip {{- ' boa' if build_with_mambabuild else '' }}' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment

--- a/news/new_py_win.rst
+++ b/news/new_py_win.rst
@@ -1,3 +1,3 @@
 **Changed:**
 
-* Bump Windows ``base`` environment Python version to 3.8
+* Bump Windows ``base`` environment Python version to 3.9

--- a/news/new_py_win.rst
+++ b/news/new_py_win.rst
@@ -1,0 +1,3 @@
+**Changed:**
+
+* Bump Windows ``base`` environment Python version to 3.8


### PR DESCRIPTION
Not entirely sure why this is pinned to Python 3.6 (maybe someone can clarify that). Anyways seems like we could use a newer version of Python and 3.8 has been supported for a while in conda-forge. So seems like a good choice. Opening to other pinnings (or dropping the pinning though guessing this is done to protect against brand new unmigrated `python` versions).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
