### PR TITLE
Add ccache caching to Azure Pipelines

### DIFF
--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -5,7 +5,16 @@
 jobs:
 - job: linux
   {{ azure_yaml|indent(2) }}
+  variables:
+    CCACHE_DIR: $(Pipeline.Workspace)/ccache
   steps:
+  - task: Cache@2
+    inputs:
+      key: 'ccache | "$(Agent.OS)"'
+      path: $(CCACHE_DIR)
+      restoreKeys: |
+        ccache | "$(Agent.OS)"
+    displayName: Cache ccache directory
 {%- if clone_depth is not none %}
   - checkout: self
     fetchDepth: {{ clone_depth }}

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -5,7 +5,16 @@
 jobs:
 - job: osx
   {{ azure_yaml|indent(2) }}
+  variables:
+    CCACHE_DIR: $(Pipeline.Workspace)/ccache
   steps:
+  - task: Cache@2
+    inputs:
+      key: 'ccache | "$(Agent.OS)"'
+      path: $(CCACHE_DIR)
+      restoreKeys: |
+        ccache | "$(Agent.OS)"
+    displayName: Cache ccache directory
   # TODO: Fast finish on azure pipelines?
 {%- if clone_depth is not none %}
   - checkout: self

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -5,7 +5,16 @@
 jobs:
 - job: win
   {{ azure_yaml|indent(2) }}
+  variables:
+    CCACHE_DIR: $(Pipeline.Workspace)/ccache
   steps:
+  - task: Cache@2
+    inputs:
+      key: 'ccache | "$(Agent.OS)"'
+      path: $(CCACHE_DIR)
+      restoreKeys: |
+        ccache | "$(Agent.OS)"
+    displayName: Cache ccache directory
 {%- if clone_depth is not none %}
     - checkout: self
       fetchDepth: {{ clone_depth }}

--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -79,6 +79,7 @@ export IS_PR_BUILD="${IS_PR_BUILD:-False}"
 {{ docker.executable }} run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
+           -v "${CCACHE_DIR}":/home/conda/.cache/ccache:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \


### PR DESCRIPTION
This PR adds the "Cache" task to Azure Pipelines steps as the first step that caches the "ccache" folder. This would allow to significantly decrease the build time for C++ projects.

When using Docker with `run_docker_build.sh` CCACHE_DIR is mounted to `/home/conda/.cache/ccache` which is default inside the container.
Whoever uses ccache would need to set `CCACHE_BASEDIR` in the build script for example to the home directory because each conda build happens in different directories.

It's not possible to add steps correctly using `conda-forge.yml` to do it on a per-recipe basis. For builds that do not use ccache this change is harmless.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
