### PR TITLE
Add --pull always flag to docker run

### DIFF
--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -90,6 +90,7 @@ export IS_PR_BUILD="${IS_PR_BUILD:-False}"
            -e CPU_COUNT \
            -e BUILD_WITH_CONDA_DEBUG \
            -e BUILD_OUTPUT_ID \
+           --pull always \
 {%- for secret in secrets %}
            -e {{ secret }} \
 {%- endfor %}

--- a/news/docker_pull.rst
+++ b/news/docker_pull.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Always pull a new version of the image used in a build
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
The default behavior of `docker run` does not update the image, which can cause things to become out of date and result in bad behavior.

```shell
$ docker run --help | grep -- --pull
      --pull string                    Pull image before running ("always"|"missing"|"never") (default "missing")
```

Not sure if there are other places this change would  be needed, AFAICT all build routes end up in `run_docker_build.sh` one way or another.


cc: @beckermr and @chrisburr who suggested this change

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
