### PR TITLE
conda_smithy/templates/travis.yml.tmpl: add --network=host to Docker flags

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -55,6 +55,7 @@ script:
 {%- if upload_on_branch %}
   - export UPLOAD_ON_BRANCH="{{ upload_on_branch }}"
 {%- endif %}
+  - export CONDA_FORGE_DOCKER_RUN_ARGS="--network=host"
   - if [[ "${TRAVIS_PULL_REQUEST:-}" == "false" ]]; then export IS_PR_BUILD="False"; else export IS_PR_BUILD="True"; fi
 {% if 'osx' in platformset %}
   - if [[ ${PLATFORM} =~ .*osx.* ]]; then {%- if idle_timeout_minutes %} travis_wait {{ idle_timeout_minutes }}{% endif %} ./.scripts/run_osx_build.sh; fi

--- a/news/travis_network_host.rst
+++ b/news/travis_network_host.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Travis CI builds now pass `--network=host` to their Docker builds, which should hopefully increase the reliability of builds that need to access the network
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
In at least some cases, it looks like this helps with various network connection timeouts and failures, as per conda-forge/conda-forge.github.io#1521 and conda-forge/rust-feedstock#94.

#### Checklist

* [x] Added a ``news`` entry