### PR TITLE
Call `docker pull` then `docker run`

### DIFF
--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -76,6 +76,7 @@ fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 export IS_PR_BUILD="${IS_PR_BUILD:-False}"
+{{ docker.executable }} pull "${DOCKER_IMAGE}"
 {{ docker.executable }} run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
@@ -90,13 +91,12 @@ export IS_PR_BUILD="${IS_PR_BUILD:-False}"
            -e CPU_COUNT \
            -e BUILD_WITH_CONDA_DEBUG \
            -e BUILD_OUTPUT_ID \
-           --pull always \
 {%- for secret in secrets %}
            -e {{ secret }} \
 {%- endfor %}
-           $DOCKER_IMAGE \
+           "${DOCKER_IMAGE}" \
            {{ docker.command }} \
-           /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh
+           "/home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh"
 
 # verify that the end of the script was reached
 test -f "$DONE_CANARY"

--- a/news/docker_pull_run.rst
+++ b/news/docker_pull_run.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Call ``docker pull`` then ``docker run`` (sometimes ``--pull`` is unavailable)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Since older `docker` installs may not have the `--pull` flag, just call `docker pull` beforehand. This should still work on even the oldest Docker installs.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/conda-smithy/issues/1523

<!--
Please add any other relevant info below:
-->

cc @isuruf @beckermr @mariusvniekerk