### PR TITLE
Use https for NumFOCUS

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -213,7 +213,8 @@ conda search {{ outputs[0] }} --channel {{ channel_name }}
 About conda-forge
 =================
 
-[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
+[![Powered by
+NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the


### PR DESCRIPTION
Prefer to use secure https links for https://numfocus.org <s>and https://www.w3.org/2000/svg</s>

Not modified in this PR are files in `tests/recipes/click-test-feedstock`, as it's part of the test suite. Maybe someone wants to follow-up with that?