### PR TITLE
linux-aarch64 builds default is changed from native (drone) to emulated (azure)

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1835,8 +1835,11 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
     logger.debug(log)
     logger.debug("## END CONFIGURATION\n")
 
-    if config["provider"]["linux_aarch64"] in {"default", "native"}:
-        config["provider"]["linux_aarch64"] = ["drone"]
+    if config["provider"]["linux_aarch64"] == "default":
+        config["provider"]["linux_aarch64"] = ["azure"]
+
+    if config["provider"]["linux_aarch64"] == "native":
+        config["provider"]["linux_aarch64"] = ["travis"]
 
     if config["provider"]["linux_ppc64le"] in {"default", "native"}:
         config["provider"]["linux_ppc64le"] = ["travis"]

--- a/news/arm_azure.rst
+++ b/news/arm_azure.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* linux-aarch64 builds default is changed from native (drone) to emulated (azure).
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
