### PR TITLE
GitHub Actions: Fix `DOCKERIMAGE` env var typo

### DIFF
--- a/conda_smithy/templates/github-actions.tmpl
+++ b/conda_smithy/templates/github-actions.tmpl
@@ -80,7 +80,7 @@ jobs:
       env:
         CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
         UPLOAD_PACKAGES: {% raw %}${{ matrix.UPLOAD_PACKAGES }}{% endraw %}
-        DOCKERIMAGE: {% raw %}${{ matrix.DOCKERIMAGE }}{% endraw %}
+        DOCKER_IMAGE: {% raw %}${{ matrix.DOCKER_IMAGE }}{% endraw %}
         CI: github_actions
 {%- if upload_on_branch %}
         UPLOAD_ON_BRANCH: {{ upload_on_branch }}

--- a/news/fix-docker-image-typo.rst
+++ b/news/fix-docker-image-typo.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed typo in GitHub Actions template, where ``DOCKERIMAGE`` was wrongly specified in the matrix configuration. The CI step and its corresponding script expect ``DOCKER_IMAGE``.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Fixed typo in GitHub Actions template, where `DOCKERIMAGE` was wrongly specified in the matrix configuration. The CI step and its corresponding script expect `DOCKER_IMAGE`.