### PR TITLE
Add utility function feedstock_io.get_repo_root(path)

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -214,7 +214,7 @@ class RegisterCI(Subcommand):
         scp = self.subcommand_parser
         scp.add_argument(
             "--feedstock_directory",
-            default=os.getcwd(),
+            default=feedstock_io.get_repo_root(os.getcwd()) or os.getcwd(),
             help="The directory of the feedstock git repository.",
         )
         scp.add_argument(
@@ -375,7 +375,7 @@ class AddAzureBuildId(Subcommand):
         scp = self.subcommand_parser
         scp.add_argument(
             "--feedstock_directory",
-            default=os.getcwd(),
+            default=feedstock_io.get_repo_root(os.getcwd()) or os.getcwd(),
             help="The directory of the feedstock git repository.",
         )
         scp.add_argument(
@@ -439,7 +439,7 @@ class Regenerate(Subcommand):
         scp = self.subcommand_parser
         scp.add_argument(
             "--feedstock_directory",
-            default=os.getcwd(),
+            default=feedstock_io.get_repo_root(os.getcwd()) or os.getcwd(),
             help="The directory of the feedstock git repository.",
         )
         scp.add_argument(
@@ -692,7 +692,7 @@ class GenerateFeedstockToken(Subcommand):
         scp = self.subcommand_parser
         scp.add_argument(
             "--feedstock_directory",
-            default=os.getcwd(),
+            default=feedstock_io.get_repo_root(os.getcwd()) or os.getcwd(),
             help="The directory of the feedstock git repository.",
         )
         group = scp.add_mutually_exclusive_group()
@@ -738,7 +738,7 @@ class RegisterFeedstockToken(Subcommand):
         scp = self.subcommand_parser
         scp.add_argument(
             "--feedstock_directory",
-            default=os.getcwd(),
+            default=feedstock_io.get_repo_root(os.getcwd()) or os.getcwd(),
             help="The directory of the feedstock git repository.",
         )
         scp.add_argument(
@@ -844,7 +844,7 @@ class UpdateAnacondaToken(Subcommand):
         scp = self.subcommand_parser
         scp.add_argument(
             "--feedstock_directory",
-            default=os.getcwd(),
+            default=feedstock_io.get_repo_root(os.getcwd()) or os.getcwd(),
             help="The directory of the feedstock git repository.",
         )
         scp.add_argument(

--- a/conda_smithy/feedstock_io.py
+++ b/conda_smithy/feedstock_io.py
@@ -21,6 +21,13 @@ def get_repo(path, search_parent_directories=True):
     return repo
 
 
+def get_repo_root(path):
+    try:
+        return get_repo(path).working_tree_dir
+    except AttributeError:
+        return None
+
+
 def set_exe_file(filename, set_exe=True):
     IXALL = stat.S_IXOTH | stat.S_IXGRP | stat.S_IXUSR
 

--- a/news/get_repo_root.rst
+++ b/news/get_repo_root.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Introduce utility function to facilitate the use case of running conda smithy
+  commands from any sub-directory in the git repo checkout of a feedstock.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_feedstock_io.py
+++ b/tests/test_feedstock_io.py
@@ -2,7 +2,9 @@ import functools
 import io
 import operator as op
 import os
+import random
 import stat
+import string
 import shutil
 import tempfile
 import unittest
@@ -65,6 +67,16 @@ class TestFeedstockIO(unittest.TestCase):
                 self.assertIsInstance(
                     fio.get_repo(pathfunc(tmp_dir)), git.Repo
                 )
+                possible_repo_subdir = os.path.join(
+                    tmp_dir,
+                    "".join(
+                        "%s%s"
+                        % (x, os.path.sep if random.random() > 0.5 else "")
+                        for x in string.ascii_lowercase
+                    ),
+                )
+                os.makedirs(possible_repo_subdir)
+                assert fio.get_repo_root(possible_repo_subdir) == tmp_dir
 
     def test_set_exe_file(self):
         perms = [stat.S_IXUSR, stat.S_IXGRP, stat.S_IXOTH]


### PR DESCRIPTION
This feature enables us to run `conda-smithy` commands from anywhere
inside a feedstock repo, instead of always `cd`-ing into the root dir or
specifying it explicitly via `--feedstock_directory`

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
