### PR TITLE
set CF_CUDA_ENABLED=True if `compiler('cuda')` is detected in meta.yaml

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -594,10 +594,13 @@ def _render_ci_provider(
         with open(
             os.path.join(forge_dir, forge_config["recipe_dir"], "meta.yaml")
         ) as f:
-            meta_full_text = f.read()
-        # looking for `compiler('cuda')` with both quote variants
-        if re.match(r"compiler\((\"cuda\"|\'cuda\')\)", meta_full_text):
-            os.environ["CF_CUDA_ENABLED"] = "True"
+            meta_lines = f.readlines()
+        # looking for `compiler('cuda')` with both quote variants;
+        # do not match if there is a `#` somewhere before on the line
+        pat = re.compile(r"^[^\#]*compiler\((\"cuda\"|\'cuda\')\).*")
+        for ml in meta_lines:
+            if pat.match(ml):
+                os.environ["CF_CUDA_ENABLED"] = "True"
 
         config = conda_build.config.get_or_merge_config(
             None,

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -669,6 +669,8 @@ def _render_ci_provider(
         for meta in metas:
             if not meta.skip():
                 enable_platform[i] = True
+            if any(x.startswith("nvcc") for x in meta.meta["requirements"].get("build", [])):
+                os.environ["CF_CUDA_ENABLED"] = "True"
         metas_list_of_lists.append(metas)
 
     if not any(enable_platform):

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -594,11 +594,10 @@ def _render_ci_provider(
         with open(
             os.path.join(forge_dir, forge_config["recipe_dir"], "meta.yaml")
         ) as f:
-            meta_lines = f.readlines()
-        for ml in meta_lines:
-            # looking for `compiler('cuda')` with both quote variants
-            if re.match(r"compiler\((\"cuda\"|\'cuda\')\)", ml):
-                os.environ["CF_CUDA_ENABLED"] = "True"
+            meta_full_text = f.read()
+        # looking for `compiler('cuda')` with both quote variants
+        if re.match(r"compiler\((\"cuda\"|\'cuda\')\)", meta_full_text):
+            os.environ["CF_CUDA_ENABLED"] = "True"
 
         config = conda_build.config.get_or_merge_config(
             None,

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -669,7 +669,10 @@ def _render_ci_provider(
         for meta in metas:
             if not meta.skip():
                 enable_platform[i] = True
-            if any(x.startswith("nvcc") for x in meta.meta["requirements"].get("build", [])):
+            if any(
+                x.startswith("nvcc")
+                for x in meta.meta["requirements"].get("build", [])
+            ):
                 os.environ["CF_CUDA_ENABLED"] = "True"
         metas_list_of_lists.append(metas)
 

--- a/news/add-CF_CUDA_ENABLED.rst
+++ b/news/add-CF_CUDA_ENABLED.rst
@@ -1,0 +1,26 @@
+**Added:**
+
+* Conda smithy will now detect if a recipe uses ``compiler('cuda')``
+and set the ``CF_CUDA_ENABLED`` environment variable to ``True`` if
+so. This can for example be useful to distinguish different options
+for builds with or without GPUs in ``conda_build_config.yaml``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -523,6 +523,8 @@ def cuda_enabled_recipe(config_yaml, request):
 package:
     name: py-test
     version: 1.0.0
+build:
+    skip: True   # [os.environ.get("CF_CUDA_ENABLED") != "True"]
 requirements:
     build:
         - {{ compiler('c') }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -516,6 +516,37 @@ choco:
 
 
 @pytest.fixture(scope="function")
+def cuda_enabled_recipe(config_yaml, request):
+    with open(os.path.join(config_yaml, "recipe", "meta.yaml"), "w") as fh:
+        fh.write(
+            """
+package:
+    name: py-test
+    version: 1.0.0
+requirements:
+    build:
+        - {{ compiler('c') }}
+        - {{ compiler('cuda') }}
+    host:
+        - python
+    run:
+        - python
+about:
+    home: home
+    """
+        )
+    return RecipeConfigPair(
+        str(config_yaml),
+        _load_forge_config(
+            config_yaml,
+            exclusive_config_file=os.path.join(
+                config_yaml, "recipe", "default_config.yaml"
+            ),
+        ),
+    )
+
+
+@pytest.fixture(scope="function")
 def jinja_env(request):
     tmplt_dir = os.path.join(conda_forge_content, "templates")
     # Load templates from the feedstock in preference to the smithy's templates.

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -815,3 +815,26 @@ def test_cos7_env_render(py_recipe, jinja_env):
         else:
             if "DEFAULT_LINUX_VERSION" in os.environ:
                 del os.environ["DEFAULT_LINUX_VERSION"]
+
+
+def test_cuda_enabled_render(cuda_enabled_recipe, jinja_env):
+    has_env = "CF_CUDA_ENABLED" in os.environ
+    if has_env:
+        old_val = os.environ["CF_CUDA_ENABLED"]
+        del os.environ["CF_CUDA_ENABLED"]
+
+    try:
+        assert "CF_CUDA_ENABLED" not in os.environ
+        cnfgr_fdstk.render_azure(
+            jinja_env=jinja_env,
+            forge_config=cuda_enabled_recipe.config,
+            forge_dir=cuda_enabled_recipe.recipe,
+        )
+        assert os.environ["CF_CUDA_ENABLED"] == "True"
+
+    finally:
+        if has_env:
+            os.environ["CF_CUDA_ENABLED"] = old_val
+        else:
+            if "CF_CUDA_ENABLED" in os.environ:
+                del os.environ["CF_CUDA_ENABLED"]

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -818,6 +818,7 @@ def test_cos7_env_render(py_recipe, jinja_env):
 
 
 def test_cuda_enabled_render(cuda_enabled_recipe, jinja_env):
+    forge_config = copy.deepcopy(cuda_enabled_recipe.config)
     has_env = "CF_CUDA_ENABLED" in os.environ
     if has_env:
         old_val = os.environ["CF_CUDA_ENABLED"]
@@ -827,10 +828,17 @@ def test_cuda_enabled_render(cuda_enabled_recipe, jinja_env):
         assert "CF_CUDA_ENABLED" not in os.environ
         cnfgr_fdstk.render_azure(
             jinja_env=jinja_env,
-            forge_config=cuda_enabled_recipe.config,
+            forge_config=forge_config,
             forge_dir=cuda_enabled_recipe.recipe,
         )
         assert os.environ["CF_CUDA_ENABLED"] == "True"
+
+        # this configuration should be run
+        assert forge_config["azure"]["enabled"]
+        matrix_dir = os.path.join(cuda_enabled_recipe.recipe, ".ci_support")
+        assert os.path.isdir(matrix_dir)
+        # single matrix entry - readme is generated later in main function
+        assert len(os.listdir(matrix_dir)) == 6
 
     finally:
         if has_env:


### PR DESCRIPTION
From the discussion in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1708, and particularly, this [description](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1708#issuecomment-943627914) of what to do.

I couldn't think of a way to detect `compiler('cuda')`, because - AFAICT - the ingestion of `meta.yaml` is done a couple lines above by `conda_build.api.render`, and after that, the jinja-functions will have already been filled in.

I think it's a feasible workaround though to just use `r"^nvcc.*"` (as a build requirement) as a stand-in for detecting that.

I haven't yet written a test for it, this is more to check whether I'm on the right path.

CC @isuruf @jakirkham 