### PR TITLE
Switch GitHub Actions to main

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1724,7 +1724,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
             "user_or_org": "conda-forge",
             "repo_name": "",
             "branch_name": "master",
-            "tooling_branch_name": "master",
+            "tooling_branch_name": "main",
         },
         "github_actions": {
             "self_hosted": False,

--- a/news/github-main.rst
+++ b/news/github-main.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* GitHub actions are now using the main branch, instead of master.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Following up on https://github.com/conda-forge/conda-smithy/pull/1501 this PR switches the GitHub actions to `main` (from `master`) as that's what they're using now:
* https://github.com/conda-forge/automerge-action/branches
* https://github.com/conda-forge/webservices-dispatch-action/branches

From what I can see in the [search](https://github.com/conda-forge/conda-smithy/search?q=tooling_branch_name) the key is not used anywhere else so this should not affect anything else.