### PR TITLE
ENH add new token to GHA template

### DIFF
--- a/conda_smithy/templates/automerge.yml.tmpl
+++ b/conda_smithy/templates/automerge.yml.tmpl
@@ -15,5 +15,6 @@ jobs:
         id: automerge-action
         uses: conda-forge/automerge-action@{{ github.tooling_branch_name }}
         with:
-          github_token: {% raw %}${{ secrets.GITHUB_TOKEN }}
+          github_token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+          rerendering_github_token: {% raw %}${{ secrets.RERENDERING_GITHUB_TOKEN }}
 {% endraw %}

--- a/conda_smithy/templates/webservices.yml.tmpl
+++ b/conda_smithy/templates/webservices.yml.tmpl
@@ -9,7 +9,6 @@ jobs:
         id: webservices
         uses: conda-forge/webservices-dispatch-action@{{ github.tooling_branch_name }}
         with:
-          github_token: {% raw %}${{ secrets.GITHUB_TOKEN }}
-{% endraw %}
+          github_token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           rerendering_github_token: {% raw %}${{ secrets.RERENDERING_GITHUB_TOKEN }}
 {% endraw %}

--- a/conda_smithy/templates/webservices.yml.tmpl
+++ b/conda_smithy/templates/webservices.yml.tmpl
@@ -11,3 +11,5 @@ jobs:
         with:
           github_token: {% raw %}${{ secrets.GITHUB_TOKEN }}
 {% endraw %}
+          rerendering_github_token: {% raw %}${{ secrets.RERENDERING_GITHUB_TOKEN }}
+{% endraw %}

--- a/news/wbeservices.rst
+++ b/news/wbeservices.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added rerendering token input to webservices github action.
+* Added rerendering token input to webservices github action and automerge github action.
 
 **Changed:**
 

--- a/news/wbeservices.rst
+++ b/news/wbeservices.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added rerendering token input to webservices github action.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR adds a new token to the GHA template for rendering and the one for automerge. Eventually, the admin bot will add this token to the repos secrets as needed. For now, I have tested things and it does no harm being here. I have also used code from Isuru to adjust the rendering bot to not change girhub action workflow files unless the token it has allows it. Thus we can merge and release changes here without an issue. 
