### PR TITLE
run_docker_build.sh: discard output of cd command

### DIFF
--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -14,7 +14,7 @@ set -xeo pipefail
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
 PROVIDER_DIR="$(basename $THISDIR)"
 
-FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
+FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/{{ recipe_dir }}"
 
 if [ -z ${FEEDSTOCK_NAME} ]; then

--- a/news/cd_run_docker_build.rst
+++ b/news/cd_run_docker_build.rst
@@ -1,0 +1,26 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+Fixed a bug in run_docker_build.sh when finding the value of FEEDSTOCK_ROOT.
+In some cases the cd command had output to stdout which was included in
+FEEDSTOCK_ROOT. Now the value is computed as for THISDIR in the same script,
+with the output of cd redirected to /dev/null.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Redirects the output of `cd` to /dev/null for FEEDSTOCK_ROOT. This fixes
a bug where `cd` has an output to stdout that then gets included in
FEEDSTOCK_ROOT.

This change mirrors the command used for THISDIR.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry