### PR TITLE
Add OSX stuff to gitignore

### DIFF
--- a/conda_smithy/feedstock_content/.gitignore
+++ b/conda_smithy/feedstock_content/.gitignore
@@ -1,3 +1,8 @@
 *.pyc
 
 build_artifacts
+
+MacOSX11.0.sdk.tar.xz
+Mambaforge-MacOSX-x86_64.sh
+miniforge3
+Mambaforge-MacOSX-arm64.sh

--- a/conda_smithy/github.py
+++ b/conda_smithy/github.py
@@ -138,7 +138,7 @@ def create_github_repo(args):
     except GithubException as gh_except:
         if (
             gh_except.data.get("errors", [{}])[0].get("message", "")
-            != u"name already exists on this account"
+            != "name already exists on this account"
         ):
             raise
         gh_repo = user_or_org.get_repo(repo_name)

--- a/news/osx-gitignore.rst
+++ b/news/osx-gitignore.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* When building OSX packages locally, the resulting miniforge3 and mambaforge folders are now ignored by git.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_ci_skeleton.py
+++ b/tests/test_ci_skeleton.py
@@ -92,6 +92,11 @@ GITIGNORE = """# conda smithy ci-skeleton start
 *.pyc
 
 build_artifacts
+
+MacOSX11.0.sdk.tar.xz
+Mambaforge-MacOSX-x86_64.sh
+miniforge3
+Mambaforge-MacOSX-arm64.sh
 # conda smithy ci-skeleton end
 """
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Ref: https://gitter.im/conda-forge/conda-forge.github.io?at=61fd703c3349fe1c71f5e975

Another option would be to clean everything afterwards but since the files are needed for every rerun this should prevent them from being downloaded every time.

The script also changes `.ci_support/osx_arm64_.yaml` so at some point that should probably be changed as well but not sure why that is done so I'm not touching it for now.