### PR TITLE
Provide an option to build with lief_dev

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1739,6 +1739,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         "private_upload": False,
         "secrets": [],
         "build_with_mambabuild": True,
+        "use_lief_dev_202202": False,
         # feedstock checkout git clone depth, None means keep default, 0 means no limit
         "clone_depth": None,
         # Specific channel for package can be given with

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -41,6 +41,9 @@ CONDARC
 {%- if build_with_mambabuild %}
 {{ CONDA_INSTALL_CMD }} update --update-specs --yes --quiet "{{ remote_ci_setup }}" conda-build pip {{ GET_BOA }}-c conda-forge
 {%- endif %}
+{%- if use_lief_dev_202202 %}
+{{ CONDA_INSTALL_CMD }} update -n base --update-specs --quiet --yes -c conda-forge/label/lief_dev -c conda-forge py-lief
+{%- endif %}
 {% if local_ci_setup %}
 conda uninstall --quiet --yes --force "{{ remote_ci_setup }}"
 pip install --no-deps ${RECIPE_ROOT}/.

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -36,6 +36,9 @@ echo -e "\n\nInstalling {{ remote_ci_setup }} and conda-build."
 {%- if build_with_mambabuild %}
 {{ CONDA_INSTALL_CMD }} update -n base --update-specs --quiet --yes "{{ remote_ci_setup }}" conda-build pip{{ GET_BOA }}
 {%- endif %}
+{%- if use_lief_dev_202202 %}
+{{ CONDA_INSTALL_CMD }} update -n base --update-specs --quiet --yes -c conda-forge/label/lief_dev -c conda-forge py-lief
+{%- endif %}
 
 {% if local_ci_setup %}
 conda uninstall --quiet --yes --force "{{ remote_ci_setup }}"

--- a/news/enable_lief_dev_202202.rst
+++ b/news/enable_lief_dev_202202.rst
@@ -1,0 +1,26 @@
+**Added:**
+
+* An option has been added to ``conda-forge.yml`` to build with lief released
+  in the development branch. The option is called ``use_lief_dev_202202`` to
+  emphasize that this option may be removed in the (near) future when
+  a release of the lief package becomes official.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
This should help with tensorflow builds that need to be run manually.

It should remove some of the back and forth between contributing members aiding in releasing packages more smoothly.

The name of the option indicates that it should be ephemeral. 

Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
