### PR TITLE
Drop `defaults` from `channel_sources`

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1729,7 +1729,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         "min_r_ver": "34",
         "max_r_ver": "34",
         "channels": {
-            "sources": ["conda-forge", "defaults"],
+            "sources": ["conda-forge"],
             "targets": [["conda-forge", "main"]],
         },
         "github": {

--- a/news/drop_defaults_channel_sources.rst
+++ b/news/drop_defaults_channel_sources.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Drop ``defaults`` from ``channel_sources``
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
This is already effectively dropped in conda-forge-pinning ( https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1954 ). The value here is a fallback. Nevertheless it is good to be consistent here to avoid confusion. So this matches what is in conda-forge-pinning.

<hr>

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
