### PR TITLE
add handling for boa recipes

### DIFF
--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -65,6 +65,9 @@ jobs:
     # Configure the VM
     - script: |
         call activate base
+        conda.exe remove boa -y -q
+        conda.exe install boa=0.8.2 -y -q --only-deps
+        pip install --no-deps "git+https://github.com/wolfv/boa.git@improve_compat_with_conda_smithy_boa_0.8.2"
         {%- if local_ci_setup %}
         conda.exe uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}
         pip install --no-deps ".\{{ recipe_dir }}\."
@@ -94,7 +97,7 @@ jobs:
     - script: |
         call activate base
         {%- if build_with_mambabuild %}
-        conda.exe mambabuild "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables
+        boa build "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables
         {%- else %}
         conda.exe build "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables
         {%- endif %}

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -67,6 +67,10 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != l
 fi
 {% endif %}
 
+mamba remove boa -y -q
+mamba install boa=0.8.2 -y -q --only-deps
+pip install --no-deps "git+https://github.com/wolfv/boa.git@improve_compat_with_conda_smithy_boa_0.8.2"
+
 ( endgroup "Configuring conda" ) 2> /dev/null
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
@@ -80,7 +84,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda {{ BUILD_CMD }} "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    boa build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -29,7 +29,7 @@ conda-build:
 CONDARC
 {% if build_with_mambabuild %}
 {%- set CONDA_INSTALL_CMD="mamba" %}
-{%- set remote_ci_setup = ["boa"] + remote_ci_setup %}
+{%- set remote_ci_setup = ["boa", "mamba"] + remote_ci_setup %}
 {%- set BUILD_CMD="mambabuild" %}
 {%- else %}
 {%- set CONDA_INSTALL_CMD="mamba" %}

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -43,6 +43,10 @@ conda uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}
 pip install --no-deps {{ recipe_dir }}/.
 {%- endif %}
 
+mamba remove boa -y -q
+mamba install boa=0.8.2 -y -q --only-deps
+pip install --no-deps "git+https://github.com/wolfv/boa.git@improve_compat_with_conda_smithy_boa_0.8.2"
+
 echo -e "\n\nSetting up the condarc and mangling the compiler."
 setup_conda_rc ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
 
@@ -84,7 +88,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda {{ BUILD_CMD }} ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml \
+    boa build ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
 

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -21,7 +21,7 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 ( startgroup "Configuring conda" ) 2> /dev/null
 {% if build_with_mambabuild %}
 {%- set CONDA_INSTALL_CMD="mamba" %}
-{%- set remote_ci_setup = ["boa"] + remote_ci_setup %}
+{%- set remote_ci_setup = ["boa", "mamba"] + remote_ci_setup %}
 {%- set BUILD_CMD="mambabuild" %}
 {%- else %}
 {%- set CONDA_INSTALL_CMD="mamba" %}


### PR DESCRIPTION
This is a preliminary PR to add handling for `boa` recipes. It didn't require many changes since we are duck-typing the relevant `MetaData` class in `boa` anyways. Variant handling is slightly different but we can certainly patch that up on the `boa`-side.
Also you can completely ignore the changes in the templates for now, since those were only made to see if I can get the xtensor-feedstock to work.