### PR TITLE
[fix] feedstock token registration

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -242,7 +242,7 @@ class RegisterCI(Subcommand):
         ]:
             scp.add_argument(
                 "--without-{}".format(ci.lower()),
-                dest=ci.lower().replace("-","_"),
+                dest=ci.lower().replace("-", "_"),
                 action="store_false",
                 help="If set, {} will be not registered".format(ci),
             )
@@ -767,7 +767,7 @@ class RegisterFeedstockToken(Subcommand):
         ]:
             scp.add_argument(
                 "--without-{}".format(ci.lower()),
-                dest=ci.lower().replace("-","_"),
+                dest=ci.lower().replace("-", "_"),
                 action="store_false",
                 help="If set, {} will be not registered".format(ci),
             )
@@ -877,7 +877,7 @@ class UpdateAnacondaToken(Subcommand):
         ]:
             scp.add_argument(
                 "--without-{}".format(ci.lower()),
-                dest=ci.lower().replace("-","_"),
+                dest=ci.lower().replace("-", "_"),
                 action="store_false",
                 help="If set, the token on {} will be not changed.".format(ci),
             )

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -242,7 +242,7 @@ class RegisterCI(Subcommand):
         ]:
             scp.add_argument(
                 "--without-{}".format(ci.lower()),
-                dest=ci.lower(),
+                dest=ci.lower().replace("-","_"),
                 action="store_false",
                 help="If set, {} will be not registered".format(ci),
             )
@@ -767,7 +767,7 @@ class RegisterFeedstockToken(Subcommand):
         ]:
             scp.add_argument(
                 "--without-{}".format(ci.lower()),
-                dest=ci.lower(),
+                dest=ci.lower().replace("-","_"),
                 action="store_false",
                 help="If set, {} will be not registered".format(ci),
             )
@@ -877,7 +877,7 @@ class UpdateAnacondaToken(Subcommand):
         ]:
             scp.add_argument(
                 "--without-{}".format(ci.lower()),
-                dest=ci.lower(),
+                dest=ci.lower().replace("-","_"),
                 action="store_false",
                 help="If set, the token on {} will be not changed.".format(ci),
             )

--- a/news/fix-cli-args.rst
+++ b/news/fix-cli-args.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* <news item>
+* Fixed issue with CLI argument for feedstock token commands.
 
 **Security:**
 


### PR DESCRIPTION
Looks like argument is registered to `args['github-actions']` but checks for `args.github_actions`. Converting should do the trick.

## Checklist
* [x] Added a ``news`` entry

## Related issues
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Resolves #1587 

<!--
Please add any other relevant info below:
-->

## Additional comments
This is a draft - probably should also add a test first.