### PR TITLE
Fix uninstallation of conda-forge-ci-setup

### DIFF
--- a/conda_smithy/templates/appveyor.yml.tmpl
+++ b/conda_smithy/templates/appveyor.yml.tmpl
@@ -55,7 +55,9 @@ install:
     # Tell conda we want an updated version of conda-build and {{ " ".join(remote_ci_setup) }}
     - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-build pip {{ " ".join(remote_ci_setup) }}
     {%- if local_ci_setup %}
-    - cmd: conda.exe uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}
+    # Uninstall the conda-forge-ci-setup package but leave its dependencies
+    # so that we may bootstrap the installation process
+    - cmd: conda.exe uninstall --quiet --yes --force conda-forge-ci-setup
     - cmd: pip install --no-deps .\{{ recipe_dir }}\.
     {%- endif %}
     - cmd: setup_conda_rc .\ .\{{ recipe_dir }} .\.ci_support\%CONFIG%.yaml

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -68,7 +68,7 @@ jobs:
     - script: |
         call activate base
         {%- if local_ci_setup %}
-        conda.exe uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}
+        conda.exe uninstall --quiet --yes --force conda-forge-ci-setup
         pip install --no-deps ".\{{ recipe_dir }}\."
         {%- endif %}
         setup_conda_rc .\ ".\{{ recipe_dir }}" .\.ci_support\%CONFIG%.yaml

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -44,7 +44,9 @@ CONDARC
     conda-build pip {{ BOA }}{{ " ".join(remote_ci_setup) }}
 {%- endif %}
 {% if local_ci_setup %}
-conda uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}
+# Uninstall the conda-forge-ci-setup package but leave its dependencies
+# so that we may bootstrap the installation process
+conda uninstall --quiet --yes --force conda-forge-ci-setup
 pip install --no-deps ${RECIPE_ROOT}/.
 {%- endif %}
 # set up the condarc

--- a/conda_smithy/templates/github-actions.tmpl
+++ b/conda_smithy/templates/github-actions.tmpl
@@ -154,7 +154,7 @@ jobs:
         mamba.exe install -c conda-forge 'python=3.9' conda-build conda pip {{ BOA }}{{ " ".join(remote_ci_setup) }}
         if errorlevel 1 exit 1
         {%- if local_ci_setup %}
-        conda.exe uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}"
+        conda.exe uninstall --quiet --yes --force conda-forge-ci-setup
         if errorlevel 1 exit 1
         pip install --no-deps ".\{{ recipe_dir }}\."
         if errorlevel 1 exit 1

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -40,7 +40,9 @@ echo -e "\n\nInstalling {{ remote_ci_setup }} and conda-build."
 {%- endif %}
 
 {% if local_ci_setup %}
-conda uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}
+# Uninstall the conda-forge-ci-setup package but leave its dependencies
+# so that we may bootstrap the installation process
+conda uninstall --quiet --yes --force conda-forge-ci-setup
 pip install --no-deps {{ recipe_dir }}/.
 {%- endif %}
 

--- a/news/do_no_uninstall_extra_packages.rst
+++ b/news/do_no_uninstall_extra_packages.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Do not uninstall extra packages specified in ``remote_ci_setup`` during the bootstrapping phase of the ci-setup of the ci-setup.


### PR DESCRIPTION
This attempts to help the bootstrap process uninstall any pre-installed version of `conda-forge-ci-setup`.

I've added comments to the effect where I knew how to do it in the relevant syntax.

The purpose of specifying extra packages was specifically designed in to avoid needless churn with the `tensorflow` package which depends on `lief_dev` which has not had a new release in about 8 months.

I'm really trying to contain scope creep here and not balloon the options provided in `conda-forge.yml`

References: 
Lief releases: https://github.com/lief-project/LIEF/releases

Request to use lief dev: https://github.com/conda-forge/tensorflow-feedstock/pull/189#issuecomment-1029924154

Interested parties: @beckermr @isuruf @xhochy

Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
