### PR TITLE
DEP deprecate using Travis CI usage on win-*, osx-* or linux_64

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -654,12 +654,16 @@ def _render_ci_provider(
             if (
                 channel_target.startswith("conda-forge ")
                 and provider_name == "travis"
-                and (platform != "linux" or arch not in ["aarch64", "ppc64le", "s390x"])
+                and (
+                    platform != "linux"
+                    or arch not in ["aarch64", "ppc64le", "s390x"]
+                )
             ):
                 raise RuntimeError(
                     "Travis CI can only be used for 'linux_aarch64', "
                     "'linux_ppc64le' or 'linux_s390x' native builds"
-                    ", not '%s_%s', to avoid using open-source build minutes!" % (platform, arch)
+                    ", not '%s_%s', to avoid using open-source build minutes!"
+                    % (platform, arch)
                 )
 
         # AFAIK there is no way to get conda build to ignore the CBC yaml

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -649,6 +649,19 @@ def _render_ci_provider(
                     "to avoid a denial of service for other infrastructure."
                 )
 
+            # we skip travis builds for anything but aarch64, ppc64le and s390x
+            # due to their current open-source policies around usage
+            if (
+                channel_target.startswith("conda-forge ")
+                and provider_name == "travis"
+                and (platform != "linux" or arch not in ["aarch64", "ppc64le", "s390x"])
+            ):
+                raise RuntimeError(
+                    "Travis CI can only be used for 'linux_aarch64', "
+                    "'linux_ppc64le' or 'linux_s390x' native builds"
+                    ", not '%s_%s', to avoid using open-source build minutes!" % (platform, arch)
+                )
+
         # AFAIK there is no way to get conda build to ignore the CBC yaml
         # in the recipe. This one can mess up migrators applied with local
         # CBC yaml files where variants in the migrators are not in the CBC.
@@ -982,19 +995,6 @@ def _get_platforms_of_provider(provider, forge_config):
             continue
         providers = forge_config["provider"][build_platform_arch]
         if provider in providers:
-            # we skip travis builds for anything but aarch64, ppc64le and s390x
-            # due to their current open-source policies around usage
-            if provider == "travis" and (
-                build_arch not in ["aarch64", "ppc64le", "s390x"]
-                or build_platform != "linux"
-            ):
-                logger.warning(
-                    "Travis CI can only be used for 'linux_aarch64', "
-                    "'linux_ppc64le' or 'linux_s390x'"
-                    ", not '%s'!" % (build_platform_arch)
-                )
-                continue
-
             platforms.append(platform)
             archs.append(arch)
             if platform == "linux" and arch == "64":

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -982,6 +982,19 @@ def _get_platforms_of_provider(provider, forge_config):
             continue
         providers = forge_config["provider"][build_platform_arch]
         if provider in providers:
+            # we skip travis builds for anything but aarch64, ppc64le and s390x
+            # due to their current open-source policies around usage
+            if provider == "travis" and (
+                build_arch not in ["aarch64", "ppc64le", "s390x"]
+                or build_platform != "linux"
+            ):
+                logger.warning(
+                    "Travis CI can only be used for 'linux_aarch64', "
+                    "'linux_ppc64le' or 'linux_s390x'"
+                    ", not '%s'!" % (build_platform_arch)
+                )
+                continue
+
             platforms.append(platform)
             archs.append(arch)
             if platform == "linux" and arch == "64":

--- a/news/travis.rst
+++ b/news/travis.rst
@@ -1,0 +1,5 @@
+**Deprecated:**
+
+* We have deprecated the usage of Travis CI for any platforms but linux_aarch64, linux_ppc64le, or
+  linux_s390x. Conda-smithy will no longer render CI scripts for other platforms on travis and will
+  emit a warning if one attempts to do so.

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -75,6 +75,7 @@ def test_r_skips_appveyor(r_recipe, jinja_env):
     assert not os.path.isdir(os.path.join(r_recipe.recipe, ".ci_support"))
 
 
+@pytest.mark.xfail(reason="Travis CI is not enabled for OSX", strict=True)
 @pytest.mark.legacy_travis
 def test_r_matrix_travis(r_recipe, jinja_env):
     r_recipe.config["provider"]["osx"] = "travis"
@@ -139,6 +140,7 @@ def test_py_matrix_appveyor(py_recipe, jinja_env):
     assert len(os.listdir(matrix_dir)) == 2
 
 
+@pytest.mark.xfail(reason="Travis CI is not enabled for OSX", strict=True)
 @pytest.mark.legacy_travis
 def test_py_matrix_travis(py_recipe, jinja_env):
     py_recipe.config["provider"]["osx"] = "travis"
@@ -331,6 +333,7 @@ def test_azure_with_empty_yum_reqs_raises(py_recipe, jinja_env):
         )
 
 
+@pytest.mark.xfail(reason="Travis CI is not enabled for OSX", strict=True)
 @pytest.mark.legacy_circle
 @pytest.mark.legacy_travis
 def test_circle_osx(py_recipe, jinja_env):
@@ -371,6 +374,49 @@ def test_circle_osx(py_recipe, jinja_env):
         jinja_env=jinja_env, forge_config=config, forge_dir=forge_dir
     )
     assert not os.path.exists(travis_yml_file)
+
+    cnfgr_fdstk.clear_scripts(forge_dir)
+    config = copy.deepcopy(py_recipe.config)
+    config["provider"]["linux"] = "dummy"
+    config["provider"]["osx"] = "circle"
+    cnfgr_fdstk.render_circle(
+        jinja_env=jinja_env, forge_config=config, forge_dir=forge_dir
+    )
+    assert os.path.exists(circle_osx_file)
+    assert not os.path.exists(circle_linux_file)
+    assert os.path.exists(circle_config_file)
+
+
+@pytest.mark.legacy_circle
+def test_circle_only_osx(py_recipe, jinja_env):
+    # Set legacy providers
+    py_recipe.config["provider"]["osx"] = "azure"
+    py_recipe.config["provider"]["linux"] = "circle"
+
+    forge_dir = py_recipe.recipe
+    circle_osx_file = os.path.join(forge_dir, ".scripts", "run_osx_build.sh")
+    circle_linux_file = os.path.join(
+        forge_dir, ".scripts", "run_docker_build.sh"
+    )
+    circle_config_file = os.path.join(forge_dir, ".circleci", "config.yml")
+
+    cnfgr_fdstk.clear_scripts(forge_dir)
+    cnfgr_fdstk.render_circle(
+        jinja_env=jinja_env, forge_config=py_recipe.config, forge_dir=forge_dir
+    )
+    assert not os.path.exists(circle_osx_file)
+    assert os.path.exists(circle_linux_file)
+    assert os.path.exists(circle_config_file)
+
+    cnfgr_fdstk.clear_scripts(forge_dir)
+    config = copy.deepcopy(py_recipe.config)
+    config["provider"]["osx"] = "circle"
+    cnfgr_fdstk.render_circle(
+        jinja_env=jinja_env, forge_config=config, forge_dir=forge_dir
+    )
+    assert os.path.exists(circle_osx_file)
+    assert os.path.exists(circle_linux_file)
+    assert os.path.exists(circle_config_file)
 
     cnfgr_fdstk.clear_scripts(forge_dir)
     config = copy.deepcopy(py_recipe.config)

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -75,7 +75,6 @@ def test_r_skips_appveyor(r_recipe, jinja_env):
     assert not os.path.isdir(os.path.join(r_recipe.recipe, ".ci_support"))
 
 
-@pytest.mark.xfail(reason="Travis CI is not enabled for OSX", strict=True)
 @pytest.mark.legacy_travis
 def test_r_matrix_travis(r_recipe, jinja_env):
     r_recipe.config["provider"]["osx"] = "travis"
@@ -140,7 +139,6 @@ def test_py_matrix_appveyor(py_recipe, jinja_env):
     assert len(os.listdir(matrix_dir)) == 2
 
 
-@pytest.mark.xfail(reason="Travis CI is not enabled for OSX", strict=True)
 @pytest.mark.legacy_travis
 def test_py_matrix_travis(py_recipe, jinja_env):
     py_recipe.config["provider"]["osx"] = "travis"
@@ -333,7 +331,6 @@ def test_azure_with_empty_yum_reqs_raises(py_recipe, jinja_env):
         )
 
 
-@pytest.mark.xfail(reason="Travis CI is not enabled for OSX", strict=True)
 @pytest.mark.legacy_circle
 @pytest.mark.legacy_travis
 def test_circle_osx(py_recipe, jinja_env):
@@ -374,49 +371,6 @@ def test_circle_osx(py_recipe, jinja_env):
         jinja_env=jinja_env, forge_config=config, forge_dir=forge_dir
     )
     assert not os.path.exists(travis_yml_file)
-
-    cnfgr_fdstk.clear_scripts(forge_dir)
-    config = copy.deepcopy(py_recipe.config)
-    config["provider"]["linux"] = "dummy"
-    config["provider"]["osx"] = "circle"
-    cnfgr_fdstk.render_circle(
-        jinja_env=jinja_env, forge_config=config, forge_dir=forge_dir
-    )
-    assert os.path.exists(circle_osx_file)
-    assert not os.path.exists(circle_linux_file)
-    assert os.path.exists(circle_config_file)
-
-
-@pytest.mark.legacy_circle
-def test_circle_only_osx(py_recipe, jinja_env):
-    # Set legacy providers
-    py_recipe.config["provider"]["osx"] = "azure"
-    py_recipe.config["provider"]["linux"] = "circle"
-
-    forge_dir = py_recipe.recipe
-    circle_osx_file = os.path.join(forge_dir, ".scripts", "run_osx_build.sh")
-    circle_linux_file = os.path.join(
-        forge_dir, ".scripts", "run_docker_build.sh"
-    )
-    circle_config_file = os.path.join(forge_dir, ".circleci", "config.yml")
-
-    cnfgr_fdstk.clear_scripts(forge_dir)
-    cnfgr_fdstk.render_circle(
-        jinja_env=jinja_env, forge_config=py_recipe.config, forge_dir=forge_dir
-    )
-    assert not os.path.exists(circle_osx_file)
-    assert os.path.exists(circle_linux_file)
-    assert os.path.exists(circle_config_file)
-
-    cnfgr_fdstk.clear_scripts(forge_dir)
-    config = copy.deepcopy(py_recipe.config)
-    config["provider"]["osx"] = "circle"
-    cnfgr_fdstk.render_circle(
-        jinja_env=jinja_env, forge_config=config, forge_dir=forge_dir
-    )
-    assert os.path.exists(circle_osx_file)
-    assert os.path.exists(circle_linux_file)
-    assert os.path.exists(circle_config_file)
 
     cnfgr_fdstk.clear_scripts(forge_dir)
     config = copy.deepcopy(py_recipe.config)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
due to how travis CI now counts CI minutes, we can no longer use it easily on windows, osx or linux-64. It can be used easily on pcc64le, aarch64 and s390x. 