### PR TITLE
add noarch_platforms to conda-forge.yml

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1850,8 +1850,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         if platform_arch not in config["provider"]:
             config["provider"][platform_arch] = None
 
-    if isinstance(config["noarch_platform"], str):
-        config["noarch_platform"] = [config["noarch_platform"]]
+    config["noarch_platform"] = conda_build.utils.ensure_list(config["noarch_platform"])
 
     for noarch_platform in sorted(config["noarch_platform"]):
         if noarch_platform not in build_platforms:

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1024,7 +1024,7 @@ def _get_platforms_of_provider(provider, forge_config):
         ):
             platforms.append(platform)
             archs.append(arch)
-            if platform == "linux" and arch == "64":
+            if platform_arch in forge_config["noarch_platform"]:
                 keep_noarchs.append(True)
             else:
                 keep_noarchs.append(False)

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1008,7 +1008,7 @@ def _get_platforms_of_provider(provider, forge_config):
         if provider in providers:
             platforms.append(platform)
             archs.append(arch)
-            if platform_arch in forge_config["noarch_platform"]:
+            if platform_arch in forge_config["noarch_platforms"]:
                 keep_noarchs.append(True)
             else:
                 keep_noarchs.append(False)
@@ -1024,7 +1024,7 @@ def _get_platforms_of_provider(provider, forge_config):
         ):
             platforms.append(platform)
             archs.append(arch)
-            if platform_arch in forge_config["noarch_platform"]:
+            if platform_arch in forge_config["noarch_platforms"]:
                 keep_noarchs.append(True)
             else:
                 keep_noarchs.append(False)
@@ -1722,6 +1722,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
             "osx": None,
             "win": None,
         },
+        # value is the build_platform, key is the target_platform
         "build_platform": {
             "linux_64": "linux_64",
             "linux_aarch64": "linux_aarch64",
@@ -1731,7 +1732,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
             "win_64": "win_64",
             "osx_64": "osx_64",
         },
-        "noarch_platform": "linux_64",
+        "noarch_platforms": ["linux_64"],
         "os_version": {
             "linux_64": None,
             "linux_aarch64": None,
@@ -1843,20 +1844,22 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
             )
         )
 
-    build_platforms = sorted(config["build_platform"].keys())
+    target_platforms = sorted(config["build_platform"].keys())
 
-    for platform_arch in build_platforms:
+    for platform_arch in target_platforms:
         config[platform_arch] = {"enabled": "True"}
         if platform_arch not in config["provider"]:
             config["provider"][platform_arch] = None
 
-    config["noarch_platform"] = conda_build.utils.ensure_list(config["noarch_platform"])
+    config["noarch_platforms"] = conda_build.utils.ensure_list(
+        config["noarch_platforms"]
+    )
 
-    for noarch_platform in sorted(config["noarch_platform"]):
-        if noarch_platform not in build_platforms:
+    for noarch_platform in sorted(config["noarch_platforms"]):
+        if noarch_platform not in target_platforms:
             raise ValueError(
                 f"Unknown noarch platform {noarch_platform}. Expected one of: "
-                f"{build_platforms}"
+                f"{target_platforms}"
             )
 
     config["secrets"] = sorted(set(config["secrets"] + ["BINSTAR_TOKEN"]))

--- a/news/add-noarch-platform.rst
+++ b/news/add-noarch-platform.rst
@@ -1,0 +1,4 @@
+**Added:**
+
+* noarch packages that cannot be built on ``linux_64`` can be configured to build
+  on one or more ``noarch_platforms`` in ``conda-forge.yml``

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -758,6 +758,23 @@ def test_conda_forge_yaml_empty(config_yaml):
     ]
 
 
+def test_noarch_platform_bad_yaml(config_yaml):
+    load_forge_config = lambda: cnfgr_fdstk._load_forge_config(  # noqa
+        config_yaml,
+        exclusive_config_file=os.path.join(
+            config_yaml, "recipe", "default_config.yaml"
+        ),
+    )
+
+    with open(os.path.join(config_yaml, "conda-forge.yml"), "a+") as fp:
+        fp.write("noarch_platform: [eniac, zx80]")
+
+    with pytest.raises(ValueError) as excinfo:
+        load_forge_config()
+
+    assert "eniac" in str(excinfo.value)
+
+
 def test_forge_yml_alt_path(config_yaml):
     load_forge_config = (
         lambda forge_yml: cnfgr_fdstk._load_forge_config(  # noqa

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -758,7 +758,7 @@ def test_conda_forge_yaml_empty(config_yaml):
     ]
 
 
-def test_noarch_platform_bad_yaml(config_yaml):
+def test_noarch_platforms_bad_yaml(config_yaml):
     load_forge_config = lambda: cnfgr_fdstk._load_forge_config(  # noqa
         config_yaml,
         exclusive_config_file=os.path.join(
@@ -767,7 +767,7 @@ def test_noarch_platform_bad_yaml(config_yaml):
     )
 
     with open(os.path.join(config_yaml, "conda-forge.yml"), "a+") as fp:
-        fp.write("noarch_platform: [eniac, zx80]")
+        fp.write("noarch_platforms: [eniac, zx80]")
 
     with pytest.raises(ValueError) as excinfo:
         load_forge_config()


### PR DESCRIPTION
Checklist
* [ ] Added a ``news`` entry

References:
- fixes #1449  
- would enable _cleanly_ fixing https://github.com/conda-forge/pywin32-on-windows-feedstock/issues/1 
- [gitter thread](https://gitter.im/conda-forge/conda-forge.github.io?at=622904f3d1b64840db5b7542)
- docs: https://github.com/conda-forge/conda-forge.github.io/pull/1624

Changes:
- [x] adds `noarch_platforms: ["linux_64"]` to the config default
- [x] casts strings to list to allow for multiple noarch build platforms (e.g. `__unix` vs `pywin32`)
- [x] adds a test for a unknown `noarch_platforms` 