### PR TITLE
ENH update travis url and badge image

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -224,10 +224,12 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
-packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Azure](https://azure.microsoft.com/en-us/services/devops/), [GitHub](https://github.com/),
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
+[Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
+it is possible to build and upload installable packages to the
+[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -83,8 +83,8 @@ Current build status
   <tr>
     <td>Travis</td>
     <td>
-      <a href="https://travis-ci.com/{{ github.user_or_org }}/{{ github.repo_name }}">
-        <img alt="macOS" src="{{ shield }}travis/com/{{ github.user_or_org }}/{{ github.repo_name }}/{{ github.branch_name }}.svg?label=macOS">
+      <a href="https://app.travis-ci.com/{{ github.user_or_org }}/{{ github.repo_name }}">
+        <img alt="linux" src="{{ shield }}travis/com/{{ github.user_or_org }}/{{ github.repo_name }}/{{ github.branch_name }}.svg?label=Linux">
       </a>
     </td>
   </tr>

--- a/news/travis.rst
+++ b/news/travis.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Travis CI badge in readme uses correct url and linux image

--- a/tests/recipes/click-test-feedstock/README.md
+++ b/tests/recipes/click-test-feedstock/README.md
@@ -21,7 +21,7 @@ Current build status
 ====================
 
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/click-test-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/click-test-feedstock)
-OSX: [![TravisCI](https://travis-ci.com/conda-forge/click-test-feedstock.svg?branch=master)](https://travis-ci.com/conda-forge/click-test-feedstock)
+OSX: [![TravisCI](https://app.travis-ci.com/conda-forge/click-test-feedstock.svg?branch=master)](https://travis-ci.com/conda-forge/click-test-feedstock)
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/click-test-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/click-test-feedstock/branch/master)
 
 Current release info


### PR DESCRIPTION
Travis now uses app.travis-ci.com and we only use linux on it.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
