### PR TITLE
update circle away from deprecated default image

### DIFF
--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -9,7 +9,8 @@ jobs:
 {%- if not configs %}
   build:
     working_directory: ~/test
-    machine: true
+    machine:
+      - image: ubuntu-2004:current
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.
@@ -19,7 +20,8 @@ jobs:
   build_{{ data.config_name }}:
     working_directory: ~/test
 {%- if data.platform.startswith('linux') %}
-    machine: true
+    machine:
+      - image: ubuntu-2004:current
 {%- else %}
     macos:
       xcode: "13.0.0"

--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -10,7 +10,7 @@ jobs:
   build:
     working_directory: ~/test
     machine:
-      - image: ubuntu-2004:current
+      image: ubuntu-2004:current
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.

--- a/news/migrate_circle_linux_image.rst
+++ b/news/migrate_circle_linux_image.rst
@@ -1,0 +1,4 @@
+**Changed:**
+
+* circleci linux image to latest ubuntu for
+  https://circleci.com/blog/ubuntu-14-16-image-deprecation/


### PR DESCRIPTION
'machine: true' in circleci will stop working on 5/31/22 per:
https://circleci.com/blog/ubuntu-14-16-image-deprecation/
Upgrade circle to using latest ubuntu ala azure. Refrained from
making the images configurable per feedstock like Azure because
I don't know if that's worth adding the extra code since most
feedstocks don't use circle

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
