### PR TITLE
Skip render tuneup

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -59,9 +59,10 @@ def package_key(config, used_loop_vars, subdir):
     )
     return key.replace("*", "_").replace(" ", "_")
 
+
 def _ignore_match(ignore, rel):
     """Return true if rel or any of it's PurePath().parents are in ignore
-    
+
     i.e. putting .github in skip_render will prevent rendering of anything
     named .github in the toplevel of the feedstock and anything below that as well
     """
@@ -1659,14 +1660,10 @@ def render_github_actions_services(jinja_env, forge_config, forge_dir):
     skip_files = _get_skip_files(forge_config)
     for template_file in ["automerge.yml", "webservices.yml"]:
         template = jinja_env.get_template(template_file + ".tmpl")
-        rel_target_fname = os.path.join(
-            ".github", "workflows", template_file
-        )
+        rel_target_fname = os.path.join(".github", "workflows", template_file)
         if _ignore_match(skip_files, rel_target_fname):
             continue
-        target_fname = os.path.join(
-            forge_dir, rel_target_fname
-        )
+        target_fname = os.path.join(forge_dir, rel_target_fname)
         new_file_contents = template.render(**forge_config)
         with write_file(target_fname) as fh:
             fh.write(new_file_contents)

--- a/news/skip_render_skips_github_services.tst
+++ b/news/skip_render_skips_github_services.tst
@@ -8,4 +8,3 @@
 **Fixed:**
 
 * skip_render can prevent github webservices from rendering
-

--- a/news/skip_render_skips_github_services.tst
+++ b/news/skip_render_skips_github_services.tst
@@ -1,0 +1,11 @@
+
+**Changed:**
+
+* skip_render can match Path().parents of files being rendered
+  i.e. '.github' in list prevents rendering .github in toplevel
+  and any files below .github/
+
+**Fixed:**
+
+* skip_render can prevent github webservices from rendering
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
[skip_render can skip github_actions_services](https://github.com/conda-forge/conda-smithy/commit/6fa380ce60f0fa388dc9e0866bb82df25dc888f3) 

Also enhanced it so that you can skip rendering anything
below a directory by specifying the directory name (without
For example, if '.github' is in the skip_render list, all
files inside .github/ will be skipped.

Logging now tells you when rendering was actually skipped
as opposed to just what was read from the config.