### PR TITLE
update pre-commit to black stable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,6 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 22.3.0
     hooks:
     -   id: black


### PR DESCRIPTION
Checklist
* [ ] Added a ``news`` entry

This updates `black` to a stable version that doesn't fail to install.

References

- from #1619