### PR TITLE
NEW: Reuse package cache when building locally

### DIFF
--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -25,6 +25,8 @@ cat >~/.condarc <<CONDARC
 
 conda-build:
  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+pkgs_dirs:
+    - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
 
 CONDARC
 {% if build_with_mambabuild %}

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -27,6 +27,7 @@ conda-build:
  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
 pkgs_dirs:
     - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
+    - /opt/conda/pkgs
 
 CONDARC
 {% if build_with_mambabuild %}

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -24,10 +24,10 @@ export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
 cat >~/.condarc <<CONDARC
 
 conda-build:
- root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
 pkgs_dirs:
-    - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
-    - /opt/conda/pkgs
+  - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
+  - /opt/conda/pkgs
 
 CONDARC
 {% if build_with_mambabuild %}

--- a/news/build_local_cache.rst
+++ b/news/build_local_cache.rst
@@ -1,0 +1,4 @@
+**Changed:**
+
+* build_locally now creates conda's shared package cache outside the container,
+  so repeated builds of the same recipe do not need to redownload packages.


### PR DESCRIPTION
Adding this key to .condarc moves the conda package cache out of the container and into build_artifacts on the local disk. This means that repeated local builds of the same recipe won't have to redownload all of the dependency packages.

Addresses some of the concerns of https://github.com/conda-forge/conda-smithy/issues/1533

Related:
https://docs.anaconda.com/anaconda/user-guide/tasks/shared-pkg-cache/

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
