### PR TITLE
Make render_README faster

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1529,32 +1529,13 @@ def render_README(jinja_env, forge_config, forge_dir, render_info=None):
         return
 
     render_info = render_info or []
-
-    # pull out relevant metadata from rendering
-    try:
-        metas = conda_build.api.render(
-            os.path.join(forge_dir, forge_config["recipe_dir"]),
-            exclusive_config_file=forge_config["exclusive_config_file"],
-            permit_undefined_jinja=True,
-            finalize=False,
-            bypass_env_check=True,
-            trim_skip=False,
-        )
-        metas = [m[0] for m in metas]
-    except Exception:
-        # sometimes the above fails so we grab actual metadata
-        done = False
-        metas = []
-        for md in render_info:
-            for _metas, enabled in zip(
-                md["metas_list_of_lists"], md["enable_platform"]
-            ):
-                if enabled and len(_metas) > 0:
-                    metas = _metas
-                    done = True
-                    break
-            if done:
-                break
+    metas = []
+    for md in render_info:
+        for _metas, enabled in zip(
+            md["metas_list_of_lists"], md["enable_platform"]
+        ):
+            if enabled and len(_metas) > 0:
+                metas.extend(_metas)
 
     if len(metas) == 0:
         raise RuntimeError(
@@ -1576,7 +1557,7 @@ def render_README(jinja_env, forge_config, forge_dir, render_info=None):
     template = jinja_env.get_template("README.md.tmpl")
     target_fname = os.path.join(forge_dir, "README.md")
     forge_config["noarch_python"] = all(meta.noarch for meta in metas)
-    forge_config["package"] = metas[0]
+    forge_config["package_about"] = metas[0].meta["about"]
     forge_config["package_name"] = package_name
     forge_config["variants"] = sorted(variants)
     forge_config["outputs"] = sorted(

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1547,7 +1547,7 @@ def render_README(jinja_env, forge_config, forge_dir, render_info=None):
                 bypass_env_check=True,
                 trim_skip=False,
             )
-            metas = [m[0] for m in metas]        
+            metas = [m[0] for m in metas]
         except Exception:
             raise RuntimeError(
                 "Could not create any metadata for rendering the README.md!"

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1538,11 +1538,22 @@ def render_README(jinja_env, forge_config, forge_dir, render_info=None):
                 metas.extend(_metas)
 
     if len(metas) == 0:
-        raise RuntimeError(
-            "Could not create any metadata for rendering the README.md!"
-            " This likely indicates a serious bug or a feedstock with no actual"
-            " builds."
-        )
+        try:
+            metas = conda_build.api.render(
+                os.path.join(forge_dir, forge_config["recipe_dir"]),
+                exclusive_config_file=forge_config["exclusive_config_file"],
+                permit_undefined_jinja=True,
+                finalize=False,
+                bypass_env_check=True,
+                trim_skip=False,
+            )
+            metas = [m[0] for m in metas]        
+        except Exception:
+            raise RuntimeError(
+                "Could not create any metadata for rendering the README.md!"
+                " This likely indicates a serious bug or a feedstock with no actual"
+                " builds."
+            )
 
     package_name = get_feedstock_name_from_meta(metas[0])
 

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -2,29 +2,29 @@
 {#-
 # -*- mode: jinja -*-
 -#}
-{%- set license_url = package.meta.about.license_url -%}
+{%- set license_url = package_about.license_url -%}
 
 About {{ package_name }}
 ======{{ '=' * package_name|length }}
 
-Home: {{ package.meta.about.home }}
+Home: {{ package_about.home }}
 
-Package license: {% if license_url %}[{% endif %}{{ package.meta.about.license }}{% if license_url %}]({{ license_url }}){% endif %}
+Package license: {% if license_url %}[{% endif %}{{ package_about.license }}{% if license_url %}]({{ license_url }}){% endif %}
 
 Feedstock license: [BSD-3-Clause](https://github.com/{{ github.user_or_org }}/{{ github.repo_name }}/blob/{{ github.branch_name }}/LICENSE.txt)
 
-Summary: {{ package.meta.about.summary }}
-{%- if package.meta.about.dev_url %}
+Summary: {{ package_about.summary }}
+{%- if package_about.dev_url %}
 
-Development: {{ package.meta.about.dev_url }}
+Development: {{ package_about.dev_url }}
 {%- endif %}
-{%- if package.meta.about.doc_url %}
+{%- if package_about.doc_url %}
 
-Documentation: {{ package.meta.about.doc_url }}
+Documentation: {{ package_about.doc_url }}
 {%- endif %}
-{%- if package.meta.about.description %}
+{%- if package_about.description %}
 
-{{ package.meta.about.description }}
+{{ package_about.description }}
 {%- endif %}
 
 Current build status


### PR DESCRIPTION
1. Avoid calling conda_build.api.render and use render_info
2. Do not send a ruamel.yaml object into jinja to avoid costly
   serialization/deserialization.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
