### PR TITLE
Add retry logic to 'Download Miniforge' step of win pipeline

### DIFF
--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -27,9 +27,22 @@ jobs:
         scriptSource: inline
         script: |
           import urllib.request
+          import time
           url = 'https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Windows-x86_64.exe'
           path = r"$(Build.ArtifactStagingDirectory)/Miniforge.exe"
-          urllib.request.urlretrieve(url, path)
+          retry_time = 2
+          retries = 5
+          while retries >= 0:
+              retries -= 1
+              try:
+                  urllib.request.urlretrieve(url, path)
+              except urllib.error.URLError as e:
+                  if retries >= 0:
+                      print(f"Encountered error: '{e}'. Retry in {retry_time} seconds.")
+                      time.sleep(retry_time)
+                      retry_time *= 2
+                  else:
+                      raise e
 
     - script: |
         start /wait "" %BUILD_ARTIFACTSTAGINGDIRECTORY%\Miniforge.exe /InstallationType=JustMe /RegisterPython=0 /S /D=C:\Miniforge

--- a/news/add-retry-logic.rst
+++ b/news/add-retry-logic.rst
@@ -1,0 +1,4 @@
+**Added:**
+
+* The 'Download Miniforge' stage of the Windows pipeline now retries in case
+  of a download error.


### PR DESCRIPTION
I'd like to solve [this download failure](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=526852&view=logs&j=5be07ae1-d8ba-5406-47b6-8e3a3a12f825&t=ab3c72cc-d8b1-58f6-4306-ed5ab2055114
) and those like it by retrying.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
