### PR TITLE
fix index for pin_compatible lint

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -583,7 +583,7 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
         if pinning_section is None:
             return
         for pin in fnmatch.filter(pinning_section, "compatible_pin*"):
-            if pin.split()[-1] in subpackage_names:
+            if pin.split()[1] in subpackage_names:
                 lints.append(
                     "pin_subpackage should be used instead of"
                     f" pin_compatible for `{pin.split()[1]}`"
@@ -591,7 +591,7 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
                     f" {subpackage_names}."
                 )
         for pin in fnmatch.filter(pinning_section, "subpackage_pin*"):
-            if pin.split()[-1] not in subpackage_names:
+            if pin.split()[1] not in subpackage_names:
                 lints.append(
                     "pin_compatible should be used instead of"
                     f" pin_subpackage for `{pin.split()[1]}`"

--- a/news/fix-pin_compatible.rst
+++ b/news/fix-pin_compatible.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fix spurious lint when using pin_subpackage or pin_compatible with a build string


### PR DESCRIPTION
in #1624, `pin[-1]` was incorrect if build pattern is specified, picking up the build string instead of the package name. The message has the right index, but the test didn't match what the message was claiming. Fixing the test to match the message allows lint to pass.

Incorrect lint example: https://github.com/conda-forge/petsc-feedstock/pull/146#issuecomment-1169836525

Checklist

* [x] Added a ``news`` entry
