### PR TITLE
Fix Azure urls in details

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -132,7 +132,7 @@ Current build status
               <td>{{ variant.strip('_') }}</td>
               <td>
                 <a href="{{ azure_url }}">
-                  <img src="{{ azure_image_url }}&jobName={{ variant_os }}&configuration={{ variant }}" alt="variant">
+                  <img src="{{ azure_image_url }}&jobName={{ variant_os }}&configuration={{ variant_os }}%20{{ variant }}" alt="variant">
                 </a>
               </td>
             </tr>


### PR DESCRIPTION
This updates the badge URLs in the README template for Azure when there are OS specific variants to display the proper badge per job. Currently, they say _"unknown"_ for each specific job. I tested this on my local machine using [`pandas-feedstock`](https://github.com/conda-forge/pandas-feedstock).
