### PR TITLE
CircleCI support aarch64 native runners

### DIFF
--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 
@@ -22,12 +22,12 @@ jobs:
 {%- if data.platform.startswith('linux') %}
     machine:
       - image: ubuntu-2004:current
-{- if data.platform == 'linux-aarch64' %}
-    resource_class: arm.large
-{%- endif %}
 {%- else %}
     macos:
       xcode: "13.0.0"
+{%- endif %}
+{- if data.platform == 'linux-aarch64' %}
+    resource_class: arm.large
 {%- endif %}
     environment:
       - CONFIG: "{{ data.config_name }}"

--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -26,7 +26,7 @@ jobs:
     macos:
       xcode: "13.0.0"
 {%- endif %}
-{- if data.platform == 'linux-aarch64' %}
+{%- if data.platform == 'linux-aarch64' %}
     resource_class: arm.large
 {%- endif %}
     environment:

--- a/conda_smithy/templates/circle.yml.tmpl
+++ b/conda_smithy/templates/circle.yml.tmpl
@@ -22,6 +22,9 @@ jobs:
 {%- if data.platform.startswith('linux') %}
     machine:
       - image: ubuntu-2004:current
+{- if data.platform == 'linux-aarch64' %}
+    resource_class: arm.large
+{%- endif %}
 {%- else %}
     macos:
       xcode: "13.0.0"

--- a/news/circle-native-aarch64.rst
+++ b/news/circle-native-aarch64.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added support for aarch64 native runners on circle CI
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
This allows for using CircleCI for some problem case builds that struggle on travisCI and under emulation.

Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
