### PR TITLE
Add py-lief<0.12 to remote_ci_setup for now

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1774,7 +1774,9 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         # Specific channel for package can be given with
         #     ${url or channel_alias}::package_name
         # defaults to conda-forge channel_alias
-        "remote_ci_setup": ["conda-forge-ci-setup=3"],
+        # Added py-lief constraint due to current osx-* segfault issues, ref:
+        #     https://github.com/conda-forge/conda-forge.github.io/issues/1823
+        "remote_ci_setup": ["conda-forge-ci-setup=3", "py-lief<0.12"],
     }
 
     if forge_yml is None:

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -40,7 +40,7 @@ jobs:
 
     - script: |
         call activate base
-        mamba.exe install 'python=3.9' conda-build conda pip {{ BOA }}'{{ " ".join(remote_ci_setup) }}' -c conda-forge --strict-channel-priority --yes
+        mamba.exe install "python=3.9" conda-build conda pip {{ BOA }}{{ " ".join(remote_ci_setup) }} -c conda-forge --strict-channel-priority --yes
       displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -31,7 +31,6 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
-echo -e "\n\nInstalling {{ remote_ci_setup }} and conda-build."
 {{ CONDA_INSTALL_CMD }} install --update-specs --quiet --yes --channel conda-forge \
     conda-build pip {{ BOA }}{{ " ".join(remote_ci_setup) }}
 {%- if build_with_mambabuild %}

--- a/news/gh-1684-Add-py-lief-0.12-to-remote_ci_setup-for-now.rst
+++ b/news/gh-1684-Add-py-lief-0.12-to-remote_ci_setup-for-now.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Add ``py-lief<0.12`` to ``remote_ci_setup`` for now
+  due to current ``osx-*`` segfault issues, ref:
+  https://github.com/conda-forge/conda-forge.github.io/issues/1823
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Add `py-lief<0.12` to `remote_ci_setup` for now
due to current ` osx-*` segfault issues, ref:
https://github.com/conda-forge/conda-forge.github.io/issues/1823

Feedstocks which require LIEF 12+ can add
```yaml
remote_ci_setup:
  - conda-forge-ci-setup=3
  - py-lief>=12
```
to their `conda-forge.yml`