### PR TITLE
Use a custom %TEMP% directory to avoid upload permission errors on Windows.

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1686,7 +1686,12 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
                     "vmImage": "windows-2019",
                 },
                 "timeoutInMinutes": 360,
-                "variables": {"CONDA_BLD_PATH": r"D:\\bld\\"},
+                "variables": {
+                    "CONDA_BLD_PATH": r"D:\\bld\\",
+                    # Custom %TEMP% for upload to avoid permission errors.
+                    # See https://github.com/conda-forge/kubo-feedstock/issues/5#issuecomment-1335504503
+                    "UPLOAD_TEMP": r"D:\\tmp",
+                },
             },
             # Force building all supported providers.
             "force": False,

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -120,6 +120,9 @@ jobs:
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        set "TEMP=$(UPLOAD_TEMP)"
+        if not exist "%TEMP%\" md "%TEMP%"
+        set "TMP=%TEMP%"
 {%- if upload_on_branch %}
         set "UPLOAD_ON_BRANCH={{ upload_on_branch }}"
 {%- endif %}

--- a/news/anaconda_upload_temp.rst
+++ b/news/anaconda_upload_temp.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Use a custom %TEMP% directory to avoid upload permission errors on Windows.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
<!--
Please add any other relevant info below:
-->
See https://github.com/conda-forge/kubo-feedstock/issues/5#issuecomment-1335504503 :
> I didn't figure out the root cause regarding the temp file access/`anaconda upload` problems on Windows.
> Meaning, I still don't know what causes access right changes to the temp folder during `conda-build` runs.
> But at least I now know why we see the upload problems lately:
> For the `.conda` rollout we updated to `anaconda-client>=1.11` since it handles `.conda`.
> The previously used `anaconda-client=1.8` didn't use a temp folder, hence we didn't have the issue then.
> Now, `binstar_client.inspect_package.conda.inspect_conda_package` extracts the package's `info` component to a temporary directory.
> Since something during our build changes permissions in `%TEMP%`, uploading `.conda.` fails on Windows.
