### PR TITLE
Replace ::set-output with redirect to $GITHUB_OUTPUT on GitHub Actions

### DIFF
--- a/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
@@ -54,8 +54,8 @@ if defined BLD_ARTIFACT_PREFIX (
         echo ##vso[task.setVariable variable=BLD_ARTIFACT_PATH]!BLD_ARTIFACT_PATH!
     )
     if "%CI%" == "github_actions" (
-        echo ::set-output name=BLD_ARTIFACT_NAME::!BLD_ARTIFACT_NAME!
-        echo ::set-output name=BLD_ARTIFACT_PATH::!BLD_ARTIFACT_PATH!
+        echo BLD_ARTIFACT_NAME=!BLD_ARTIFACT_NAME! >> %GITHUB_OUTPUT%
+        echo BLD_ARTIFACT_PATH=!BLD_ARTIFACT_PATH! >> %GITHUB_OUTPUT%
     )
 )
 
@@ -74,7 +74,7 @@ if defined ENV_ARTIFACT_PREFIX (
         echo ##vso[task.setVariable variable=ENV_ARTIFACT_PATH]!ENV_ARTIFACT_PATH!
     )
     if "%CI%" == "github_actions" (
-        echo ::set-output name=ENV_ARTIFACT_NAME::!ENV_ARTIFACT_NAME!
-        echo ::set-output name=ENV_ARTIFACT_PATH::!ENV_ARTIFACT_PATH!
+        echo ENV_ARTIFACT_NAME=!ENV_ARTIFACT_NAME! >> %GITHUB_OUTPUT%
+        echo ENV_ARTIFACT_PATH=!ENV_ARTIFACT_PATH! >> %GITHUB_OUTPUT%
     )
 )

--- a/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
@@ -54,8 +54,8 @@ if defined BLD_ARTIFACT_PREFIX (
         echo ##vso[task.setVariable variable=BLD_ARTIFACT_PATH]!BLD_ARTIFACT_PATH!
     )
     if "%CI%" == "github_actions" (
-        echo BLD_ARTIFACT_NAME=!BLD_ARTIFACT_NAME! >> %GITHUB_OUTPUT%
-        echo BLD_ARTIFACT_PATH=!BLD_ARTIFACT_PATH! >> %GITHUB_OUTPUT%
+        echo BLD_ARTIFACT_NAME=!BLD_ARTIFACT_NAME!>> %GITHUB_OUTPUT%
+        echo BLD_ARTIFACT_PATH=!BLD_ARTIFACT_PATH!>> %GITHUB_OUTPUT%
     )
 )
 
@@ -74,7 +74,7 @@ if defined ENV_ARTIFACT_PREFIX (
         echo ##vso[task.setVariable variable=ENV_ARTIFACT_PATH]!ENV_ARTIFACT_PATH!
     )
     if "%CI%" == "github_actions" (
-        echo ENV_ARTIFACT_NAME=!ENV_ARTIFACT_NAME! >> %GITHUB_OUTPUT%
-        echo ENV_ARTIFACT_PATH=!ENV_ARTIFACT_PATH! >> %GITHUB_OUTPUT%
+        echo ENV_ARTIFACT_NAME=!ENV_ARTIFACT_NAME!>> %GITHUB_OUTPUT%
+        echo ENV_ARTIFACT_PATH=!ENV_ARTIFACT_PATH!>> %GITHUB_OUTPUT%
     )
 )

--- a/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
@@ -79,8 +79,8 @@ if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
         echo "##vso[task.setVariable variable=BLD_ARTIFACT_NAME]$BLD_ARTIFACT_NAME"
         echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_PATH"
     elif [[ "$CI" == "github_actions" ]]; then
-        echo "::set-output name=BLD_ARTIFACT_NAME::$BLD_ARTIFACT_NAME"
-        echo "::set-output name=BLD_ARTIFACT_PATH::$BLD_ARTIFACT_PATH"
+        echo "BLD_ARTIFACT_NAME=$BLD_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+        echo "BLD_ARTIFACT_PATH=$BLD_ARTIFACT_PATH" >> $GITHUB_OUTPUT
     fi
 fi
 
@@ -107,7 +107,7 @@ if [[ ! -z "$ENV_ARTIFACT_PREFIX" ]]; then
         echo "##vso[task.setVariable variable=ENV_ARTIFACT_NAME]$ENV_ARTIFACT_NAME"
         echo "##vso[task.setVariable variable=ENV_ARTIFACT_PATH]$ENV_ARTIFACT_PATH"
     elif [[ "$CI" == "github_actions" ]]; then
-        echo "::set-output name=ENV_ARTIFACT_NAME::$ENV_ARTIFACT_NAME"
-        echo "::set-output name=ENV_ARTIFACT_PATH::$ENV_ARTIFACT_PATH"
+        echo "ENV_ARTIFACT_NAME=$ENV_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+        echo "ENV_ARTIFACT_PATH=$ENV_ARTIFACT_PATH" >> $GITHUB_OUTPUT
     fi
 fi

--- a/news/gha-set-output.rst
+++ b/news/gha-set-output.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Replaced deprecated use of ::set-output during conda artifact storage on GitHub Actions with the recommended redirect to $GITHUB_OUTPUT. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I noticed some warnings due to [a change in how variables are set for subsequent steps with GitHub Actions](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). This follows the recommendation given at that link to switch to the new behavior and prevent eventual job failures after May 31, 2023.

Tested by re-rendering locally with this change and confirming that the artifacts are saved on GitHub Actions:
https://github.com/ryanvolz/gr-fosphor/actions/runs/3633811395