### PR TITLE
`{{ blas_impl}}` in requirements.host lints cleanly.

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -475,6 +475,8 @@ def lintify(meta, recipe_dir=None, conda_forge=False):
     # 22: Single space in pinned requirements
     for section, requirements in requirements_section.items():
         for requirement in requirements or []:
+            # rather than adding to utils.render_meta_yaml() we could
+            # handle requirement is None by ignoring it
             req, _, _ = requirement.partition("#")
             if "{{" in req:
                 continue

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -82,6 +82,7 @@ def render_meta_yaml(text):
             time=time,
             target_platform="linux-64",
             mpi="mpi",
+            blas_impl="openblas",
         )
     )
     mockos = MockOS()

--- a/news/blas_impl_linting.rst
+++ b/news/blas_impl_linting.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* ``{{ blas_impl }}`` use in requirements.host now lints cleanly as `described in conda-forge maintainer knowledge base <https://conda-forge.org/docs/maintainer/knowledge_base.html#blas:~:text=If%20a%20package%20needs%20a%20specific%20implementation%E2%80%99s%20internal%20API%20for%20more%20control%20you%20can%20have>`
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

In conda-forge/dakota-feedstock#31, when building `dakota` using the netlib reference BLAS packages and then testing with openblas, we get a segfault as detailed at https://github.com/conda-forge/dakota-feedstock/pull/31#issuecomment-1335803404.
If we specifically depend on `{{ blas_impl }}` [as described in the conda-forge mantainer knowledge base](https://conda-forge.org/docs/maintainer/knowledge_base.html#blas:~:text=If%20a%20package%20needs%20a%20specific%20implementation%E2%80%99s%20internal%20API%20for%20more%20control%20you%20can%20have) `dakota` builds and tests cleanly.  However, `conda smithy recipe-lint` doesn't handle `{{ blas_impl }}` in `requirements.host`.  The current code hits an `AttributeError` at https://github.com/conda-forge/conda-smithy/blob/2bd12c86814b358ab548a3b6581212d4a0fd2832/conda_smithy/lint_recipe.py#L478 because `blas_impl` is not defined in the `jinja2.Environment` used by `conda_smithy.utils.render_meta_yaml`.

This PR defines `blas_impl` so that it will lint.

