### PR TITLE
Rework error catching on Windows (WIP)

### DIFF
--- a/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
@@ -46,7 +46,7 @@ if defined BLD_ARTIFACT_PREFIX (
 
     set "BLD_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%BLD_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.zip"
     7z a "!BLD_ARTIFACT_PATH!" "%CONDA_BLD_DIR%" -xr^^!.git/ -xr^^!_*_env*/ -xr^^!*_cache/ -bb
-    if errorlevel 1 exit 1
+    if %errorlevel% NEQ 0 exit %errorlevel%
     echo BLD_ARTIFACT_PATH: !BLD_ARTIFACT_PATH!
 
     if "%CI%" == "azure" (
@@ -66,7 +66,7 @@ if defined ENV_ARTIFACT_PREFIX (
 
     set "ENV_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%ENV_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.zip"
     7z a "!ENV_ARTIFACT_PATH!" -r "%CONDA_BLD_DIR%"/_*_env*/ -bb
-    if errorlevel 1 exit 1
+    if %errorlevel% NEQ 0 exit %errorlevel%
     echo ENV_ARTIFACT_PATH: !ENV_ARTIFACT_PATH!
 
     if "%CI%" == "azure" (

--- a/conda_smithy/templates/github-actions.tmpl
+++ b/conda_smithy/templates/github-actions.tmpl
@@ -152,15 +152,15 @@ jobs:
       run: |
         call activate base
         mamba.exe install -c conda-forge 'python=3.9' conda-build conda pip {{ BOA }}{{ " ".join(remote_ci_setup) }}
-        if errorlevel 1 exit 1
+        if %errorlevel% NEQ 0 exit %errorlevel%
         {%- if local_ci_setup %}
         conda.exe uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}"
-        if errorlevel 1 exit 1
+        if %errorlevel% NEQ 0 exit %errorlevel%
         pip install --no-deps ".\{{ recipe_dir }}\."
-        if errorlevel 1 exit 1
+        if %errorlevel% NEQ 0 exit %errorlevel%
         {%- endif %}
         setup_conda_rc .\ ".\{{ recipe_dir }}" .\.ci_support\%CONFIG%.yaml
-        if errorlevel 1 exit 1
+        if %errorlevel% NEQ 0 exit %errorlevel%
         {% if build_setup -%}
         {{ build_setup.replace("\n", "\n        ").rstrip() }}
         {%- endif %}
@@ -173,7 +173,7 @@ jobs:
         {%- else %}
         conda.exe build "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml
         {%- endif %}
-        if errorlevel 1 exit 1
+        if %errorlevel% NEQ 0 exit %errorlevel%
         set "FEEDSTOCK_NAME=%GITHUB_REPOSITORY:*/=%"
         set "GIT_BRANCH=%GITHUB_REF:refs/heads/=%"
         if /i "%GITHUB_EVENT_NAME%" == "pull_request" (
@@ -183,7 +183,7 @@ jobs:
         )
         {%- if conda_forge_output_validation %}
         validate_recipe_outputs "%FEEDSTOCK_NAME%"
-        if errorlevel 1 exit 1
+        if %errorlevel% NEQ 0 exit %errorlevel%
         {%- endif %}
         if /i "%UPLOAD_PACKAGES%" == "true" (
           if /i "%IS_PR_BUILD%" == "false" (


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I found a case where [conda-build crashes with error level -1](https://github.com/napari/packaging/issues/50#issuecomment-1362008150), which the current constructs were not catching (only >=1). I found more info in this [SO answer](https://stackoverflow.com/questions/34936240/batch-goto-loses-errorlevel/34937706#34937706) and this might worth a more thorough audit of `conda-build-setup-ci` and its usage (e.g. using `CALL`).

Leaving this here while I evaluate other error catching options on Windows (like using `||`).