### PR TITLE
BUG always check team membership even when making the team

### DIFF
--- a/conda_smithy/github.py
+++ b/conda_smithy/github.py
@@ -232,10 +232,10 @@ def configure_github_team(meta, gh_repo, org, feedstock_name, remove=True):
             "The {} {} contributors!".format(choice(superlative), team_name),
         )
         fs_team.add_to_repos(gh_repo)
-    else:
-        current_maintainers = set(
-            [e.login.lower() for e in fs_team.get_members()]
-        )
+
+    current_maintainers = set(
+        [e.login.lower() for e in fs_team.get_members()]
+    )
 
     # Get the all-members team
     description = "All of the awesome {} contributors!".format(org.login)

--- a/conda_smithy/github.py
+++ b/conda_smithy/github.py
@@ -233,9 +233,7 @@ def configure_github_team(meta, gh_repo, org, feedstock_name, remove=True):
         )
         fs_team.add_to_repos(gh_repo)
 
-    current_maintainers = set(
-        [e.login.lower() for e in fs_team.get_members()]
-    )
+    current_maintainers = set([e.login.lower() for e in fs_team.get_members()])
 
     # Get the all-members team
     description = "All of the awesome {} contributors!".format(org.login)

--- a/news/teams.rst
+++ b/news/teams.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Always check team membership even when making teams.


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
The person on the token used to make the team gets added by default. This means our bots appear as team members. This PR fixes that so that the bots are not on the teams. This is a potential security risk since it escalates permissions. 

Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
