### PR TITLE
switch default image on windows to windows-2022

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1726,7 +1726,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
             },
             "settings_win": {
                 "pool": {
-                    "vmImage": "windows-2019",
+                    "vmImage": "windows-2022",
                 },
                 "timeoutInMinutes": 360,
                 "variables": {

--- a/news/vs2022.rst
+++ b/news/vs2022.rst
@@ -1,0 +1,3 @@
+**Changed:**
+
+* Changed default image for windows to `windows-2022`.


### PR DESCRIPTION
Came up during review of https://github.com/conda-forge/conda-forge.github.io/pull/1878

CC @wolfv @isuruf 