### PR TITLE
Fixed bug in codepath to allow debugging of cross compiled OSX config…

### DIFF
--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -67,11 +67,6 @@ echo -e "\n\nRunning the build setup script."
 
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./{{ recipe_dir }} ./.ci_support/${CONFIG}.yaml
-{% if test in ["native", "native_and_emulated"] %}
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
-fi
-{% endif %}
 
 if [[ -f LICENSE.txt ]]; then
   cp LICENSE.txt "{{ recipe_dir }}/recipe-scripts-license.txt"
@@ -88,6 +83,11 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
+{% if test in ["native", "native_and_emulated"] %}
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+{% endif %}
     conda {{ BUILD_CMD }} ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml

--- a/news/fix_bug_preventing_osx_debuging_using_build_locally.rst
+++ b/news/fix_bug_preventing_osx_debuging_using_build_locally.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed bug in codepath to allow debugging of cross compiled OSX configuratons using ``build-locally.py``.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
…uratons using ``build-locally.py``.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
