### PR TITLE
Correct escaping of \r in the Travis CI logging utilities

### DIFF
--- a/conda_smithy/feedstock_content/.scripts/logging_utils.sh
+++ b/conda_smithy/feedstock_content/.scripts/logging_utils.sh
@@ -12,7 +12,7 @@ function startgroup {
             echo "##[group]$1";;
         travis )
             echo "$1"
-            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:start:'"${1// /}"'\r';;
         github_actions )
             echo "::group::$1";;
         * )
@@ -28,7 +28,7 @@ function endgroup {
         azure )
             echo "##[endgroup]";;
         travis )
-            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:end:'"${1// /}"'\r';;
         github_actions )
             echo "::endgroup::";;
     esac

--- a/news/fix_travis_ci_fold_quoting.rst
+++ b/news/fix_travis_ci_fold_quoting.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed bug in the display of grouping commands in the Travis CI logging utilities.
+
+**Security:**
+
+* <news item>

--- a/news/fix_travis_ci_fold_quoting.rst
+++ b/news/fix_travis_ci_fold_quoting.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Fixed bug in the display of grouping commands in the Travis CI logging utilities.
+* Fixed bug in the display of grouping commands in the Travis CI logging utilities. (#1730)
 
 **Security:**
 


### PR DESCRIPTION
It should be `"\\r"` or `'\r'`, but not `'\\r'`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
