### PR TITLE
add linter-rule for now-obsolete ouput names (e.g. after renaming)

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -931,6 +931,11 @@ def run_conda_forge_specific(meta, recipe_dir, lints, hints):
             "`matplotlib` so that runtime environments do not require large "
             "packages like `qt`."
         ),
+        "jpeg": (
+            "Recipes should usually depend on `libjpeg-turbo` as opposed to "
+            "`jpeg` for improved performance. For more information please see"
+            "https://github.com/conda-forge/conda-forge.github.io/issues/673"
+        ),
         "pytorch-cpu": (
             "Please depend on `pytorch` directly, in order to avoid forcing "
             "CUDA users to downgrade to the CPU version for no reason."

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -931,6 +931,14 @@ def run_conda_forge_specific(meta, recipe_dir, lints, hints):
             "`matplotlib` so that runtime environments do not require large "
             "packages like `qt`."
         ),
+        "pytorch-cpu": (
+            "Please depend on `pytorch` directly, in order to avoid forcing "
+            "CUDA users to downgrade to the CPU version for no reason."
+        ),
+        "pytorch-gpu": (
+            "Please depend on `pytorch` directly. If your package definitely "
+            "requires the CUDA version, please depend on `pytorch =*=cuda*`."
+        ),
         "abseil-cpp": "The `abseil-cpp` output has been superseded by `libabseil`",
         "grpc-cpp": "The `grpc-cpp` output has been superseded by `libgrpc`",
     }

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -947,6 +947,7 @@ def run_conda_forge_specific(meta, recipe_dir, lints, hints):
         ),
         "abseil-cpp": "The `abseil-cpp` output has been superseded by `libabseil`",
         "grpc-cpp": "The `grpc-cpp` output has been superseded by `libgrpc`",
+        "build": "The pypa `build` package has been renamed to `python-build`",
     }
 
     for rq in build_reqs + host_reqs + run_reqs:

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -914,16 +914,17 @@ def run_conda_forge_specific(meta, recipe_dir, lints, hints):
 
     # 5: Package-specific hints
     # (e.g. do not depend on matplotlib, only matplotlib-base)
-    run_reqs = requirements_section.get("run") or []
+    build_reqs = requirements_section.get("build") or []
     host_reqs = requirements_section.get("host") or []
+    run_reqs = requirements_section.get("run") or []
     for out in outputs_section:
         _req = out.get("requirements") or {}
         if isinstance(_req, Mapping):
-            run_reqs += _req.get("run") or []
+            build_reqs += _req.get("build") or []
             host_reqs += _req.get("host") or []
+            run_reqs += _req.get("run") or []
         else:
             run_reqs += _req
-            host_reqs += _req
 
     specific_hints = {
         "matplotlib": (
@@ -948,7 +949,7 @@ def run_conda_forge_specific(meta, recipe_dir, lints, hints):
         "grpc-cpp": "The `grpc-cpp` output has been superseded by `libgrpc`",
     }
 
-    for rq in run_reqs + host_reqs:
+    for rq in build_reqs + host_reqs + run_reqs:
         dep = rq.split(" ")[0].strip()
         if dep in specific_hints and specific_hints[dep] not in hints:
             hints.append(specific_hints[dep])

--- a/news/add_linting_for_obsoleted_outputs.rst
+++ b/news/add_linting_for_obsoleted_outputs.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added linting for obsoleted outputs, e.g. those who have been renamed conda-forge-wide.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
In the context of https://github.com/conda-forge/conda-forge.github.io/issues/1894 & https://github.com/conda-forge/conda-forge.github.io/issues/1073, I think it would be good to enforce (or at least nudge) that obsolete outputs aren't actually used anymore in the wild.

We already completed `abseil-cpp` -> `libabseil` & `grpc-cpp` -> `libgrpc`, while `arrow-cpp` -> `libarrow` is in flight (due to supporting 4 versions in conda-forge, it needs more time), and `boost-cpp` -> `libboost` is being planned.

But aside from larger libs, maintainers might individually obsolete output names on their feedstocks, with no real mechanism to enforce it. For example, it would be good to get rid of `pytorch-cpu` & `pytorch-gpu`, that exist solely for compatibility with packages that were published by the pytorch channel long ago.

Closes #1719