### PR TITLE
Fix README headers for recipes with multiple outputs

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -10,7 +10,7 @@ Feedstock license: [BSD-3-Clause](https://github.com/{{ github.user_or_org }}/{{
 
 {% for output_name, about in package_about -%}
 {%- set license_url = about.license_url -%}
-{%- if package_about|length > 1 -%}
+{%- if package_about|length > 1 %}
 About {{ output_name }}
 ------{{ '-' * output_name|length }}
 

--- a/news/readme_headers_multiple_outputs.rst
+++ b/news/readme_headers_multiple_outputs.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed README headers for recipes with multiple outputs
+
+**Security:**
+
+* <news item>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -186,16 +186,16 @@ def test_render_readme_with_multiple_outputs(testing_workdir, dirname):
         # case 2: implicit subpackage, has individual subpackage about
         assert "About test_multiple_outputs2" in readme
         assert "BSD" in readme
-        assert "About test_output_1" in readme
+        assert "\n\nAbout test_output_1" in readme
         assert "Apache" in readme
-        assert "About test_output_2" not in readme
+        assert "\n\nAbout test_output_2" not in readme
     elif dirname == "multiple_outputs3":
         # case 3: explicit subpackage, has individual subpackage about
         assert "About test_multiple_outputs3" in readme
         assert "BSD" in readme
-        assert "About test_output_1" in readme
+        assert "\n\nAbout test_output_1" in readme
         assert "Apache" in readme
-        assert "About test_output_2" not in readme
+        assert "\n\nAbout test_output_2" not in readme
     else:
         assert False
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

For recipes with multiple outputs, the feedstock README headers aren't formatted correctly because of a missing empty line. Thus the previous line is formatted as a header. As an example, see the [arrow-cpp-feedstock README](https://github.com/conda-forge/arrow-cpp-feedstock#readme), where the summary is incorporated into the header:

![image](https://github.com/conda-forge/conda-smithy/assets/1608317/692792ce-f675-457b-8aaf-4a3a7f15cfa7)

With this PR, a blank line is included before the header of each output. It has no effect on recipes with a single output.


