### PR TITLE
Provide GHA option to set maximum parallel jobs

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1806,6 +1806,8 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         },
         "github_actions": {
             "self_hosted": False,
+            # Set maximum parallel jobs
+            "max_parallel": None,
             # Toggle creating artifacts for conda build_artifacts dir
             "store_build_artifacts": False,
             "artifact_retention_days": 14,

--- a/conda_smithy/templates/github-actions.tmpl
+++ b/conda_smithy/templates/github-actions.tmpl
@@ -27,6 +27,9 @@ jobs:
     {%- endif %}
     strategy:
       fail-fast: false
+      {%- if github_actions.max_parallel %}
+      max-parallel: {{ github_actions.max_parallel }}
+      {%- endif %}
       matrix:
         include:
         {%- for data in configs %}

--- a/news/gha_max_par_opt.rst
+++ b/news/gha_max_par_opt.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add GHA option to limit number of parallel jobs - #1744
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Provide a `conda-forge.yml` option to configure the number of GHA jobs that can be used in parallel. Default is to leave this unspecified. When set to a non-zero value, this is added to the appropriate field in the GHA workflow YAML.

<hr>

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
