### PR TITLE
Change aptitude to apt-get

### DIFF
--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -18,9 +18,8 @@ jobs:
                   /opt/hostedtoolcache \
                   /usr/lib/jvm \
                   /usr/local/.ghcup \
-                  /usr/local/android \
                   /usr/local/lib/android \
-                  /usr/local/powershell \
+                  /usr/local/share/powershell \
                   /usr/share/dotnet \
                   /usr/share/swift \
                   ; do

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -25,9 +25,9 @@ jobs:
                   ; do
            sudo rsync --stats -a --delete /opt/empty_dir/ $d || true
          done
-         sudo aptitude purge -y -f firefox \
-                                   google-chrome-stable \
-                                   microsoft-edge-stable
+         sudo apt-get purge -y -f firefox \
+                                  google-chrome-stable \
+                                  microsoft-edge-stable
          sudo apt-get autoremove -y >& /dev/null
          sudo apt-get autoclean -y >& /dev/null
          sudo docker image prune --all --force

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -33,6 +33,7 @@ jobs:
          sudo docker image prune --all --force
          df -h
     displayName: Manage disk space
+    continueOnError: true
 {%- endif %}
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -19,6 +19,7 @@ jobs:
                   /usr/lib/jvm \
                   /usr/local/.ghcup \
                   /usr/local/android \
+                  /usr/local/lib/android \
                   /usr/local/powershell \
                   /usr/share/dotnet \
                   /usr/share/swift \

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -33,7 +33,6 @@ jobs:
          sudo docker image prune --all --force
          df -h
     displayName: Manage disk space
-    continueOnError: true
 {%- endif %}
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This changes #1747 so that `apt-get` is used instead of `aptitude`. `aptitude` is not in the default image.