### PR TITLE
reinstate basic cleanup if `azure.free_disk_space` is False

### DIFF
--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -10,8 +10,8 @@ jobs:
   - checkout: self
     fetchDepth: {{ clone_depth }}
 {%- endif %}
-{%- if azure.free_disk_space %}
   - script: |
+{%- if azure.free_disk_space %}
          sudo mkdir -p /opt/empty_dir || true
          for d in \
                   /opt/ghc \
@@ -31,9 +31,12 @@ jobs:
          sudo apt-get autoremove -y >& /dev/null
          sudo apt-get autoclean -y >& /dev/null
          sudo docker image prune --all --force
+{%- else %}
+         rm -rf /opt/ghc
+{%- endif %}
          df -h
     displayName: Manage disk space
-{%- endif %}
+
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/news/reinstate_basic_disc_cleanup.rst
+++ b/news/reinstate_basic_disc_cleanup.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Ensure that even without `azure.free_disk_space`, basic clean up still happens
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
I noticed in a feedstock I just rerendered with conda-smithy 3.24.1 that it does:
```diff
diff --git a/.azure-pipelines/azure-pipelines-linux.yml b/.azure-pipelines/azure-pipelines-linux.yml
index e85c38f..6190e29 100755
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -23,11 +23,6 @@ jobs:
   timeoutInMinutes: 360

   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |
```

I cannot read @beckermr's mind about his intention in #1747; it's possible to argue that we can avoid the deletion of `/opt/ghc` - however fast - for all feedstocks that don't need it, but the deletion of the more basic disk space handling could also have been an unintentional side-effect of introducing the `azure.free_disk_space` option.

CC @beckermr @bkpoon @isuruf @jakirkham 