### PR TITLE
added --rm flag to docker run

### DIFF
--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -78,6 +78,7 @@ export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 export IS_PR_BUILD="${IS_PR_BUILD:-False}"
 {{ docker.executable }} pull "${DOCKER_IMAGE}"
 {{ docker.executable }} run ${DOCKER_RUN_ARGS} \
+           --rm \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \

--- a/news/make_docker_rm_default.rst
+++ b/news/make_docker_rm_default.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Now --rm is added to docker run by default in run_docker_build.sh
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Resolves #909
<!--
Please add any other relevant info below:
-->

I spent an evening do a lot of `python build-locally.py` and blew through ~1.5TB of disk space. I am not sure if there are any downsides to passing in `--rm` by default. When making this PR I noticed that I could set `CONDA_FORGE_DOCKER_RUN_ARGS` https://github.com/conda-forge/conda-smithy/blob/main/conda_smithy/templates/run_docker_build.sh.tmpl#L67-L68 which is nice but I think that is something easy to forget.