### PR TITLE
Add option to cleanup GHA images

### DIFF
--- a/conda_smithy/templates/github-actions.tmpl
+++ b/conda_smithy/templates/github-actions.tmpl
@@ -71,6 +71,33 @@ jobs:
         {%- endif %}
         {%- endfor %}
     steps:
+{%- if github_actions.free_disk_space %}
+
+    - name: Manage disk space
+      if: matrix.os == 'ubuntu'
+      run: |
+        sudo mkdir -p /opt/empty_dir || true
+        for d in \
+                 /opt/ghc \
+                 /opt/hostedtoolcache \
+                 /usr/lib/jvm \
+                 /usr/local/.ghcup \
+                 /usr/local/lib/android \
+                 /usr/local/share/powershell \
+                 /usr/share/dotnet \
+                 /usr/share/swift \
+                 ; do
+          sudo rsync --stats -a --delete /opt/empty_dir/ $d || true
+        done
+        sudo apt-get purge -y -f firefox \
+                                 google-chrome-stable \
+                                 microsoft-edge-stable
+        sudo apt-get autoremove -y >& /dev/null
+        sudo apt-get autoclean -y >& /dev/null
+        sudo docker image prune --all --force
+        df -h
+{%- endif %}
+
     - name: Checkout code
       uses: actions/checkout@v3
 {%- if clone_depth is not none %}

--- a/conda_smithy/templates/github-actions.tmpl
+++ b/conda_smithy/templates/github-actions.tmpl
@@ -191,7 +191,7 @@ jobs:
         {%- endif %}
         setup_conda_rc .\ ".\{{ recipe_dir }}" .\.ci_support\%CONFIG%.yaml
         if errorlevel 1 exit 1
-        {% if build_setup -%}
+        {%- if build_setup %}
         {{ build_setup.replace("\n", "\n        ").rstrip() }}
         {%- endif %}
 

--- a/news/gha_free_disk_space.rst
+++ b/news/gha_free_disk_space.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Add option to cleanup GHA images - #1754
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Provide a similar option for GHA to cleanup images before builds as was done on Azure. As the same image is used in both cases, the same approach works in both cases.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
