### PR TITLE
Implement `conda_install_tool` to let users choose `{conda,mamba} install`

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1843,6 +1843,8 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         "secrets": [],
         "conda_build_tool": "mambabuild",
         "conda_build_tool_deps": "boa",
+        "conda_install_tool": "mamba",
+        "conda_install_tool_deps": "mamba",
         # feedstock checkout git clone depth, None means keep default, 0 means no limit
         "clone_depth": None,
         # Specific channel for package can be given with
@@ -1960,6 +1962,18 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         config["conda_build_tool_deps"] = "conda-build conda-libmamba-solver"
     else:
         config["conda_build_tool_deps"] = "conda-build"
+
+    valid_install_tools = ("conda", "mamba")
+    assert config["conda_install_tool"] in valid_install_tools, (
+        f"Invalid conda_install_tool: {config['conda_install_tool']}. "
+        f"Valid values are: {valid_install_tools}."
+    )
+    if config["conda_install_tool"] == "mamba":
+        config["conda_install_tool_deps"] = "mamba"
+    elif config["conda_install_tool"] in "conda":
+        config["conda_install_tool_deps"] = "conda"
+        if config.get("conda_solver", "libmamba"):
+            config["conda_install_tool_deps"] += " conda-libmamba-solver"
 
     config["secrets"] = sorted(set(config["secrets"] + ["BINSTAR_TOKEN"]))
 

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1957,7 +1957,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         f"Valid values are: {valid_build_tools}."
     )
     if config["conda_build_tool"] == "mambabuild":
-        config["conda_build_tool_deps"] = "boa"
+        config["conda_build_tool_deps"] = "conda-build boa"
     elif config["conda_build_tool"] == "conda-build+conda-libmamba-solver":
         config["conda_build_tool_deps"] = "conda-build conda-libmamba-solver"
     else:

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -30,7 +30,6 @@ pkgs_dirs:
   - /opt/conda/pkgs
 
 CONDARC
-{%- set CONDA_INSTALL_CMD="mamba" %}
 {%- if conda_build_tool == "mambabuild" %}
 {%- set BUILD_CMD="conda mambabuild" %}
 {%- elif conda_build_tool == "conda-build+conda-libmamba-solver" %}
@@ -41,14 +40,14 @@ CONDARC
 {%- set BUILD_CMD="conda build" %}
 {%- endif %}
 
-{{ CONDA_INSTALL_CMD }} install --update-specs --yes --quiet --channel conda-forge \
-    pip {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}
-{%- if conda_build_tool_deps != "" %}
-{{ CONDA_INSTALL_CMD }} update --update-specs --yes --quiet --channel conda-forge \
-    pip {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}
+{{ conda_install_tool }} install --update-specs --yes --quiet --channel conda-forge \
+    pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}
+{%- if conda_build_tool_deps != "" or conda_install_tool_deps != "" %}
+{{ conda_install_tool }} update --update-specs --yes --quiet --channel conda-forge \
+    pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}
 {%- endif %}
 {% if local_ci_setup %}
-conda uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}
+{{ conda_install_tool }} uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}
 pip install --no-deps ${RECIPE_ROOT}/.
 {%- endif %}
 # set up the condarc

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -19,7 +19,6 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 ( endgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
 ( startgroup "Configuring conda" ) 2> /dev/null
-{%- set CONDA_INSTALL_CMD="mamba" %}
 {%- if conda_build_tool == "mambabuild" %}
 {%- set BUILD_CMD="conda mambabuild" %}
 {%- elif conda_build_tool == "conda-build+conda-libmamba-solver" %}
@@ -33,15 +32,15 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
-{{ CONDA_INSTALL_CMD }} install --update-specs --quiet --yes --channel conda-forge \
-    pip {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}
-{%- if conda_build_tool_deps != "" %}
-{{ CONDA_INSTALL_CMD }} update --update-specs --yes --quiet --channel conda-forge \
-    pip {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}
+{{ conda_install_tool }} install --update-specs --quiet --yes --channel conda-forge \
+    pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}
+{%- if conda_build_tool_deps != "" or conda_install_tool_deps != "" %}
+{{ conda_install_tool }} update --update-specs --yes --quiet --channel conda-forge \
+    pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}
 {%- endif %}
 
 {% if local_ci_setup %}
-conda uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}
+{{ conda_install_tool }} uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}
 pip install --no-deps {{ recipe_dir }}/.
 {%- endif %}
 

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -20,12 +20,12 @@ call activate base
 
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
-mamba.exe install "python=3.10" conda pip {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }} -c conda-forge --strict-channel-priority --yes
+{{ conda_install_tool }}.exe install "python=3.10" pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }} -c conda-forge --strict-channel-priority --yes
 if errorlevel 1 exit 1
 
 {%- if local_ci_setup %}
 echo Overriding conda-forge-ci-setup with local version
-conda.exe uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}"
+{{ conda_install_tool }}.exe uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}"
 if errorlevel 1 exit 1
 pip install --no-deps ".\{{ recipe_dir }}\."
 if errorlevel 1 exit 1

--- a/news/1762-conda-install-tool
+++ b/news/1762-conda-install-tool
@@ -1,0 +1,24 @@
+**Added:**
+
+* Add ``conda_install_tool`` configuration option to allow choosing between
+  ``conda`` and ``mamba`` as the dependency handling tool. (#1762)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Part of the conda-libmamba-solver deployment in https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/275. Documented at https://github.com/conda-forge/conda-forge.github.io/pull/2003.