### PR TITLE
Windows: Catch all non-zero exit codes (negative values too)

### DIFF
--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -20,7 +20,7 @@ call activate base
 
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
-{{ conda_install_tool }}.exe install "python=3.10" pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }} -c conda-forge --strict-channel-priority --yes || exit 1
+{{ conda_install_tool }}.exe install "python=3.10" pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }} -c conda-forge --strict-channel-priority --yes
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 {%- if local_ci_setup %}

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -20,26 +20,26 @@ call activate base
 
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
-{{ conda_install_tool }}.exe install "python=3.10" pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }} -c conda-forge --strict-channel-priority --yes
-if errorlevel 1 exit 1
+{{ conda_install_tool }}.exe install "python=3.10" pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }} -c conda-forge --strict-channel-priority --yes || exit 1
+if !errorlevel! neq 0 exit /b !errorlevel!
 
 {%- if local_ci_setup %}
 echo Overriding conda-forge-ci-setup with local version
 {{ conda_install_tool }}.exe uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}"
-if errorlevel 1 exit 1
+if !errorlevel! neq 0 exit /b !errorlevel!
 pip install --no-deps ".\{{ recipe_dir }}\."
-if errorlevel 1 exit 1
+if !errorlevel! neq 0 exit /b !errorlevel!
 {%- endif %}
 
 :: Set basic configuration
 echo Setting up configuration
 setup_conda_rc .\ ".\{{ recipe_dir }}" .\.ci_support\%CONFIG%.yaml
-if errorlevel 1 exit 1
+if !errorlevel! neq 0 exit /b !errorlevel!
 
 {%- if build_setup %}
 echo Running build setup
 {{ build_setup }}
-if errorlevel 1 exit 1
+if !errorlevel! neq 0 exit /b !errorlevel!
 {%- endif %}
 
 if EXIST LICENSE.txt (
@@ -68,7 +68,7 @@ conda.exe build "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-varia
 {%- elif conda_build_tool == "conda-build" %}
 conda.exe build "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 {%- endif %}
-if errorlevel 1 exit 1
+if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Prepare some environment variables for the upload step
 if /i "%CI%" == "github_actions" (
@@ -100,7 +100,7 @@ set "UPLOAD_ON_BRANCH={{ upload_on_branch }}"
 {%- if conda_forge_output_validation %}
 call :start_group "Validating outputs"
 validate_recipe_outputs "%FEEDSTOCK_NAME%"
-if errorlevel 1 exit 1
+if !errorlevel! neq 0 exit /b !errorlevel!
 call :end_group
 {%- endif %}
 
@@ -110,7 +110,7 @@ if /i "%UPLOAD_PACKAGES%" == "true" (
         if not exist "%TEMP%\" md "%TEMP%"
         set "TMP=%TEMP%"
         upload_package {% if conda_forge_output_validation %}--validate --feedstock-name="%FEEDSTOCK_NAME%"{% endif %}{% if private_upload %} --private{% endif %} .\ ".\{{ recipe_dir }}" .ci_support\%CONFIG%.yaml
-        if errorlevel 1 exit 1
+        if !errorlevel! neq 0 exit /b !errorlevel!
         call :end_group
     )
 )

--- a/news/1763-catch-negative-exit-code
+++ b/news/1763-catch-negative-exit-code
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Catch negative exit codes on Windows. (#1763)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Supersedes #1704. The formula `if errorlevel 1` actually means "if the exit code is >=1", so it doesn't catch `-1` and other negative exit codes. This can happen in conda-build when it segfaults during the linkage analysis steps, for example.

Exit codes in CMD are tricky and there are many gotchas. Since we can afford to enable delayed expansion, this is relatively robust. See [this SO answer](https://stackoverflow.com/questions/34936240/batch-goto-loses-errorlevel/34937706#34937706) for (way ) more info if you are curious.