### PR TITLE
Create CODEOWNERS with @conda-forge/core

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @conda-forge/core


### PR DESCRIPTION
This repository is maintained by @conda-forge/core and thus I would like to also list them automatically as a reviewer.