### PR TITLE
Follow up for `conda_install_tool` and `conda_solver` settings

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -29,6 +29,7 @@ import conda_build.utils
 import conda_build.variants
 import conda_build.conda_interface
 import conda_build.render
+from conda.models.match_spec import MatchSpec
 
 from copy import deepcopy
 
@@ -1956,6 +1957,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         f"Invalid conda_build_tool: {config['conda_build_tool']}. "
         f"Valid values are: {valid_build_tools}."
     )
+    # NOTE: Currently assuming these dependencies are name-only (no version constraints)
     if config["conda_build_tool"] == "mambabuild":
         config["conda_build_tool_deps"] = "conda-build boa"
     elif config["conda_build_tool"] == "conda-build+conda-libmamba-solver":
@@ -1968,6 +1970,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         f"Invalid conda_install_tool: {config['conda_install_tool']}. "
         f"Valid values are: {valid_install_tools}."
     )
+    # NOTE: Currently assuming these dependencies are name-only (no version constraints)
     if config["conda_install_tool"] == "mamba":
         config["conda_install_tool_deps"] = "mamba"
     elif config["conda_install_tool"] in "conda":
@@ -2029,9 +2032,8 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
     if config["provider"]["linux_s390x"] in {"default", "native"}:
         config["provider"]["linux_s390x"] = ["travis"]
 
-    config["remote_ci_setup"] = _santize_remote_ci_setup(
-        config["remote_ci_setup"]
-    )
+    config["remote_ci_setup"] = _santize_remote_ci_setup(config["remote_ci_setup"])
+    config["remote_ci_setup_names"] = [MatchSpec(pkg).name for pkg in config["remote_ci_setup"]]
 
     # Older conda-smithy versions supported this with only one
     # entry. To avoid breakage, we are converting single elements

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1846,6 +1846,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         "conda_build_tool_deps": "boa",
         "conda_install_tool": "mamba",
         "conda_install_tool_deps": "mamba",
+        # Default value matches logic in conda-forge-ci-setup
         "conda_solver": "libmamba",
         # feedstock checkout git clone depth, None means keep default, 0 means no limit
         "clone_depth": None,

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2033,8 +2033,12 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
     if config["provider"]["linux_s390x"] in {"default", "native"}:
         config["provider"]["linux_s390x"] = ["travis"]
 
-    config["remote_ci_setup"] = _santize_remote_ci_setup(config["remote_ci_setup"])
-    config["remote_ci_setup_names"] = [MatchSpec(pkg).name for pkg in config["remote_ci_setup"]]
+    config["remote_ci_setup"] = _santize_remote_ci_setup(
+        config["remote_ci_setup"]
+    )
+    config["remote_ci_setup_names"] = [
+        MatchSpec(pkg).name for pkg in config["remote_ci_setup"]
+    ]
 
     # Older conda-smithy versions supported this with only one
     # entry. To avoid breakage, we are converting single elements

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1846,6 +1846,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         "conda_build_tool_deps": "boa",
         "conda_install_tool": "mamba",
         "conda_install_tool_deps": "mamba",
+        "conda_solver": "libmamba",
         # feedstock checkout git clone depth, None means keep default, 0 means no limit
         "clone_depth": None,
         # Specific channel for package can be given with
@@ -1975,7 +1976,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         config["conda_install_tool_deps"] = "mamba"
     elif config["conda_install_tool"] in "conda":
         config["conda_install_tool_deps"] = "conda"
-        if config.get("conda_solver", "libmamba"):
+        if config.get("conda_solver") == "libmamba":
             config["conda_install_tool_deps"] += " conda-libmamba-solver"
 
     config["secrets"] = sorted(set(config["secrets"] + ["BINSTAR_TOKEN"]))

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1846,8 +1846,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         "conda_build_tool_deps": "boa",
         "conda_install_tool": "mamba",
         "conda_install_tool_deps": "mamba",
-        # Default value matches logic in conda-forge-ci-setup
-        "conda_solver": "libmamba",
+        "conda_solver": None,
         # feedstock checkout git clone depth, None means keep default, 0 means no limit
         "clone_depth": None,
         # Specific channel for package can be given with

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -28,6 +28,9 @@ conda-build:
 pkgs_dirs:
   - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
   - /opt/conda/pkgs
+{%- if conda_solver %}
+solver: {{ conda_solver }}
+{%- endif %}
 
 CONDARC
 {%- if conda_build_tool == "mambabuild" %}

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -46,10 +46,10 @@ CONDARC
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 {%- endif %}
 
-{{ conda_install_tool }} install --update-specs --yes --quiet --channel conda-forge \
+{{ conda_install_tool }} install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
     pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}
 {%- if conda_build_tool_deps != "" or conda_install_tool_deps != "" %}
-{{ conda_install_tool }} update --update-specs --yes --quiet --channel conda-forge \
+{{ conda_install_tool }} update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
     pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup_names) }}
 {%- endif %}
 {% if local_ci_setup %}

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -44,10 +44,10 @@ CONDARC
     pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}
 {%- if conda_build_tool_deps != "" or conda_install_tool_deps != "" %}
 {{ conda_install_tool }} update --update-specs --yes --quiet --channel conda-forge \
-    pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}
+    pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup_names) }}
 {%- endif %}
 {% if local_ci_setup %}
-{{ conda_install_tool }} uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}
+{{ conda_install_tool }} uninstall --quiet --yes --force {{ " ".join(remote_ci_setup_names)}}
 pip install --no-deps ${RECIPE_ROOT}/.
 {%- endif %}
 # set up the condarc

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -42,6 +42,9 @@ CONDARC
 {%- else %}
 {%- set BUILD_CMD="conda build" %}
 {%- endif %}
+{%- if conda_solver == "libmamba" %}
+export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
+{%- endif %}
 
 {{ conda_install_tool }} install --update-specs --yes --quiet --channel conda-forge \
     pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -36,11 +36,11 @@ conda activate base
     pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}
 {%- if conda_build_tool_deps != "" or conda_install_tool_deps != "" %}
 {{ conda_install_tool }} update --update-specs --yes --quiet --channel conda-forge \
-    pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}
+    pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup_names) }}
 {%- endif %}
 
 {% if local_ci_setup %}
-{{ conda_install_tool }} uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}
+{{ conda_install_tool }} uninstall --quiet --yes --force {{ " ".join(remote_ci_setup_names) }}
 pip install --no-deps {{ recipe_dir }}/.
 {%- endif %}
 

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -34,6 +34,9 @@ conda activate base
 {%- if conda_solver %}
 export CONDA_SOLVER="{{ conda_solver }}"
 {%- endif %}
+{%- if conda_solver == "libmamba" %}
+export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
+{%- endif %}
 
 {{ conda_install_tool }} install --update-specs --quiet --yes --channel conda-forge \
     pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -38,10 +38,10 @@ export CONDA_SOLVER="{{ conda_solver }}"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 {%- endif %}
 
-{{ conda_install_tool }} install --update-specs --quiet --yes --channel conda-forge \
+{{ conda_install_tool }} install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
     pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}
 {%- if conda_build_tool_deps != "" or conda_install_tool_deps != "" %}
-{{ conda_install_tool }} update --update-specs --yes --quiet --channel conda-forge \
+{{ conda_install_tool }} update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
     pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup_names) }}
 {%- endif %}
 

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -31,6 +31,9 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
+{%- if conda_solver %}
+export CONDA_SOLVER="{{ conda_solver }}"
+{%- endif %}
 
 {{ conda_install_tool }} install --update-specs --quiet --yes --channel conda-forge \
     pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -18,6 +18,12 @@ call :start_group "Configuring conda"
 :: Activate the base conda environment
 call activate base
 
+{%- if conda_solver %}
+:: Configure the solver
+set "CONDA_SOLVER={{ conda_solver }}"
+if !errorlevel! neq 0 exit /b !errorlevel!
+{%- endif %}
+
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
 {{ conda_install_tool }}.exe install "python=3.10" pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }} -c conda-forge --strict-channel-priority --yes

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -23,6 +23,9 @@ call activate base
 set "CONDA_SOLVER={{ conda_solver }}"
 if !errorlevel! neq 0 exit /b !errorlevel!
 {%- endif %}
+{%- if conda_solver == "libmamba" %}
+set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"
+{%- endif %}
 
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -25,7 +25,7 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 
 {%- if local_ci_setup %}
 echo Overriding conda-forge-ci-setup with local version
-{{ conda_install_tool }}.exe uninstall --quiet --yes --force {{ " ".join(remote_ci_setup) }}"
+{{ conda_install_tool }}.exe uninstall --quiet --yes --force {{ " ".join(remote_ci_setup_names) }}
 if !errorlevel! neq 0 exit /b !errorlevel!
 pip install --no-deps ".\{{ recipe_dir }}\."
 if !errorlevel! neq 0 exit /b !errorlevel!

--- a/news/1762-conda-install-tool
+++ b/news/1762-conda-install-tool
@@ -1,7 +1,8 @@
 **Added:**
 
-* Add ``conda_install_tool`` configuration option to allow choosing between
-  ``conda`` and ``mamba`` as the dependency handling tool. (#1762, #1768)
+* Add ``conda_install_tool`` and ``conda_solver`` configuration options to allow choosing between
+  ``mamba`` and ``conda`` (with ``classic`` or ``libmamba`` solvers) as the dependency 
+  handling tools. (#1762, #1768)
 
 **Changed:**
 
@@ -17,7 +18,7 @@
 
 **Fixed:**
 
-* <news item>
+* Use name-only specs in ``conda update`` and ``conda uninstall`` subcommands. (#1768)
 
 **Security:**
 

--- a/news/1762-conda-install-tool
+++ b/news/1762-conda-install-tool
@@ -1,7 +1,7 @@
 **Added:**
 
 * Add ``conda_install_tool`` configuration option to allow choosing between
-  ``conda`` and ``mamba`` as the dependency handling tool. (#1762)
+  ``conda`` and ``mamba`` as the dependency handling tool. (#1762, #1768)
 
 **Changed:**
 

--- a/news/1762-conda-install-tool
+++ b/news/1762-conda-install-tool
@@ -1,7 +1,7 @@
 **Added:**
 
 * Add ``conda_install_tool`` and ``conda_solver`` configuration options to allow choosing between
-  ``mamba`` and ``conda`` (with ``classic`` or ``libmamba`` solvers) as the dependency 
+  ``mamba`` and ``conda`` (with ``classic`` or ``libmamba`` solvers) as the dependency
   handling tools. (#1762, #1768)
 
 **Changed:**

--- a/news/1762-conda-install-tool
+++ b/news/1762-conda-install-tool
@@ -6,7 +6,7 @@
 
 **Changed:**
 
-* <news item>
+* Use strict channel priority on Linux and macOS. (#1768)
 
 **Deprecated:**
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Round of fixes found while tesrting for: #1767

- `conda update` is receiving specs with version constraints (`conda update conda-forge-ci-setup=3` fails). `update` and `uninstall` expect name only specs.
- Checks for `conda_solver` didn't check for value, only presence
- Configure `solver` here instead of `conda-forge-ci-setup` so the first `conda` calls respect the configured value (conda-forge-ci-setup arrives "too late" for those initial calls). In Docker we use `conda config ...` because it's a Docker instance and it's disposable. In macOS and Windows we set an env var so the changes are only visible to that script and do not leak into local configurations when run outside CI.
- Ensure strict channel priority on Linux and macOS to prevent packages from `defaults` leaking in the CI.