### PR TITLE
fix how `FEEDSTOCK_NAME` is set on Windows

### DIFF
--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -91,7 +91,7 @@ if /i "%CI%" == "github_actions" (
     set "TEMP=%RUNNER_TEMP%"
 )
 if /i "%CI%" == "azure" (
-    set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME%"
+    set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
     set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
     if /i "%BUILD_REASON%" == "PullRequest" (
         set "IS_PR_BUILD=True"

--- a/news/1770-feedstock-name
+++ b/news/1770-feedstock-name
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Set ``FEEDSTOCK_NAME`` correctly on Windows in Azure Pipelines. (#1770)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

A bug introduced in #1761, where `FEEDSTOCK_NAME` on Azure was being set to the whole thing (e.g. `conda-forge/package-feedstock`) instead of just `package-feedstock).

This is causing failing uploads on Windows.
