### PR TITLE
always use `conda` for uninstalls

### DIFF
--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -53,7 +53,7 @@ export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
     pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup_names) }}
 {%- endif %}
 {% if local_ci_setup %}
-{{ conda_install_tool }} uninstall --quiet --yes --force {{ " ".join(remote_ci_setup_names)}}
+conda uninstall --quiet --yes --force {{ " ".join(remote_ci_setup_names)}}
 pip install --no-deps ${RECIPE_ROOT}/.
 {%- endif %}
 # set up the condarc

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -46,7 +46,7 @@ export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 {%- endif %}
 
 {% if local_ci_setup %}
-{{ conda_install_tool }} uninstall --quiet --yes --force {{ " ".join(remote_ci_setup_names) }}
+conda uninstall --quiet --yes --force {{ " ".join(remote_ci_setup_names) }}
 pip install --no-deps {{ recipe_dir }}/.
 {%- endif %}
 

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -34,7 +34,7 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 
 {%- if local_ci_setup %}
 echo Overriding conda-forge-ci-setup with local version
-{{ conda_install_tool }}.exe uninstall --quiet --yes --force {{ " ".join(remote_ci_setup_names) }}
+conda.exe uninstall --quiet --yes --force {{ " ".join(remote_ci_setup_names) }}
 if !errorlevel! neq 0 exit /b !errorlevel!
 pip install --no-deps ".\{{ recipe_dir }}\."
 if !errorlevel! neq 0 exit /b !errorlevel!

--- a/news/1771-conda-uninstall
+++ b/news/1771-conda-uninstall
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Always use ``conda`` to ``uninstall --force``. (#1771)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Seen in https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/276. `mamba uninstall --force` ignores `--force` and removes more packages than intended.

xref https://github.com/mamba-org/mamba/issues/1523