### PR TITLE
Fix `MatchSpec` parsing when `remote_ci_setup` specs are quoted

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2037,7 +2037,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         config["remote_ci_setup"]
     )
     config["remote_ci_setup_names"] = [
-        MatchSpec(pkg).name for pkg in config["remote_ci_setup"]
+        MatchSpec(pkg.strip('"').strip("'")).name for pkg in config["remote_ci_setup"]
     ]
 
     # Older conda-smithy versions supported this with only one

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2037,7 +2037,8 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         config["remote_ci_setup"]
     )
     config["remote_ci_setup_names"] = [
-        MatchSpec(pkg.strip('"').strip("'")).name for pkg in config["remote_ci_setup"]
+        MatchSpec(pkg.strip('"').strip("'")).name
+        for pkg in config["remote_ci_setup"]
     ]
 
     # Older conda-smithy versions supported this with only one

--- a/news/1775-quotes
+++ b/news/1775-quotes
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Fix ``MatchSpec`` parsing when ``remote_ci_setup`` specs are quoted. (#1773 via #1775)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -907,3 +907,19 @@ def test_conda_build_tools(config_yaml):
 
     with pytest.raises(AssertionError):
         assert load_forge_config()
+
+
+def test_remote_ci_setup(config_yaml):
+    load_forge_config = lambda: cnfgr_fdstk._load_forge_config(  # noqa
+        config_yaml,
+        exclusive_config_file=os.path.join(
+            config_yaml, "recipe", "default_config.yaml"
+        ),
+    )
+    cfg = load_forge_config()
+    with open(os.path.join(config_yaml, "conda-forge.yml"), "a+") as fp:
+        fp.write("remote_ci_setup: ['remote-ci-setup=3', 'pylief<0.12']")
+    cfg = load_forge_config()
+    # pylief was quoted due to <
+    assert cfg["remote_ci_setup"] == ["remote-ci-setup=3", '"pylief<0.12"']
+    assert cfg["remote_ci_setup_names"] == ["remote-ci-setup", "pylief"]

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -921,5 +921,8 @@ def test_remote_ci_setup(config_yaml):
         fp.write("remote_ci_setup: ['conda-forge-ci-setup=3', 'py-lief<0.12']")
     cfg = load_forge_config()
     # pylief was quoted due to <
-    assert cfg["remote_ci_setup"] == ["conda-forge-ci-setup=3", '"pylief<0.12"']
+    assert cfg["remote_ci_setup"] == [
+        "conda-forge-ci-setup=3",
+        '"py-lief<0.12"',
+    ]
     assert cfg["remote_ci_setup_names"] == ["conda-forge-ci-setup", "py-lief"]

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -918,8 +918,8 @@ def test_remote_ci_setup(config_yaml):
     )
     cfg = load_forge_config()
     with open(os.path.join(config_yaml, "conda-forge.yml"), "a+") as fp:
-        fp.write("remote_ci_setup: ['remote-ci-setup=3', 'pylief<0.12']")
+        fp.write("remote_ci_setup: ['conda-forge-ci-setup=3', 'py-lief<0.12']")
     cfg = load_forge_config()
     # pylief was quoted due to <
-    assert cfg["remote_ci_setup"] == ["remote-ci-setup=3", '"pylief<0.12"']
-    assert cfg["remote_ci_setup_names"] == ["remote-ci-setup", "pylief"]
+    assert cfg["remote_ci_setup"] == ["conda-forge-ci-setup=3", '"pylief<0.12"']
+    assert cfg["remote_ci_setup_names"] == ["conda-forge-ci-setup", "py-lief"]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

Closes #1773

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
