### PR TITLE
ensure cache_dir is a Path when XDG_CACHE_HOME is set

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2195,7 +2195,7 @@ def get_cache_dir():
     if sys.platform.startswith("win"):
         return Path(os.environ.get("TEMP"))
     else:
-        return os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")
+        return Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
 
 
 def get_cached_cfp_file_path(temporary_directory):

--- a/news/xdg-cache-dir.rst
+++ b/news/xdg-cache-dir.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Crash when XDG_CACHE_DIR is defined


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

When XDG_CACHE_HOME was set, a string was returned, but consumers of get_cache_dir assume it returns a Path object.