### PR TITLE
Fix name of anaconda.org in README template.

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -272,7 +272,7 @@ available continuous integration services. Thanks to the awesome service provide
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
 [Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
 it is possible to build and upload installable packages to the
-[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+[conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance

--- a/news/fix-name.rst
+++ b/news/fix-name.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix name of anaconda.org in README template, to prevent confusion with anaconda.cloud (#1798). 
+
+**Security:**
+
+* <news item>

--- a/news/fix-name.rst
+++ b/news/fix-name.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Fix name of anaconda.org in README template, to prevent confusion with anaconda.cloud (#1798). 
+* Fix name of anaconda.org in README template, to prevent confusion with anaconda.cloud (#1798).
 
 **Security:**
 


### PR DESCRIPTION
This should prevent confusion compared to https://anaconda.cloud

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
