### PR TITLE
Set conda_build_tool: mambabuild as default again

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1936,7 +1936,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         "conda_forge_output_validation": False,
         "private_upload": False,
         "secrets": [],
-        "conda_build_tool": "conda-build",
+        "conda_build_tool": "mambabuild",
         "conda_install_tool": "mamba",
         "conda_solver": "libmamba",
         # feedstock checkout git clone depth, None means keep default, 0 means no limit

--- a/news/conda_build_tool-mambabuild.rst
+++ b/news/conda_build_tool-mambabuild.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Set ``conda_build_tool: mambabuild`` as default again until
+  https://github.com/conda/conda-libmamba-solver/issues/393 is fixed (#1807).
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -878,7 +878,7 @@ def test_conda_build_tools(config_yaml):
     assert (
         "build_with_mambabuild" not in cfg
     )  # superseded by conda_build_tool=mambabuild
-    assert cfg["conda_build_tool"] == "conda-build"  # current default
+    assert cfg["conda_build_tool"] == "mambabuild"  # current default
 
     # legacy compatibility config
     with open(os.path.join(config_yaml, "conda-forge.yml")) as fp:


### PR DESCRIPTION
until https://github.com/conda/conda-libmamba-solver/issues/393 is fixed

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
closes gh-1805
<!--
Please add any other relevant info below:
-->
