### PR TITLE
Add Mambaforge and macos SDK files to feedstock gitignore file

### DIFF
--- a/conda_smithy/feedstock_content/.gitignore
+++ b/conda_smithy/feedstock_content/.gitignore
@@ -1,3 +1,6 @@
 *.pyc
 
 build_artifacts
+
+Mambaforge-MacOSX-*.sh
+MacOSX*.sdk.tar.xz


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I found those two files to be annoying when debugging a feedstock locally on macOS.
