### PR TITLE
Fix squished zip key ordering

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -391,6 +391,16 @@ def _collapse_subpackage_variants(
 
     for k, v in squished_used_variants.items():
         if k in all_used_vars:
+            input_variant = squished_input_variants.get(k)
+            if input_variant and isinstance(input_variant, (tuple, list)):
+                # Ensure we retain the input order to avoid mismatched entries
+                # with the preserve_top_level_loops overrides below.
+                # NOTE: "pin_run_as_build" (dict of dict) order is not handled.
+                # "tuple" below only used for uniform list/tuple/str comparison.
+                v_set = set(map(tuple, v))
+                v = type(input_variant)(
+                    v_i for v_i in input_variant if tuple(v_i) in v_set
+                )
             used_key_values[k] = v
 
     for k in preserve_top_level_loops:

--- a/news/fix-squished-zip_key-ordering.rst
+++ b/news/fix-squished-zip_key-ordering.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix randomly mismatched zipped variant keys. (#1459 and #1782 via #1815)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes gh-1459
Fixes the `conda-smithy` part affecting gh-1782 (that issue needs further adjustments to the recipe and/or `conda-build`).

<!--
Please add any other relevant info below:
-->
gh-1459 is an old issue such that the initial discussion refers to old code.
A recent analysis regarding current code is at https://github.com/conda-forge/conda-smithy/issues/1459#issuecomment-1858846653 .
This PR adds the suggested change from https://github.com/conda-forge/conda-smithy/issues/1459#issuecomment-1858848004 .

With that change the issue from https://github.com/conda-forge/python-feedstock/pull/656#discussion_r1428500644 has not been reproducible for me (for a selection of `PYTHONHASHSEED` values).
Similarly the issue from https://github.com/conda-forge/pytensor-suite-feedstock/issues/54 reported here at gh-1782 does not reproduce for me (when fixing top-level `py` selector without `{{ python }}` usage in that recipe).