### PR TITLE
Revert "Update `.gitignore` to exclude everything except `recipe/` and `conda-forge.yml`"

### DIFF
--- a/conda_smithy/ci_skeleton.py
+++ b/conda_smithy/ci_skeleton.py
@@ -26,11 +26,6 @@ def _render_template(template_file, env, forge_dir, config):
         fh.write(new_file_contents)
 
 
-GITIGNORE_ADDITIONAL = """*.pyc
-build_artifacts
-"""
-
-
 def _insert_into_gitignore(
     feedstock_directory=".",
     prefix="# conda smithy ci-skeleton start\n",
@@ -50,7 +45,11 @@ def _insert_into_gitignore(
         dname = os.path.dirname(fname)
         if dname:
             os.makedirs(dname, exist_ok=True)
-    new = prefix + GITIGNORE_ADDITIONAL + suffix
+    # get new values
+    gi = os.path.join(conda_forge_content, "feedstock_content", ".gitignore")
+    with open(gi, "r") as f:
+        s = f.read()
+    new = prefix + s + suffix
     # write out the file
     with open(fname, "w") as f:
         f.write(before + new + after)

--- a/conda_smithy/feedstock_content/.gitignore
+++ b/conda_smithy/feedstock_content/.gitignore
@@ -1,13 +1,3 @@
-# User content belongs under recipe/.
-# Feedstock configuration goes in `conda-forge.yml`
-# Everything else is managed by the conda-smithy rerender process.
-# Please do not modify
-
-*
-!/conda-forge.yml
-
-!/*/
-!/recipe/**
-!/.ci_support/**
-
 *.pyc
+
+build_artifacts

--- a/news/revert-gitignore
+++ b/news/revert-gitignore
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Reverted changes to gitignore that excluded all contents from recipe

--- a/tests/test_ci_skeleton.py
+++ b/tests/test_ci_skeleton.py
@@ -90,6 +90,7 @@ test:
 
 GITIGNORE = """# conda smithy ci-skeleton start
 *.pyc
+
 build_artifacts
 # conda smithy ci-skeleton end
 """


### PR DESCRIPTION
Currently, all builds using `maturin` are broken due to this change. As there seems to be no easy workaround, I would rather revert this and have a more in-depth discussion to avoid the issues stemming from it (e.g. we could also adapt our folder placements in the linux containers).

For more context see https://github.com/conda-forge/pydantic-core-feedstock/pull/82

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

cc @hmaarrfk 