### PR TITLE
Track feedstock changes in `.github`

### DIFF
--- a/conda_smithy/feedstock_content/.gitignore
+++ b/conda_smithy/feedstock_content/.gitignore
@@ -12,6 +12,7 @@
 # Don't ignore any files/folders recursively in the following folders
 !/recipe/**
 !/.ci_support/**
+!/.github/**
 
 # Since we ignore files/folders recursively, any folders inside
 # build_artifacts gets ignored which trips some build systems.

--- a/news/track_feedstock_github_dir.rst
+++ b/news/track_feedstock_github_dir.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Track changes in feedstock's ``.github`` directory ( #1821 )
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Feedstocks can customize the content of `.github`. However if `git` ignores these changes, it could result in these files being dropped. So exclude them from `.gitignore` to ensure `git` still tracks them