### PR TITLE
Fix local builds of feedstock submodules

### DIFF
--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -83,12 +83,6 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
   cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
 fi
 
-if [[ "${sha:-}" == "" ]]; then
-  pushd ${FEEDSTOCK_ROOT}
-  sha=$(git rev-parse HEAD)
-  popd
-fi
-
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"

--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -21,6 +21,12 @@ if [ -z ${FEEDSTOCK_NAME} ]; then
     export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd "${FEEDSTOCK_ROOT}"
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted

--- a/news/fix_local_submodule_builds.rst
+++ b/news/fix_local_submodule_builds.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix local builds of feedstocks submodules ( #1826 ).
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-smithy/issues/1825

In `conda-smithy` version `3.28.0` logic was added to store metadata about CI ( https://github.com/conda-forge/conda-smithy/pull/1577 ) like the `sha` of the feedstock that was used to build. As the `sha` variable may not be set when running locally, logic was added with the container to determine this by running `git rev-parse` to fill in this value

https://github.com/conda-forge/conda-smithy/blob/00fcb77e51b8d69d8acfbeaca2da5b02a8b0a34e/conda_smithy/templates/build_steps.sh.tmpl#L86-L90

While this works in the simple case of cloning a feedstock directly, it does not work in the case of building a feedstock from a submodule as is the case with [the `feedstocks` repo]( https://github.com/conda-forge/feedstocks ). This is due to the fact that the `.git` repo information is not full available within the Docker container as it does not exist in the feedstock that is mounted (and is not otherwise provided for).

However this information is available before spinning up the Docker container. So this PR moves the logic to fill in `sha` to precede spinning up the Docker container. This is equivalent to the behavior already present in the local macOS builds, which don't use containers

https://github.com/conda-forge/conda-smithy/blob/00fcb77e51b8d69d8acfbeaca2da5b02a8b0a34e/conda_smithy/templates/run_osx_build.sh.tmpl#L68-L70

Closes https://github.com/conda-forge/ca-certificates-feedstock/pull/64 (used for testing these changes)

<hr>

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
