### PR TITLE
Update GHA workflow to checkout@v4

### DIFF
--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -84,7 +84,7 @@ jobs:
 {%- endif %}
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 {%- if clone_depth is not none %}
       with:
         fetch-depth: {{ clone_depth }}

--- a/news/1839-gha-checkout.rst
+++ b/news/1839-gha-checkout.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Resolve warnings in Github Actions workflows by updating to ``actions/checkout@v4``. (#1839)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Resolves [deprecation warnings in GHA workflows like this one](https://github.com/conda-forge/pytorch-cpu-feedstock/actions/runs/7727743331) (node 16 no longer supported).