### PR TITLE
Change default build tool to conda-build again

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1946,7 +1946,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         "conda_forge_output_validation": False,
         "private_upload": False,
         "secrets": [],
-        "conda_build_tool": "mambabuild",
+        "conda_build_tool": "conda-build",
         "conda_install_tool": "mamba",
         "conda_solver": "libmamba",
         # feedstock checkout git clone depth, None means keep default, 0 means no limit

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1954,7 +1954,7 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
         # Specific channel for package can be given with
         #     ${url or channel_alias}::package_name
         # defaults to conda-forge channel_alias
-        "remote_ci_setup": ["conda-forge-ci-setup=4"],
+        "remote_ci_setup": ["conda-forge-ci-setup=4", "conda-build>=24.1"],
     }
 
     if forge_yml is None:

--- a/news/1844-conda_build_tool-conda-build
+++ b/news/1844-conda_build_tool-conda-build
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Default build tool changed from conda-mambabuild to conda-build again. (#1844)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -878,7 +878,7 @@ def test_conda_build_tools(config_yaml):
     assert (
         "build_with_mambabuild" not in cfg
     )  # superseded by conda_build_tool=mambabuild
-    assert cfg["conda_build_tool"] == "mambabuild"  # current default
+    assert cfg["conda_build_tool"] == "conda-build"  # current default
 
     # legacy compatibility config
     with open(os.path.join(config_yaml, "conda-forge.yml")) as fp:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
I'd like us to get the [fixes from `conda-build=24.1.2` in which also affect `conda-build=3.28.4`](https://github.com/conda/conda-build/blob/24.1.2/CHANGELOG.md#2412-2024-02-15) which we are currently limited to due to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/657 / https://github.com/mamba-org/boa/issues/392 .
If we change to `conda-build` by default, we can avoid the constraint needed for `boa=0.16.0`.
(We should also put out a `boa=0.16.1` for feedstocks that have `conda-mambabuild` set explicitly, of course.)