### PR TITLE
ENH: add handling for stdlib-jinja function

### DIFF
--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -93,6 +93,7 @@ def render_meta_yaml(text):
     env.globals.update(
         dict(
             compiler=lambda x: x + "_compiler_stub",
+            stdlib=lambda x: x + "_stdlib_stub",
             pin_subpackage=stub_subpackage_pin,
             pin_compatible=stub_compatible_pin,
             cdt=lambda *args, **kwargs: "cdt_stub",

--- a/news/1840-stdlib-jinja.rst
+++ b/news/1840-stdlib-jinja.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Smithy now understand the new stdlib jinja function.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
This is an absolutely minimal PR towards #1840 (smithy will fail to parse a recipe containing `{{ stdlib("c") }}` otherwise). Explicit testing will follow once we get support in conda-build fixed up.