### PR TITLE
Use Azure owner in URL for missing token error message

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -381,7 +381,7 @@ class RegisterCI(Subcommand):
             if azure_ci_utils.default_config.token is None:
                 print(
                     "No azure token. Create a token at https://dev.azure.com/"
-                    "conda-forge/_usersSettings/tokens and\n"
+                    f"{owner}/_usersSettings/tokens and\n"
                     "put it in ~/.conda-smithy/azure.token"
                 )
             ci_register.add_project_to_azure(owner, repo)

--- a/news/1854-use-azure-owner-in-url-for-missing-token-error-message.rst
+++ b/news/1854-use-azure-owner-in-url-for-missing-token-error-message.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Use Azure owner in URL for missing token error message. (#1854)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Checklist
* [x] Added a ``news`` entry

Today I ran `conda smithy register-ci` on a new computer which didn't yet have `~/.conda-smithy/azure.token`. It sent me to the URL https://dev.azure.com/conda-forge/_usersSettings/tokens, which I don't have access to. I need to use my Azure account name, ie https://dev.azure.com/jdblischak/_usersSettings/tokens

```sh
export AZURE_ORG_OR_USER="jdblischak"
conda smithy register-ci --user "jdblischak" --feedstock_directory . --without-all --with-azure
## No azure token. Create a token at https://dev.azure.com/conda-forge/_usersSettings/tokens and
## put it in ~/.conda-smithy/azure.token
```

The `owner` is defined earlier in `cli.py`, so I inserted it into the error message

https://github.com/conda-forge/conda-smithy/blob/e296d0d3079f4fdc9be5d5d84f8816f94a55ff78/conda_smithy/cli.py#L317

Then I confirmed it works as expected

```sh
mamba env create --file environment.yml
conda activate conda-smithy
which conda-smithy
python -m pip install -v --no-build-isolation -e .
which conda-smithy
## /home/wsl/mambaforge/envs/conda-smithy/bin/conda-smithy

conda-smithy register-ci --user "custom" --feedstock_directory . --without-all --with-azure
## No azure token. Create a token and
## put it in ~/.conda-smithy/azure.token
## No azure token. Create a token at https://dev.azure.com/custom/_usersSettings/tokens and
## put it in ~/.conda-smithy/azure.token

conda-smithy register-ci --organization "custom" --feedstock_directory . --without-all --with-azure
## No azure token. Create a token and
## put it in ~/.conda-smithy/azure.token
## No azure token. Create a token at https://dev.azure.com/custom/_usersSettings/tokens and
## put it in ~/.conda-smithy/azure.token
```

There is an earlier error message without the helpful URL in `azure_ci_utils.py`

https://github.com/conda-forge/conda-smithy/blob/e296d0d3079f4fdc9be5d5d84f8816f94a55ff78/conda_smithy/azure_ci_utils.py#L50-L53

I was going to update that error message to also include the URL, but then I saw that the URL was purposefully omitted in the original commit (1f6dabef49c48e8f628bef3b7bcf18078b468206) that added both of these error messages, so I left it alone

Also I confirmed that `AZURE_ORG_OR_USER` has no effect on this error message. It only determines whether or not it can successfully query Azure Devops

Also I looked at the other URLs to create tokens for the other CI services, but none of them include the user/org