### PR TITLE
Invoke conda-{build,mambabuild} directly, not as conda subcommand

### DIFF
--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -34,13 +34,13 @@ solver: {{ conda_solver }}
 
 CONDARC
 {%- if conda_build_tool == "mambabuild" %}
-{%- set BUILD_CMD="conda mambabuild" %}
+{%- set BUILD_CMD="conda-mambabuild" %}
 {%- elif conda_build_tool == "conda-build+conda-libmamba-solver" %}
-{%- set BUILD_CMD="CONDA_SOLVER=libmamba conda build" %}
+{%- set BUILD_CMD="CONDA_SOLVER=libmamba conda-build" %}
 {%- elif conda_build_tool == "conda-build+classic" %}
-{%- set BUILD_CMD="CONDA_SOLVER=classic conda build" %}
+{%- set BUILD_CMD="CONDA_SOLVER=classic conda-build" %}
 {%- else %}
-{%- set BUILD_CMD="conda build" %}
+{%- set BUILD_CMD="conda-build" %}
 {%- endif %}
 {%- if conda_solver == "libmamba" %}
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -20,13 +20,13 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 
 ( startgroup "Configuring conda" ) 2> /dev/null
 {%- if conda_build_tool == "mambabuild" %}
-{%- set BUILD_CMD="conda mambabuild" %}
+{%- set BUILD_CMD="conda-mambabuild" %}
 {%- elif conda_build_tool == "conda-build+conda-libmamba-solver" %}
-{%- set BUILD_CMD="CONDA_SOLVER=libmamba conda build" %}
+{%- set BUILD_CMD="CONDA_SOLVER=libmamba conda-build" %}
 {%- elif conda_build_tool == "conda-build+classic" %}
-{%- set BUILD_CMD="CONDA_SOLVER=classic conda build" %}
+{%- set BUILD_CMD="CONDA_SOLVER=classic conda-build" %}
 {%- else %}
-{%- set BUILD_CMD="conda build" %}
+{%- set BUILD_CMD="conda-build" %}
 {%- endif %}
 
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -78,15 +78,15 @@ call :end_group
 :: Build the recipe
 echo Building recipe
 {%- if conda_build_tool == "mambabuild" %}
-conda.exe mambabuild "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
+conda-mambabuild.exe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 {%- elif conda_build_tool == "conda-build+conda-libmamba-solver" %}
 set "CONDA_SOLVER=libmamba"
-conda.exe build "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
+conda-build.exe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 {%- elif conda_build_tool == "conda-build+classic" %}
 set "CONDA_SOLVER=classic"
-conda.exe build "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
+conda-build.exe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 {%- elif conda_build_tool == "conda-build" %}
-conda.exe build "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
+conda-build.exe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 {%- endif %}
 if !errorlevel! neq 0 exit /b !errorlevel!
 

--- a/news/1859-avoid-conda-subcommand-plugin.rst
+++ b/news/1859-avoid-conda-subcommand-plugin.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Invoke conda-{build,mambabuild} directly, not as conda subcommand. (#1859)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Recent conda-build versions register itself as conda subcommands via conda's plugin mechanisms.
Since conda-build failures don't gracefully exit, but rather just by raising exceptions, conda's exception handling and error reporting mechanisms add additional verbose output on build failures.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
