### PR TITLE
Set extra=forbid for Pydantic Schema Fields

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -74,7 +74,7 @@ def generate_feedstock_content(target_directory, source_recipe_dir):
             yaml.dump(_cfg_feedstock, fp)
 
 
-class Subcommand(object):
+class Subcommand:
     #: The name of the subcommand
     subcommand = None
     aliases = []

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2082,7 +2082,7 @@ def _read_forge_config(forge_dir, forge_yml=None):
     # Validate loaded configuration against a JSON schema.
     validate_lints, validate_hints = validate_json_schema(file_config)
     for err in chain(validate_lints, validate_hints):
-        logger.warn(
+        logger.warning(
             "%s: %s = %s -> %s",
             os.path.relpath(forge_yml, forge_dir),
             err.json_path,

--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -822,6 +822,7 @@
       "type": "object"
     },
     "build_platform": {
+      "additionalProperties": false,
       "properties": {
         "emscripten_wasm32": {
           "anyOf": [
@@ -1026,6 +1027,7 @@
       "type": "object"
     },
     "os_version": {
+      "additionalProperties": false,
       "properties": {
         "linux_32": {
           "anyOf": [
@@ -1167,6 +1169,7 @@
       "type": "object"
     },
     "provider": {
+      "additionalProperties": false,
       "properties": {
         "linux": {
           "anyOf": [

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -474,6 +474,7 @@ BuildPlatform = create_model(
         platform.value: (Optional[Platforms], Field(default=platform.value))
         for platform in Platforms
     },
+    __config__=ConfigDict(extra="forbid"),
 )
 
 OSVersion = create_model(
@@ -483,6 +484,7 @@ OSVersion = create_model(
         for platform in Platforms
         if platform.value.startswith("linux")
     },
+    __config__=ConfigDict(extra="forbid"),
 )
 
 ProviderType = Union[List[CIservices], CIservices, bool, Nullable]
@@ -499,6 +501,7 @@ Provider = create_model(
             for plat in ("linux_64", "osx_64", "win_64")
         ]
     ),
+    __config__=ConfigDict(extra="forbid"),
 )
 
 

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -118,7 +118,7 @@ def render_meta_yaml(text):
 def update_conda_forge_config(forge_yaml):
     """Utility method used to update conda forge configuration files
 
-    Uage:
+    Usage:
     >>> with update_conda_forge_config(somepath) as cfg:
     ...     cfg['foo'] = 'bar'
     """


### PR DESCRIPTION
The Pydantic model currently allows additional fields for BuildPlatform, OSVersion, ProviderType, which does not make a lot of sense and can hide errors IMO.

(This PR previously contained changed related to `bot.inspection` which were addressed separately.)