### PR TITLE
Address conda-build deprecations

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -13,6 +13,7 @@ import jsonschema
 import yaml
 import warnings
 from collections import Counter, OrderedDict, namedtuple
+from copy import deepcopy
 from itertools import chain, product
 from os import fspath
 from pathlib import Path, PurePath
@@ -32,17 +33,10 @@ try:
 except ImportError:
     import json
 
-import conda_build.api
-import conda_build.utils
-import conda_build.variants
-import conda_build.conda_interface
-import conda_build.render
 from conda.models.match_spec import MatchSpec
-
-from copy import deepcopy
+from conda.models.version import VersionOrder
 
 import conda_build.api
-import conda_build.conda_interface
 import conda_build.render
 import conda_build.utils
 import conda_build.variants
@@ -2207,8 +2201,6 @@ def _load_forge_config(forge_dir, exclusive_config_file, forge_yml=None):
 
 
 def get_most_recent_version(name, include_broken=False):
-    from conda_build.conda_interface import VersionOrder
-
     request = requests.get(
         "https://api.anaconda.org/package/conda-forge/" + name
     )
@@ -2223,8 +2215,6 @@ def get_most_recent_version(name, include_broken=False):
 
 
 def check_version_uptodate(name, installed_version, error_on_warn):
-    from conda_build.conda_interface import VersionOrder
-
     most_recent_version = get_most_recent_version(name).version
     if installed_version is None:
         msg = "{} is not installed in conda-smithy's environment.".format(name)

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -23,11 +23,11 @@ if sys.version_info[:2] < (3, 11):
 else:
     import tomllib
 
+from conda.models.version import VersionOrder
 from conda_build.metadata import (
     ensure_valid_license_family,
     FIELDS as cbfields,
 )
-import conda_build.conda_interface
 from conda_smithy.validate_schema import validate_json_schema
 
 from .utils import render_meta_yaml, get_yaml
@@ -495,7 +495,7 @@ def lintify_meta_yaml(
     if package_section.get("version") is not None:
         ver = str(package_section.get("version"))
         try:
-            conda_build.conda_interface.VersionOrder(ver)
+            VersionOrder(ver)
         except:
             lints.append(
                 "Package version {} doesn't match conda spec".format(ver)

--- a/news/1868-address-conda-build-deprecations
+++ b/news/1868-address-conda-build-deprecations
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Stop using conda_build.conda_interface. (#1868)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
`conda_build.conda_interface` is going to be marked for deprecation.

refs:
- https://github.com/conda/conda-build/pull/5222

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
