### PR TITLE
[WIP] Require `backports.strenum` on Python pre-3.12

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -34,5 +34,5 @@ dependencies:
   - cirun >=0.30
   - pydantic >=2,<3
   - jsonschema
-  - backports.strenum
+  - backports.strenum  # [py<312]
   - exceptiongroup

--- a/news/strenum_pre_py312.rst
+++ b/news/strenum_pre_py312.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Require ``backports.strenum`` on Python pre-3.12 ( #1883 )
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
As `backports.strenum` cannot be installed on Python 3.12 atm, maybe we should soften this requirement somehow

xref: https://github.com/conda-forge/backports.strenum-feedstock/pull/2/commits/7d0d99c3c5b97f7cfe754b0317cb332de4f4c261

<hr>

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
