### PR TITLE
Rerenders: do not raise on validation errors

### DIFF
--- a/conda_smithy/validate_schema.py
+++ b/conda_smithy/validate_schema.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-
+from typing import Tuple, List
 from jsonschema import Draft202012Validator, validators
 from jsonschema.exceptions import ValidationError
 
@@ -36,7 +36,9 @@ def get_validator_class():
 _VALIDATOR_CLASS = get_validator_class()
 
 
-def validate_json_schema(config, schema_file: str = None):
+def validate_json_schema(
+    config, schema_file: str = None
+) -> Tuple[List[ValidationError], List[ValidationError]]:
     # Validate the merged configuration against a JSON schema
     if not schema_file:
         schema_file = CONDA_FORGE_YAML_SCHEMA_FILE

--- a/news/1885-do-not-raise-on-validation-errors.rst
+++ b/news/1885-do-not-raise-on-validation-errors.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Do not raise on ``conda-forge.yml`` validation errors during rerender. A warning will be printed instead. (#1879 via #1885)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -1,11 +1,12 @@
+import copy
+import logging
 import os
-
-from conda_smithy import configure_feedstock
+import textwrap
 
 import pytest
-import copy
 import yaml
-import textwrap
+
+from conda_smithy import configure_feedstock
 
 
 def test_noarch_skips_appveyor(noarch_recipe, jinja_env):
@@ -762,7 +763,7 @@ def test_conda_forge_yaml_empty(config_yaml):
     assert load_forge_config()["recipe_dir"] == "recipe"
 
 
-def test_noarch_platforms_bad_yaml(config_yaml):
+def test_noarch_platforms_bad_yaml(config_yaml, caplog):
     load_forge_config = lambda: configure_feedstock._load_forge_config(  # noqa
         config_yaml,
         exclusive_config_file=os.path.join(
@@ -773,10 +774,10 @@ def test_noarch_platforms_bad_yaml(config_yaml):
     with open(os.path.join(config_yaml, "conda-forge.yml"), "a+") as fp:
         fp.write("noarch_platforms: [eniac, zx80]")
 
-    with pytest.raises(configure_feedstock.ExceptionGroup) as excinfo:
+    with caplog.at_level(logging.WARNING):
         load_forge_config()
 
-    assert "eniac" in repr(excinfo.value)
+    assert "eniac" in caplog.text
 
 
 def test_forge_yml_alt_path(config_yaml):

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -868,7 +868,7 @@ def test_cuda_enabled_render(cuda_enabled_recipe, jinja_env):
                 del os.environ["CF_CUDA_ENABLED"]
 
 
-def test_conda_build_tools(config_yaml):
+def test_conda_build_tools(config_yaml, caplog):
     load_forge_config = lambda: configure_feedstock._load_forge_config(  # noqa
         config_yaml,
         exclusive_config_file=os.path.join(
@@ -901,8 +901,9 @@ def test_conda_build_tools(config_yaml):
         fp.write(unmodified)
         fp.write("conda_build_tool: does-not-exist")
 
-    with pytest.raises(configure_feedstock.ExceptionGroup):
+    with caplog.at_level(logging.WARNING):
         assert load_forge_config()
+    assert "does-not-exist" in caplog.text
 
 
 def test_remote_ci_setup(config_yaml):


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Closes #1879 

<!--
Please add any other relevant info below:
-->

For now it doesn't offer any configuration options, and just replaces the previous errors with warnings formatted like this:

```
WARNING  conda_smithy.configure_feedstock:configure_feedstock.py:2002 conda-forge.yml: $.noarch_platforms = ['eniac', 'zx80'] -> ['eniac', 'zx80'] is not valid under any of the given schemas
```

Let me know if you want to have an option in the CLI, but for now users could just run `recipe-lint` before or after 🤷 