### PR TITLE
adjust linter output formatting for friendlier markdown rendering

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -599,9 +599,13 @@ class Regenerate(Subcommand):
 
 class RecipeLint(Subcommand):
     subcommand = "recipe-lint"
+    aliases = ["lint"]
 
     def __init__(self, parser):
-        super(RecipeLint, self).__init__(parser, "Lint a single conda recipe.")
+        super(RecipeLint, self).__init__(
+            parser,
+            "Lint a single conda recipe and its configuration.",
+        )
         scp = self.subcommand_parser
         scp.add_argument("--conda-forge", action="store_true")
         scp.add_argument("recipe_directory", default=[os.getcwd()], nargs="*")

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -6,15 +6,18 @@ str_type = str
 
 import copy
 import fnmatch
-from glob import glob
 import io
 import itertools
+import json
 import os
 import re
 import requests
 import shutil
 import subprocess
 import sys
+from glob import glob
+from inspect import cleandoc
+from textwrap import indent
 
 import github
 
@@ -1065,6 +1068,22 @@ def jinja_lines(lines):
             yield line, i
 
 
+def _format_validation_msg(error: "jsonschema.ValidationError"):
+    return cleandoc(
+        f"""
+        In conda-forge.yml: `{error.json_path} = {error.instance}`.
+{indent(error.message, " " * 12 + "> ")}
+            <details>
+            <summary>Schema</summary>
+
+            ```json
+{indent(json.dumps(error.schema, indent=2), " " * 12)}
+            ```
+
+            </details>
+        """
+    )
+
 def main(recipe_dir, conda_forge=False, return_hints=False):
     recipe_dir = os.path.abspath(recipe_dir)
     recipe_meta = os.path.join(recipe_dir, "meta.yaml")
@@ -1080,19 +1099,31 @@ def main(recipe_dir, conda_forge=False, return_hints=False):
         recipe_dir=recipe_dir
     )
 
-    validation_errors = [str(err) for err in validation_errors]
-    validation_errors = [
-        (
-            err.split("\n")[0]
-            if err.startswith("Additional properties are not allowed")
-            else err
-        )
-        for err in validation_errors
-    ]
-    results.extend(validation_errors)
-    hints.extend([str(lint) for lint in validation_hints])
+    results.extend([_format_validation_msg(err) for err in validation_errors])
+    hints.extend([_format_validation_msg(hint) for hint in validation_hints])
 
     if return_hints:
         return results, hints
     else:
         return results
+
+
+if __name__ == "__main__":
+    # This block is supposed to help debug how the rendered version
+    # of the linter bot would look like in Github. Taken from
+    # https://github.com/conda-forge/conda-forge-webservices/blob/747f75659/conda_forge_webservices/linting.py#L138C1-L146C72
+    rel_path = sys.argv[1]
+    lints, hints = main(rel_path, False, True)
+    messages = []
+    if lints:
+        print(lints, file=sys.stderr)
+        all_pass = False
+        messages.append("\nFor **{}**:\n\n{}".format(
+            rel_path,
+            '\n'.join('* {}'.format(lint) for lint in lints)))
+    if hints:
+        messages.append("\nFor **{}**:\n\n{}".format(
+            rel_path,
+            '\n'.join('* {}'.format(hint) for hint in hints)))
+
+    print(*messages, sep="\n")

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -1070,11 +1070,15 @@ def jinja_lines(lines):
 
 def _format_validation_msg(error: "jsonschema.ValidationError"):
     if error.schema:
-        descriptionless_schema = {k:v for (k, v) in error.schema.items() if k != "description"}
+        descriptionless_schema = {
+            k: v for (k, v) in error.schema.items() if k != "description"
+        }
     else:
         descriptionless_schema = {}
     # We can get the help url from the first level on the JSON path ($.top_level_key.2nd_level_key)
-    top_level_key = error.json_path.split(".")[1].split("[")[0].replace("_", "-")
+    top_level_key = (
+        error.json_path.split(".")[1].split("[")[0].replace("_", "-")
+    )
     help_url = f"https://conda-forge.org/docs/maintainer/conda_forge_yml/#{top_level_key}"
     return cleandoc(
         f"""
@@ -1090,6 +1094,7 @@ def _format_validation_msg(error: "jsonschema.ValidationError"):
             </details>
         """
     )
+
 
 def main(recipe_dir, conda_forge=False, return_hints=False):
     recipe_dir = os.path.abspath(recipe_dir)
@@ -1124,12 +1129,16 @@ if __name__ == "__main__":
     messages = []
     if lints:
         all_pass = False
-        messages.append("\nFor **{}**:\n\n{}".format(
-            rel_path,
-            '\n'.join('* {}'.format(lint) for lint in lints)))
+        messages.append(
+            "\nFor **{}**:\n\n{}".format(
+                rel_path, "\n".join("* {}".format(lint) for lint in lints)
+            )
+        )
     if hints:
-        messages.append("\nFor **{}**:\n\n{}".format(
-            rel_path,
-            '\n'.join('* {}'.format(hint) for hint in hints)))
+        messages.append(
+            "\nFor **{}**:\n\n{}".format(
+                rel_path, "\n".join("* {}".format(hint) for hint in hints)
+            )
+        )
 
     print(*messages, sep="\n")

--- a/news/1886-prettier-lints.rst
+++ b/news/1886-prettier-lints.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Adjust how the linter processes ``conda-forge.yml`` validation issues for prettier Markdown rendering. (#1860 via #1886)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

A possible solution to closing #1860. This does not implement a table (conda-forge-webservices assumes a list of items), but at least makes it more readable. The key links to the help documentation in conda-forge.org.

I also added an alias to `conda-smithy recipe-lint` because _technically_ we are now linting for more things than _just_ the recipe.

Compared to the current format:

![image](https://github.com/conda-forge/conda-smithy/assets/2559438/180c0d8a-e9dc-424a-bad1-decee26ec51a)


This PR would make it look like this, more or less (ignore the "For local-path" bits, that's just a local emulation):

![image](https://github.com/conda-forge/conda-smithy/assets/2559438/e5bc833c-aa1a-4313-b8cc-61f182a78ed2)



<!--
Please add any other relevant info below:
-->
