### PR TITLE
add "disabled" bot inspection to schema

### DIFF
--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -285,7 +285,7 @@
         "inspection": {
           "anyOf": [
             {
-              "type": "boolean"
+              "const": false
             },
             {
               "$ref": "#/$defs/BotConfigInspectionChoice"
@@ -358,7 +358,8 @@
         "hint-grayskull",
         "update-all",
         "update-source",
-        "update-grayskull"
+        "update-grayskull",
+        "disabled"
       ],
       "title": "BotConfigInspectionChoice",
       "type": "string"
@@ -1783,7 +1784,7 @@
           "type": "null"
         }
       ],
-      "description": "This dictates the behavior of the conda-forge auto-tick bot which issues\nautomatic version updates/migrations for feedstocks.\nA valid example is:\n\n```yaml\nbot:\n    # can the bot automerge PRs it makes on this feedstock\n    automerge: true\n    # only automerge on successful version PRs, migrations are not automerged\n    automerge: 'version'\n    # only automerge on successful migration PRs, versions are not automerged\n    automerge: 'migration'\n\n    # only open PRs if resulting environment is solvable, useful for tightly coupled packages\n    check_solvable: true\n\n    # The bot.inspection key in the conda-forge.yml can have one of six possible values:\n    inspection: hint  # generate hints using source code (backwards compatible)\n    inspection: hint-all  # generate hints using all methods\n    inspection: hint-source  # generate hints using only source code\n    inspection: hint-grayskull  # generate hints using only grayskull\n    inspection: update-all  # update recipe using all methods\n    inspection: update-source  # update recipe using only source code\n    inspection: update-grayskull  # update recipe using only grayskull\n\n    # any branches listed in this section will get bot migration PRs in addition\n    # to the default branch\n    abi_migration_branches:\n        - 'v1.10.x'\n\n    version_updates:\n        # use this for packages that are updated too frequently\n        random_fraction_to_keep: 0.1  # keeps 10% of versions at random\n        exclude:\n            - '08.14'\n```\n\nThe `abi_migration_branches` feature is useful to, for example, add a\nlong-term support (LTS) branch for a package."
+      "description": "This dictates the behavior of the conda-forge auto-tick bot which issues\nautomatic version updates/migrations for feedstocks.\nA valid example is:\n\n```yaml\nbot:\n    # can the bot automerge PRs it makes on this feedstock\n    automerge: true\n    # only automerge on successful version PRs, migrations are not automerged\n    automerge: 'version'\n    # only automerge on successful migration PRs, versions are not automerged\n    automerge: 'migration'\n\n    # only open PRs if resulting environment is solvable, useful for tightly coupled packages\n    check_solvable: true\n\n    # The bot.inspection key in the conda-forge.yml can have one of seven possible values and controls\n    # the bots behaviour for automatic dependency updates:\n    inspection: hint  # generate hints using source code (backwards compatible)\n    inspection: hint-all  # generate hints using all methods\n    inspection: hint-source  # generate hints using only source code\n    inspection: hint-grayskull  # generate hints using only grayskull\n    inspection: update-all  # update recipe using all methods\n    inspection: update-source  # update recipe using only source code\n    inspection: update-grayskull  # update recipe using only grayskull\n    inspection: disabled # don't update recipe, don't generate hints\n\n    # any branches listed in this section will get bot migration PRs in addition\n    # to the default branch\n    abi_migration_branches:\n        - 'v1.10.x'\n\n    version_updates:\n        # use this for packages that are updated too frequently\n        random_fraction_to_keep: 0.1  # keeps 10% of versions at random\n        exclude:\n            - '08.14'\n```\n\nThe `abi_migration_branches` feature is useful to, for example, add a\nlong-term support (LTS) branch for a package."
     },
     "build_platform": {
       "anyOf": [

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -72,6 +72,7 @@ class BotConfigInspectionChoice(StrEnum):
     UPDATE_ALL = "update-all"
     UPDATE_SOURCE = "update-source"
     UPDATE_GRAYSKULL = "update-grayskull"
+    DISABLED = "disabled"
 
 
 class BotConfigVersionUpdatesSourcesChoice(StrEnum):
@@ -353,9 +354,11 @@ class BotConfig(BaseModel):
         description="Open PRs only if resulting environment is solvable.",
     )
 
-    inspection: Optional[Union[bool, BotConfigInspectionChoice]] = Field(
-        default="hint",
-        description="Method for generating hints or updating recipe",
+    inspection: Optional[Union[Literal[False], BotConfigInspectionChoice]] = (
+        Field(
+            default="hint",
+            description="Method for generating hints or updating recipe",
+        )
     )
 
     abi_migration_branches: Optional[List[str]] = Field(
@@ -612,7 +615,8 @@ class ConfigModel(BaseModel):
             # only open PRs if resulting environment is solvable, useful for tightly coupled packages
             check_solvable: true
 
-            # The bot.inspection key in the conda-forge.yml can have one of six possible values:
+            # The bot.inspection key in the conda-forge.yml can have one of seven possible values and controls
+            # the bots behaviour for automatic dependency updates:
             inspection: hint  # generate hints using source code (backwards compatible)
             inspection: hint-all  # generate hints using all methods
             inspection: hint-source  # generate hints using only source code
@@ -620,6 +624,7 @@ class ConfigModel(BaseModel):
             inspection: update-all  # update recipe using all methods
             inspection: update-source  # update recipe using only source code
             inspection: update-grayskull  # update recipe using only grayskull
+            inspection: disabled # don't update recipe, don't generate hints
 
             # any branches listed in this section will get bot migration PRs in addition
             # to the default branch

--- a/news/1891-disabled-bot-inspection.rst
+++ b/news/1891-disabled-bot-inspection.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* ``disabled`` is now a supported option for ``bot.inspection`` in the ``conda-forge.yml`` file (previously: ``false``)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
https://github.com/regro/cf-scripts/pull/2274 added support for the `disabled` bot inspection choice for `conda-forge.yml`, which is added with this PR. Also, `True` was never supported as an inspection option.