### PR TITLE
drop support for bot.inspection = false

### DIFF
--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -285,9 +285,6 @@
         "inspection": {
           "anyOf": [
             {
-              "const": false
-            },
-            {
               "$ref": "#/$defs/BotConfigInspectionChoice"
             },
             {
@@ -295,8 +292,7 @@
             }
           ],
           "default": "hint",
-          "description": "Method for generating hints or updating recipe",
-          "title": "Inspection"
+          "description": "Method for generating hints or updating recipe"
         },
         "abi_migration_branches": {
           "anyOf": [

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -354,11 +354,9 @@ class BotConfig(BaseModel):
         description="Open PRs only if resulting environment is solvable.",
     )
 
-    inspection: Optional[Union[Literal[False], BotConfigInspectionChoice]] = (
-        Field(
-            default="hint",
-            description="Method for generating hints or updating recipe",
-        )
+    inspection: Optional[BotConfigInspectionChoice] = Field(
+        default="hint",
+        description="Method for generating hints or updating recipe",
     )
 
     abi_migration_branches: Optional[List[str]] = Field(

--- a/news/1892-drop-support-inspection-false.rst
+++ b/news/1892-drop-support-inspection-false.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* ``false`` is no longer a valid value for ``bot.inspection`` in the ``conda-forge.yml`` file. Use ``disabled`` instead.
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
replaced by bot.inspection = disabled

See https://github.com/regro/cf-scripts/issues/2272#issuecomment-2004119968

According to my information, `false` is not used by any feedstock anymore. All feedstocks are migrated.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

@beckermr
