### PR TITLE
remove `c_stdlib{,_version}` from `always_keep_keys` in configure_feedstock.py

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -591,8 +591,6 @@ def _collapse_subpackage_variants(
         "macos_machine",
         "channel_sources",
         "channel_targets",
-        "c_stdlib",
-        "c_stdlib_version",
         "docker_image",
         "build_number_decrement",
         # The following keys are required for some of our aarch64 builds

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytest-cov
   # Runtime dependencies
   - conda >=4.2
-  - conda-build >=3.21.8
+  - conda-build >=24.3
   - conda-package-handling >=1.9.0
   - jinja2
   - requests

--- a/news/1908-less-stdlib-spam.rst
+++ b/news/1908-less-stdlib-spam.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Do not populate `c_stdlib{,_version}` in CI configs that don't need them (#1908)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Discussed in the core call today. As of conda-build 24.3, this isn't necessary anymore; update the minimum version to reflect this.

@beckermr wasn't in the call but [asked](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/691#discussion_r1543491834) the same thing a while back.