### PR TITLE
provide linter hints about adding stdlib, removing outdated ways to do it

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -845,6 +845,47 @@ def lintify_meta_yaml(
             "[here]( https://conda-forge.org/docs/maintainer/adding_pkgs.html#spdx-identifiers-and-expressions )."
         )
 
+    # stdlib-related hints
+    build_reqs = requirements_section.get("build") or []
+    run_reqs = requirements_section.get("run") or []
+    constraints = requirements_section.get("run_constrained") or []
+
+    stdlib_hint = (
+        "This recipe is using a compiler, which now requires adding a build "
+        'dependence on `{{ stdlib("c") }}` as well. For further details, please '
+        "see https://github.com/conda-forge/conda-forge.github.io/issues/2102."
+    )
+    pat_compiler_stub = re.compile(
+        "(m2w64_)?(c|cxx|fortran|rust)_compiler_stub"
+    )
+    has_compiler = any(pat_compiler_stub.match(rq) for rq in build_reqs)
+    if has_compiler and "c_stdlib_stub" not in build_reqs:
+        if stdlib_hint not in hints:
+            hints.append(stdlib_hint)
+
+    sysroot_hint = (
+        "You're setting a requirement on sysroot_linux-<arch> directly; this should "
+        'now be done by adding a build dependence on `{{ stdlib("c") }}`, and '
+        "overriding `c_stdlib_version` in `recipe/conda_build_config.yaml` for the "
+        "respective platform as necessary. For further details, please see "
+        "https://github.com/conda-forge/conda-forge.github.io/issues/2102."
+    )
+    pat_sysroot = re.compile(r"sysroot_linux.*")
+    if any(pat_sysroot.match(req) for req in build_reqs):
+        if sysroot_hint not in hints:
+            hints.append(sysroot_hint)
+
+    osx_hint = (
+        "You're setting a constraint on the `__osx` virtual package directly; this "
+        'should now be done by adding a build dependence on `{{ stdlib("c") }}`, '
+        "and overriding `c_stdlib_version` in `recipe/conda_build_config.yaml` for "
+        "the respective platform as necessary. For further details, please see "
+        "https://github.com/conda-forge/conda-forge.github.io/issues/2102."
+    )
+    if any(req.startswith("__osx") for req in run_reqs + constraints):
+        if osx_hint not in hints:
+            hints.append(osx_hint)
+
     return lints, hints
 
 

--- a/news/1909-stdlib-linter.rst
+++ b/news/1909-stdlib-linter.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Added linter rules for providing hints about updating to new stdlib-functionality (#1909)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -30,6 +30,70 @@ def tmp_directory():
     shutil.rmtree(tmp_dir)
 
 
+@pytest.mark.parametrize(
+    "comp_lang",
+    ["c", "cxx", "fortran", "rust", "m2w64_c", "m2w64_cxx", "m2w64_fortran"],
+)
+def test_stdlib_hint(comp_lang):
+    expected_message = "This recipe is using a compiler"
+
+    with tmp_directory() as recipe_dir:
+        with io.open(os.path.join(recipe_dir, "meta.yaml"), "w") as fh:
+            fh.write(
+                f"""
+                package:
+                   name: foo
+                requirements:
+                  build:
+                    # since we're in an f-string: double up braces (2->4)
+                    - {{{{ compiler("{comp_lang}") }}}}
+                """
+            )
+
+        _, hints = linter.main(recipe_dir, return_hints=True)
+        assert any(h.startswith(expected_message) for h in hints)
+
+
+def test_sysroot_hint():
+    expected_message = "You're setting a requirement on sysroot"
+
+    with tmp_directory() as recipe_dir:
+        with io.open(os.path.join(recipe_dir, "meta.yaml"), "w") as fh:
+            fh.write(
+                """
+                package:
+                   name: foo
+                requirements:
+                  build:
+                    - sysroot_{{ target_platform }} 2.17
+                """
+            )
+
+        _, hints = linter.main(recipe_dir, return_hints=True)
+        assert any(h.startswith(expected_message) for h in hints)
+
+
+@pytest.mark.parametrize("where", ["run", "run_constrained"])
+def test_osx_hint(where):
+    expected_message = "You're setting a constraint on the `__osx` virtual"
+
+    with tmp_directory() as recipe_dir:
+        with io.open(os.path.join(recipe_dir, "meta.yaml"), "w") as fh:
+            fh.write(
+                f"""
+                package:
+                   name: foo
+                requirements:
+                  {where}:
+                    # since we're in an f-string: double up braces (2->4)
+                    - __osx >={{{{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}}}  # [osx and x86_64]
+                """
+            )
+
+        _, hints = linter.main(recipe_dir, return_hints=True)
+        assert any(h.startswith(expected_message) for h in hints)
+
+
 class Test_linter(unittest.TestCase):
     def test_pin_compatible_in_run_exports(self):
         meta = {

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -848,19 +848,23 @@ class Test_linter(unittest.TestCase):
             "instead saw: run, build."
         )
 
-        meta = {"requirements": OrderedDict([["run", "a"], ["build", "a"]])}
+        meta = {
+            "requirements": OrderedDict([["run", ["a"]], ["build", ["a"]]])
+        }
         lints, hints = linter.lintify_meta_yaml(meta)
         self.assertIn(expected_message, lints)
 
         meta = {
             "requirements": OrderedDict(
-                [["run", "a"], ["invalid", "a"], ["build", "a"]]
+                [["run", ["a"]], ["invalid", ["a"]], ["build", ["a"]]]
             )
         }
         lints, hints = linter.lintify_meta_yaml(meta)
         self.assertIn(expected_message, lints)
 
-        meta = {"requirements": OrderedDict([["build", "a"], ["run", "a"]])}
+        meta = {
+            "requirements": OrderedDict([["build", ["a"]], ["run", ["a"]]])
+        }
         lints, hints = linter.lintify_meta_yaml(meta)
         self.assertNotIn(expected_message, lints)
 


### PR DESCRIPTION
As discussed in core call today; I wanted to add this into `run_conda_forge_specific` originally (where the other hint logic from https://github.com/conda-forge/conda-smithy/pull/1772 lives[^1], but it's a pain to run that in testing because `run_conda_forge_specific` requires a `GH_TOKEN`. If desired, I can still move it there, especially now that the tests have been debugged (and assuming CI here has a valid token). 🤷  

[^1]: which we cannot reuse because it currently only works for plain package names, no patterns, versions etc.

Note: I'd also want to wait before ~merging~ releasing this until we have updated the stdlib docs in the knowledge base, to avoid people getting confused.