### PR TITLE
Do not ignore zip-unrelated keys in migrators

### DIFF
--- a/conda_smithy/variant_algebra.py
+++ b/conda_smithy/variant_algebra.py
@@ -174,7 +174,7 @@ def op_variant_key_add(v1: dict, v2: dict):
     # update result with all other keys specified in the migrator,
     # which aren't part of the migrator specs or zipped keys
     already_handled = {"__migrator"} | all_keys_in_zips | newly_added_zip_keys
-    for key in set(v2.keys()) - already_handled:
+    for key in (set(result.keys()) & set(v2.keys())) - already_handled:
         result[key] = v2[key]
 
     for pkey_ind, pkey_val in enumerate(v2[primary_key]):

--- a/news/1912-zip_key-hole.rst
+++ b/news/1912-zip_key-hole.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Do not ignore keys updated by migrator if they do not appear in a `zip_keys:` (#1912)
+
+**Security:**
+
+* <news item>

--- a/tests/test_variant_algebra.py
+++ b/tests/test_variant_algebra.py
@@ -531,7 +531,7 @@ def test_multiple_key_add_migration():
     assert "numpy" not in res3
 
 
-def test_other_keys_in_additional_zip_migrator():
+def test_update_other_keys_not_in_zip_keys():
     """Test updating keys in migrators not related to zips still get updated."""
     # based on global pinning
     base = parse_variant(

--- a/tests/test_variant_algebra.py
+++ b/tests/test_variant_algebra.py
@@ -344,19 +344,19 @@ def test_py39_migration():
       - 3.6.* *_cpython   # [not (osx and arm64)]
       - 3.7.* *_cpython   # [not (osx and arm64)]
       - 3.8.* *_cpython
-      - 3.6.* *_73_pypy   # [not (win64 or (osx and arm64))]
+      - 3.6.* *_73_pypy   # [not (osx and arm64)]
 
     numpy:
       - 1.16       # [not (osx and arm64)]
       - 1.16       # [not (osx and arm64)]
       - 1.16
-      - 1.18       # [not (win64 or (osx and arm64))]
+      - 1.18       # [not (osx and arm64)]
 
     python_impl:
       - cpython    # [not (osx and arm64)]
       - cpython    # [not (osx and arm64)]
       - cpython
-      - pypy       # [not (win64 or (osx and arm64))]
+      - pypy       # [not (osx and arm64)]
 
 
     zip_keys:
@@ -449,19 +449,19 @@ def test_multiple_key_add_migration():
       - 3.6.* *_cpython   # [not (osx and arm64)]
       - 3.7.* *_cpython   # [not (osx and arm64)]
       - 3.8.* *_cpython
-      - 3.6.* *_73_pypy   # [not (win64 or (osx and arm64))]
+      - 3.6.* *_73_pypy   # [not (osx and arm64)]
 
     numpy:
       - 1.16       # [not (osx and arm64)]
       - 1.16       # [not (osx and arm64)]
       - 1.16
-      - 1.18       # [not (win64 or (osx and arm64))]
+      - 1.18       # [not (osx and arm64)]
 
     python_impl:
       - cpython    # [not (osx and arm64)]
       - cpython    # [not (osx and arm64)]
       - cpython
-      - pypy       # [not (win64 or (osx and arm64))]
+      - pypy       # [not (osx and arm64)]
 
 
     zip_keys:


### PR DESCRIPTION
Tentative fix for #1911, needed for https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5790 (AFAIU), tested in https://github.com/conda-forge/scipy-feedstock/pull/274 and https://github.com/conda-forge/pythran-feedstock/pull/84