### PR TITLE
Use macos-13 explicitly for osx-64 on Github Actions

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1516,7 +1516,8 @@ def _github_actions_specific_setup(
         },
         "osx-arm64": {
             "os": "macos",
-            "hosted_labels": ("macos-14",),  # FUTURE: Use -latest once GHA fully migrates
+            # FUTURE: Use -latest once GHA fully migrates
+            "hosted_labels": ("macos-14",),
             "self_hosted_labels": ("macOS", "arm64"),
         },
         "linux-64": {

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1511,12 +1511,12 @@ def _github_actions_specific_setup(
     runs_on = {
         "osx-64": {
             "os": "macos",
-            "hosted_labels": ("macos-latest",),
+            "hosted_labels": ("macos-12",),
             "self_hosted_labels": ("macOS", "x64"),
         },
         "osx-arm64": {
             "os": "macos",
-            "hosted_labels": ("macos-14",),
+            "hosted_labels": ("macos-14",),  # FUTURE: Use -latest once GHA fully migrates
             "self_hosted_labels": ("macOS", "arm64"),
         },
         "linux-64": {

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1511,7 +1511,7 @@ def _github_actions_specific_setup(
     runs_on = {
         "osx-64": {
             "os": "macos",
-            "hosted_labels": ("macos-12",),
+            "hosted_labels": ("macos-13",),
             "self_hosted_labels": ("macOS", "x64"),
         },
         "osx-arm64": {

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -165,7 +165,7 @@ jobs:
 {% endfor %}
 
     - name: Install Miniconda for windows
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-version: latest
         miniforge-variant: Mambaforge

--- a/news/1913-macos-x64.rst
+++ b/news/1913-macos-x64.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* Explicitly use ``macos-12`` for ``osx-64`` runners. (#1913)
+* Explicitly use ``macos-13`` for ``osx-64`` runners. (#1913)
 
 **Deprecated:**
 

--- a/news/1913-macos-x64.rst
+++ b/news/1913-macos-x64.rst
@@ -4,7 +4,8 @@
 
 **Changed:**
 
-* Explicitly use ``macos-13`` for ``osx-64`` runners. (#1913)
+* Github Actions: Explicitly use ``macos-13`` for ``osx-64`` runners. (#1913)
+* Github Actions: Bump to ``setup-miniconda@v3`` on Windows builds. (#1913)
 
 **Deprecated:**
 

--- a/news/1913-macos-x64.rst
+++ b/news/1913-macos-x64.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Explicitly use ``macos-12`` for ``osx-64`` runners. (#1913)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

See https://github.com/conda-incubator/setup-miniconda/issues/344 for more  context. `macos-latest` is slowly defaulting to `-14` which means ARM64, not Intel.