### PR TITLE
WIP: add test for updating migrator-keys not part of zip_keys

### DIFF
--- a/tests/test_variant_algebra.py
+++ b/tests/test_variant_algebra.py
@@ -569,6 +569,10 @@ def test_update_other_keys_not_in_zip_keys():
             """
             __migrator:
               kind: version
+              ordering:
+                channel_sources:
+                  - conda-forge
+                  - conda-forge/label/numpy_dev,conda-forge
 
             # needs to fully reproduce zip of {python, python_impl, numpy}
             # in order to override it

--- a/tests/test_variant_algebra.py
+++ b/tests/test_variant_algebra.py
@@ -531,6 +531,76 @@ def test_multiple_key_add_migration():
     assert "numpy" not in res3
 
 
+def test_update_other_keys_not_in_zip_keys():
+    """Test updating keys in migrators not related to zips still get updated."""
+    # based on global pinning
+    base = parse_variant(
+        dedent(
+            """
+            python:
+              - 3.8.* *_cpython
+              - 3.9.* *_cpython
+              - 3.10.* *_cpython
+              - 3.11.* *_cpython
+            python_impl:
+              - cpython
+              - cpython
+              - cpython
+              - cpython
+            numpy:
+              - 1.22
+              - 1.22
+              - 1.22
+              - 1.23
+            # not part of zip
+            channel_sources:
+              - conda-forge
+            zip_keys:
+              -
+                - python
+                - numpy
+                - python_impl
+            """
+        )
+    )
+
+    migration_numpy = parse_variant(
+        dedent(
+            """
+            __migrator:
+              kind: version
+
+            # needs to fully reproduce zip of {python, python_impl, numpy}
+            # in order to override it
+            numpy:
+              - 1.22  # no py38 support for numpy 2.0
+              - 2.0
+              - 2.0
+              - 2.0
+            python:
+              - 3.8.* *_cpython
+              - 3.9.* *_cpython
+              - 3.10.* *_cpython
+              - 3.11.* *_cpython
+            python_impl:
+              - cpython
+              - cpython
+              - cpython
+              - cpython
+            channel_sources:
+              - conda-forge/label/numpy_dev,conda-forge
+            """
+        )
+    )
+
+    res = variant_add(base, migration_numpy)
+
+    # assert that key not involved in zip_keys (i.e. channel_sources) got updated
+    assert res["channel_sources"] == [
+        "conda-forge/label/numpy_dev,conda-forge"
+    ]
+
+
 def test_variant_key_remove():
     base = parse_variant(
         dedent(


### PR DESCRIPTION
In context of #1911 / #1912