### PR TITLE
Add linter hints for issues with OSX configuration in CBC

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -910,11 +910,19 @@ def lintify_meta_yaml(
     # ```
     cbc_osx = dict(filter(lambda item: item[1] is not None, cbc_osx.items()))
 
-    # for fallback, assume ordering [x64, arm64] which is used (almost) universally
+    def sort_osx(versions):
+        # we need to have a known order for [x64, arm64]; in the absence of more
+        # complicated regex processing, we assume that if there are two versions
+        # being specified, the higher one is osx-arm64.
+        if len(versions) == 2:
+            if VersionOrder(str(versions[0])) > VersionOrder(str(versions[1])):
+                versions = versions[::-1]
+        return versions
+
     baseline_version = ["10.13", "11.0"]
-    v_stdlib = cbc_osx.get("c_stdlib_version", baseline_version)
-    macdt = cbc_osx.get("MACOSX_DEPLOYMENT_TARGET", baseline_version)
-    sdk = cbc_osx.get("MACOSX_SDK_VERSION", baseline_version)
+    v_stdlib = sort_osx(cbc_osx.get("c_stdlib_version", baseline_version))
+    macdt = sort_osx(cbc_osx.get("MACOSX_DEPLOYMENT_TARGET", baseline_version))
+    sdk = sort_osx(cbc_osx.get("MACOSX_SDK_VERSION", baseline_version))
 
     if {"MACOSX_DEPLOYMENT_TARGET", "c_stdlib_version"} <= set(cbc_osx.keys()):
         # both specified, check that they match

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -953,12 +953,13 @@ def lintify_meta_yaml(
     merged_dt = cbc_osx.get("merged", baseline_version)
     sdk_hint = (
         "You are setting `MACOSX_SDK_VERSION` below `c_stdlib_version`, "
-        "which is not possible! Please ensure `MACOSX_SDK_VERSION` is at "
-        "least `c_stdlib_version` (you can leave it out if it is equal).\n"
+        "in conda_build_config.yaml which is not possible! Please ensure "
+        "`MACOSX_SDK_VERSION` is at least `c_stdlib_version` "
+        "(you can leave it out if it is equal).\n"
         "If you are not setting `c_stdlib_version` yourself, this means "
         "you are requesting a version below the current global baseline in "
         "conda-forge. In this case, you also need to override "
-        "`c_stdlib_version` and `MACOSX_DEPLOYMENT_TARGET`."
+        "`c_stdlib_version` and `MACOSX_DEPLOYMENT_TARGET` locally."
     )
     if len(sdk) == len(merged_dt):
         # if length matches, compare individually

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -902,6 +902,13 @@ def lintify_meta_yaml(
     cbc_lines_osx = [pat.sub("", x) for x in cbc_lines]
     cbc_content_osx = "\n".join(cbc_lines_osx)
     cbc_osx = get_yaml().load(cbc_content_osx) or {}
+    # filter None values out of cbc_osx dict, can appear for example with
+    # ```
+    # c_stdlib_version:  # [unix]
+    #   - 2.17           # [linux]
+    #   # note lack of osx
+    # ```
+    cbc_osx = dict(filter(lambda item: item[1] is not None, cbc_osx.items()))
 
     # for fallback, assume ordering [x64, arm64] which is used (almost) universally
     baseline_version = ["10.13", "11.0"]

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -436,6 +436,7 @@ def lintify_meta_yaml(
                 )
             )
 
+    conda_build_config_filename = None
     if recipe_dir:
         conda_build_config_filename = find_local_config_file(
             recipe_dir, "conda_build_config.yaml"
@@ -885,6 +886,92 @@ def lintify_meta_yaml(
     if any(req.startswith("__osx >") for req in run_reqs + constraints):
         if osx_hint not in hints:
             hints.append(osx_hint)
+
+    # stdlib issues in CBC
+    cbc_lines = []
+    if conda_build_config_filename:
+        with open(conda_build_config_filename, "r") as fh:
+            cbc_lines = fh.readlines()
+
+    # filter on osx-relevant lines
+    pat = re.compile(
+        r"^([^\#]*?)\s+\#\s\[.*(not\s(osx|unix)|(?<!not\s)(linux|win)).*\]\s*$"
+    )
+    # remove lines with selectors that don't apply to osx, i.e. if they contain
+    # "not osx", "not unix", "linux" or "win"; this also removes trailing newlines
+    cbc_lines_osx = [pat.sub("", x) for x in cbc_lines]
+    cbc_content_osx = "\n".join(cbc_lines_osx)
+    cbc_osx = get_yaml().load(cbc_content_osx) or {}
+
+    baseline_version = ["10.13"]
+    v_stdlib = cbc_osx.get("c_stdlib_version", baseline_version)
+    macdt = cbc_osx.get("MACOSX_DEPLOYMENT_TARGET", baseline_version)
+    sdk = cbc_osx.get("MACOSX_SDK_VERSION", baseline_version)
+
+    if {"MACOSX_DEPLOYMENT_TARGET", "c_stdlib_version"} <= set(cbc_osx.keys()):
+        # both specified, check that they match
+        if len(v_stdlib) != len(macdt):
+            # if lengths aren't matching, assume it's a legal combination
+            # where one key is specified for less arches than the other and
+            # let the rerender deal with the details
+            pass
+        else:
+            mismatch_hint = (
+                "Conflicting specification for minimum macOS deployment target!\n"
+                "If your conda_build_config.yaml sets `MACOSX_DEPLOYMENT_TARGET`, "
+                "please change the name of that key to `c_stdlib_version`!\n"
+                f"Continuing with `max(c_stdlib_version, MACOSX_DEPLOYMENT_TARGET)`."
+            )
+            merged_dt = []
+            for v_std, v_mdt in zip(v_stdlib, macdt):
+                # versions with a single dot may have been read as floats
+                v_std, v_mdt = str(v_std), str(v_mdt)
+                if VersionOrder(v_std) != VersionOrder(v_mdt):
+                    if mismatch_hint not in hints:
+                        hints.append(mismatch_hint)
+                merged_dt.append(
+                    v_mdt
+                    if VersionOrder(v_std) < VersionOrder(v_mdt)
+                    else v_std
+                )
+            cbc_osx["merged"] = merged_dt
+    elif "MACOSX_DEPLOYMENT_TARGET" in cbc_osx.keys():
+        # only MACOSX_DEPLOYMENT_TARGET, should be renamed
+        deprecated_dt = (
+            "In your conda_build_config.yaml, please change the name of "
+            "`MACOSX_DEPLOYMENT_TARGET`, to `c_stdlib_version`!"
+        )
+        if deprecated_dt not in hints:
+            hints.append(deprecated_dt)
+        cbc_osx["merged"] = macdt
+    elif "c_stdlib_version" in cbc_osx.keys():
+        # no warning
+        cbc_osx["merged"] = v_stdlib
+
+    # warn if SDK is lower than merged v_stdlib/macdt
+    merged_dt = cbc_osx.get("merged", baseline_version)
+    sdk_hint = (
+        "You are setting `MACOSX_SDK_VERSION` below `c_stdlib_version`, "
+        "which is not possible! Please ensure `MACOSX_SDK_VERSION` is at "
+        "least `c_stdlib_version` (you can leave it out if it is equal)."
+    )
+    if len(sdk) == len(merged_dt):
+        # if length matches, compare individually
+        for v_sdk, v_mdt in zip(sdk, merged_dt):
+            # versions with a single dot may have been read as floats
+            v_sdk, v_mdt = str(v_sdk), str(v_mdt)
+            if VersionOrder(v_sdk) < VersionOrder(v_mdt):
+                if sdk_hint not in hints:
+                    hints.append(sdk_hint)
+    elif len(sdk) == 1 and "MACOSX_SDK_VERSION" in cbc_osx.keys():
+        # if length doesn't match, only warn if a single SDK version is lower
+        # than _all_ merged deployment targets
+        if all(
+            VersionOrder(str(sdk[0])) < VersionOrder(str(v_mdt))
+            for v_mdt in merged_dt
+        ):
+            if sdk_hint not in hints:
+                hints.append(sdk_hint)
 
     return lints, hints
 

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -903,7 +903,8 @@ def lintify_meta_yaml(
     cbc_content_osx = "\n".join(cbc_lines_osx)
     cbc_osx = get_yaml().load(cbc_content_osx) or {}
 
-    baseline_version = ["10.13"]
+    # for fallback, assume ordering [x64, arm64] which is used (almost) universally
+    baseline_version = ["10.13", "11.0"]
     v_stdlib = cbc_osx.get("c_stdlib_version", baseline_version)
     macdt = cbc_osx.get("MACOSX_DEPLOYMENT_TARGET", baseline_version)
     sdk = cbc_osx.get("MACOSX_SDK_VERSION", baseline_version)
@@ -953,7 +954,11 @@ def lintify_meta_yaml(
     sdk_hint = (
         "You are setting `MACOSX_SDK_VERSION` below `c_stdlib_version`, "
         "which is not possible! Please ensure `MACOSX_SDK_VERSION` is at "
-        "least `c_stdlib_version` (you can leave it out if it is equal)."
+        "least `c_stdlib_version` (you can leave it out if it is equal).\n"
+        "If you are not setting `c_stdlib_version` yourself, this means "
+        "you are requesting a version below the current global baseline in "
+        "conda-forge. In this case, you also need to override "
+        "`c_stdlib_version` and `MACOSX_DEPLOYMENT_TARGET`."
     )
     if len(sdk) == len(merged_dt):
         # if length matches, compare individually

--- a/news/1929-lint-osx-misconfigurations-in-CBC.rst
+++ b/news/1929-lint-osx-misconfigurations-in-CBC.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Provide linter hints if macOS quantities are misconfigured in `conda_build_config.yaml` (#1929)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -144,6 +144,12 @@ def test_osx_noarch_hint(where):
         # handling below, repeat same test twice with different expected hints
         (["10.9", "11.0"], ["10.13", "11.0"], ["10.12"], "Conflicting spec"),
         (["10.9", "11.0"], ["10.13", "11.0"], ["10.12"], "You are"),
+        # only sdk -> no warning
+        (None, None, ["10.13"], None),
+        (None, None, ["10.14", "12.0"], None),
+        # only sdk, but below global baseline -> warning
+        (None, None, ["10.12"], "You are"),
+        (None, None, ["10.12", "11.0"], "You are"),
     ],
 )
 def test_cbc_osx_hints(with_linux, macdt, v_std, sdk, exp_hint):

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -131,6 +131,10 @@ def test_osx_noarch_hint(where):
         (["10.13", "11.0"], None, None, "In your conda_build_config.yaml"),
         # only stdlib -> no warning
         (None, ["10.13", "11.0"], None, None),
+        (None, ["10.15"], None, None),
+        # only stdlib, but outdated -> warn
+        (None, ["10.9", "11.0"], None, "You are"),
+        (None, ["10.9"], None, "You are"),
         # sdk below stdlib / deployment target -> warn
         (["10.13", "11.0"], ["10.13", "11.0"], ["10.12"], "You are"),
         (["10.13", "11.0"], ["10.13", "11.0"], ["10.12", "12.0"], "You are"),

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -166,11 +166,7 @@ MACOSX_DEPLOYMENT_TARGET:   # [osx]
 """
                 )
             if v_std is not None or with_linux:
-                fh.write(
-                    f"""\
-c_stdlib_version:           # [unix]\
-"""
-                )
+                fh.write("c_stdlib_version:           # [unix]")
                 if v_std is not None:
                     fh.write(f"\n  - {v_std[0]}            # [osx and x86_64]")
                 if v_std is not None and len(v_std) > 1:
@@ -179,6 +175,7 @@ c_stdlib_version:           # [unix]\
                     # to check that other stdlib specifications don't mess us up
                     fh.write("\n  - 2.17                   # [linux]")
             if sdk is not None:
+                # often SDK is set uniformly for osx; test this as well
                 fh.write(
                     f"""
 MACOSX_SDK_VERSION:         # [osx]

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -165,18 +165,19 @@ MACOSX_DEPLOYMENT_TARGET:   # [osx]
   - {macdt[1]}              # [osx and arm64]
 """
                 )
-            if v_std is not None:
+            if v_std is not None or with_linux:
                 fh.write(
                     f"""\
-c_stdlib_version:           # [unix]
-  - {v_std[0]}              # [osx and x86_64]
+c_stdlib_version:           # [unix]\
 """
                 )
-                if len(v_std) > 1:
-                    fh.write(f"  - {v_std[1]}              # [osx and arm64]")
+                if v_std is not None:
+                    fh.write(f"\n  - {v_std[0]}            # [osx and x86_64]")
+                if v_std is not None and len(v_std) > 1:
+                    fh.write(f"\n  - {v_std[1]}            # [osx and arm64]")
                 if with_linux:
                     # to check that other stdlib specifications don't mess us up
-                    fh.write("\n  - 2.17                    # [linux]")
+                    fh.write("\n  - 2.17                   # [linux]")
             if sdk is not None:
                 fh.write(
                     f"""


### PR DESCRIPTION
Linter portion of #1927, but also adding linter hints for warnings from #1889, which were so far only visible when running smithy locally.