### PR TITLE
Add dependabot configuration and pin Github Actions actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directory: ".github/workflows/"
     schedule:
       interval: "weekly"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: ".github/workflows/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/_proxy-file-for-dependabot-tests.yml
+++ b/.github/workflows/_proxy-file-for-dependabot-tests.yml
@@ -1,0 +1,15 @@
+# This file is just a parsable YAML that collects all the actions used by
+# conda_smithy/templates/github-actions.yml.tmpl. It's here so dependabot
+# can pick it up and then we can test whether the actions are up-to-date in
+# the template.
+on:
+  workflow_dispatch:
+
+jobs:
+  inventory:
+    runs-on: ubuntu-latest
+    if: false
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3.0.4
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -90,7 +90,7 @@ jobs:
 {%- endif %}
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 {%- if clone_depth is not none %}
       with:
         fetch-depth: {{ clone_depth }}
@@ -165,7 +165,7 @@ jobs:
 {% endfor %}
 
     - name: Install Miniconda for windows
-      uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3.0.4
       with:
         miniforge-version: latest
         miniforge-variant: Mambaforge
@@ -227,7 +227,7 @@ jobs:
       continue-on-error: true
 
     - name: Store conda build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       if: {% raw %}${{ always() && steps.prepare-artifacts.outcome == 'success' }}{% endraw %}
       with:
         name: {% raw %}${{ steps.prepare-artifacts.outputs.BLD_ARTIFACT_NAME }}{% endraw %}
@@ -236,7 +236,7 @@ jobs:
       continue-on-error: true
 
     - name: Store conda build environment artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       if: {% raw %}${{ failure() && steps.prepare-artifacts.outcome == 'success' }}{% endraw %}
       with:
         name: {% raw %}${{ steps.prepare-artifacts.outputs.ENV_ARTIFACT_NAME }}{% endraw %}

--- a/news/1930-dependabot.rst
+++ b/news/1930-dependabot.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Enable Dependabot for Github Actions workflows. (#1930)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/1930-dependabot.rst
+++ b/news/1930-dependabot.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Enable Dependabot for Github Actions workflows. (#1930)
+* Enable Dependabot for Github Actions workflows and templates. (#1930)
 
 **Changed:**
 

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -2040,17 +2040,26 @@ def test_github_actions_pins():
     a proxy file with the inventory of used actions.
 
     This test will check that the `uses: owner/repo@version` lines are the same in both files.
-    If Dependabot opens a PR against the proxy, just copy the new pins to the template to 
+    If Dependabot opens a PR against the proxy, just copy the new pins to the template to
     make this pass.
     """
     repo_root = Path(__file__).parents[1]
-    github_actions_template = repo_root / "conda_smithy" / "templates" / "github-actions.yml.tmpl"
-    dependabot_inventory = repo_root / ".github" / "workflows" / "_proxy-file-for-dependabot-tests.yml"
+    github_actions_template = (
+        repo_root / "conda_smithy" / "templates" / "github-actions.yml.tmpl"
+    )
+    dependabot_inventory = (
+        repo_root
+        / ".github"
+        / "workflows"
+        / "_proxy-file-for-dependabot-tests.yml"
+    )
 
     def get_uses(path):
         content = path.read_text()
         for line in content.splitlines():
             if " uses: " in line:
                 yield line.strip().lstrip("-").strip()
-    
-    assert sorted(set(get_uses(github_actions_template))) == sorted(set(get_uses(dependabot_inventory)))
+
+    assert sorted(set(get_uses(github_actions_template))) == sorted(
+        set(get_uses(dependabot_inventory))
+    )


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->


Trying this out. I'm expecting this config to do the following:

- Update the workflows under `.github/workflows` as usual
- ~Maaaaybe pick the `github-actions.yml.tmpl` file in the templates. If that's true, we should see a PR updating `upload-artifacts`.~ It won't.
- I added a dummy workflow with the same `uses` lines as the GHA template. This will act as a proxy that we reconcile via a test with the actual template.