### PR TITLE
ENH lint for no `.ci_support` files and thus no package builds

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -1198,7 +1198,7 @@ def run_conda_forge_specific(meta, recipe_dir, lints, hints):
         )
         if not ci_support_files:
             lints.append(
-                "The feedstock has no `.ci_support` files and thus will not build any packages. "
+                "The feedstock has no `.ci_support` files and thus will not build any packages."
             )
 
 

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -1191,6 +1191,17 @@ def run_conda_forge_specific(meta, recipe_dir, lints, hints):
                 f"{', '.join(non_participating_maintainers)}. Please ask them to comment on this PR if they are."
             )
 
+    # 7: Ensure that the recipe has some .ci_support files
+    if not is_staged_recipes and recipe_dir is not None:
+        ci_support_files = glob(
+            os.path.join(recipe_dir, "..", ".ci_support", "*.yaml")
+        )
+        if not ci_support_files:
+            lints.append(
+                "The feedstock has no `.ci_support` files and thus will not build any packages. "
+                "Please check that this is the intended behavior."
+            )
+
 
 def is_selector_line(line, allow_platforms=False, allow_keys=set()):
     # Using the same pattern defined in conda-build (metadata.py),

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -1199,7 +1199,6 @@ def run_conda_forge_specific(meta, recipe_dir, lints, hints):
         if not ci_support_files:
             lints.append(
                 "The feedstock has no `.ci_support` files and thus will not build any packages. "
-                "Please check that this is the intended behavior."
             )
 
 

--- a/news/lint_no_builds.rst
+++ b/news/lint_no_builds.rst
@@ -1,0 +1,3 @@
+**Added:**
+
+* Added new lint for no ``.ci_support`` files which indicates no packages being built.

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1772,5 +1772,25 @@ class TestCLI_recipe_lint(unittest.TestCase):
             assert_jinja('{% set version= "0.27.3"%}', is_good=False)
 
 
+def test_lint_no_builds(comp_lang):
+    expected_message = "The feedstock has no `.ci_support` files and "
+
+    with tmp_directory() as feedstock_dir:
+        ci_support_dir = os.path.join(feedstock_dir, "recipe")
+        with io.open(os.path.join(ci_support_dir, "README"), "w") as fh:
+            fh.write("blah")
+        recipe_dir = os.path.join(feedstock_dir, "recipe")
+        with io.open(os.path.join(recipe_dir, "meta.yaml"), "w") as fh:
+            fh.write(
+                """
+                package:
+                   name: foo
+                """
+            )
+
+        lints = linter.main(recipe_dir)
+        assert any(lint.startswith(expected_message) for lint in lints)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1788,7 +1788,7 @@ def test_lint_no_builds(comp_lang):
                 """
             )
 
-        lints = linter.main(recipe_dir)
+        lints = linter.main(recipe_dir, conda_forge=True)
         assert any(lint.startswith(expected_message) for lint in lints)
 
 

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1777,9 +1777,11 @@ def test_lint_no_builds():
 
     with tmp_directory() as feedstock_dir:
         ci_support_dir = os.path.join(feedstock_dir, ".ci_support")
+        os.makedirs(ci_support_dir, exist_ok=True)
         with io.open(os.path.join(ci_support_dir, "README"), "w") as fh:
             fh.write("blah")
         recipe_dir = os.path.join(feedstock_dir, "recipe")
+        os.makedirs(recipe_dir, exist_ok=True)
         with io.open(os.path.join(recipe_dir, "meta.yaml"), "w") as fh:
             fh.write(
                 """

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1776,7 +1776,7 @@ def test_lint_no_builds():
     expected_message = "The feedstock has no `.ci_support` files and "
 
     with tmp_directory() as feedstock_dir:
-        ci_support_dir = os.path.join(feedstock_dir, "recipe")
+        ci_support_dir = os.path.join(feedstock_dir, ".ci_support")
         with io.open(os.path.join(ci_support_dir, "README"), "w") as fh:
             fh.write("blah")
         recipe_dir = os.path.join(feedstock_dir, "recipe")

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1791,6 +1791,12 @@ def test_lint_no_builds():
         lints = linter.main(recipe_dir, conda_forge=True)
         assert any(lint.startswith(expected_message) for lint in lints)
 
+        with io.open(os.path.join(ci_support_dir, "blah.yaml"), "w") as fh:
+            fh.write("blah")
+
+        lints = linter.main(recipe_dir, conda_forge=True)
+        assert not any(lint.startswith(expected_message) for lint in lints)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1772,7 +1772,7 @@ class TestCLI_recipe_lint(unittest.TestCase):
             assert_jinja('{% set version= "0.27.3"%}', is_good=False)
 
 
-def test_lint_no_builds(comp_lang):
+def test_lint_no_builds():
     expected_message = "The feedstock has no `.ci_support` files and "
 
     with tmp_directory() as feedstock_dir:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
xref: https://github.com/regro/cf-scripts/issues/2627