### PR TITLE
BUG: robustify CBC linter w.r.t. `or`'d selectors

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -932,10 +932,14 @@ def lintify_meta_yaml(
 
     # filter on osx-relevant lines
     pat = re.compile(
-        r"^([^\#]*?)\s+\#\s\[.*(not\s(osx|unix)|(?<!not\s)(linux|win)).*\]\s*$"
+        r"^([^:\#]*?)\s+\#\s\[.*(not\s(osx|unix)|(?<!not\s)(linux|win)).*\]\s*$"
     )
     # remove lines with selectors that don't apply to osx, i.e. if they contain
-    # "not osx", "not unix", "linux" or "win"; this also removes trailing newlines
+    # "not osx", "not unix", "linux" or "win"; this also removes trailing newlines.
+    # the regex here doesn't handle `or`-conjunctions, but the important thing for
+    # having a valid yaml after filtering below is that we avoid filtering lines with
+    # a colon (`:`), meaning that all yaml keys "survive". As an example, keys like
+    # c_stdlib_version can have `or`'d selectors, even if all values are arch-specific.
     cbc_lines_osx = [pat.sub("", x) for x in cbc_lines]
     cbc_content_osx = "\n".join(cbc_lines_osx)
     cbc_osx = get_yaml().load(cbc_content_osx) or {}

--- a/news/1939-lint-or.rst
+++ b/news/1939-lint-or.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Avoid linter failing on more complicated selector patterns in `conda_build_config.yaml`. (#1939)
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -116,12 +116,17 @@ def test_osx_noarch_hint(where):
         assert not any(h.startswith(avoid_message) for h in hints)
 
 
-@pytest.mark.parametrize("std_selector", ["unix", "linux or (osx and x86_64)"])
+@pytest.mark.parametrize(
+    "std_selector",
+    ["unix", "linux or (osx and x86_64)"],
+    ids=["plain", "or-conjunction"],
+)
 @pytest.mark.parametrize("with_linux", [True, False])
 @pytest.mark.parametrize(
     "reverse_arch",
     # we reverse x64/arm64 separately per deployment target, stdlib & sdk
     [(False, False, False), (True, True, True), (False, True, False)],
+    ids=["False", "True", "mixed"],
 )
 @pytest.mark.parametrize(
     "macdt,v_std,sdk,exp_hint",

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -116,6 +116,7 @@ def test_osx_noarch_hint(where):
         assert not any(h.startswith(avoid_message) for h in hints)
 
 
+@pytest.mark.parametrize("std_selector", ["unix", "linux or (osx and x86_64)"])
 @pytest.mark.parametrize("with_linux", [True, False])
 @pytest.mark.parametrize(
     "reverse_arch",
@@ -161,7 +162,9 @@ def test_osx_noarch_hint(where):
         (None, None, ["10.12", "11.0"], "You are"),
     ],
 )
-def test_cbc_osx_hints(with_linux, reverse_arch, macdt, v_std, sdk, exp_hint):
+def test_cbc_osx_hints(
+    std_selector, with_linux, reverse_arch, macdt, v_std, sdk, exp_hint
+):
     with tmp_directory() as rdir:
         with open(os.path.join(rdir, "meta.yaml"), "w") as fh:
             fh.write("package:\n   name: foo")
@@ -177,7 +180,7 @@ MACOSX_DEPLOYMENT_TARGET:   # [osx]
             if v_std is not None or with_linux:
                 arch1 = "arm64" if reverse_arch[1] else "x86_64"
                 arch2 = "x86_64" if reverse_arch[1] else "arm64"
-                fh.write("c_stdlib_version:           # [unix]")
+                fh.write(f"c_stdlib_version:          # [{std_selector}]")
                 if v_std is not None:
                     fh.write(f"\n  - {v_std[0]}       # [osx and {arch1}]")
                 if v_std is not None and len(v_std) > 1:


### PR DESCRIPTION
For https://github.com/conda-forge/conda-smithy/pull/1929, we needed to do some basic filtering in CBC to the platform we're looking at, in order to not produce spurious warnings. In order to keep things simple and not rewrite too much of conda-build, this was done with some simple-ish regex pattern, that however wasn't smart enough to deal with `or`-conjunctions.

I've recently hit a linter bug on the otherwise benign
```yaml
c_stdlib_version:  # [linux or (osx and x86_64)]
  - 2.17           # [linux]
  - 10.15          # [osx and x86_64]
```
and this is something we shouldn't fail on. I know how to [work around](https://github.com/conda-forge/pytorch-cpu-feedstock/pull/238/commits/bd282c8d22621ae0e639b8a6d47626499e4bbff7) it, but only because I wrote the linter rule 😅 

Fortunately, there is a simple fix that occurred to me: just don't filter out any of the yaml keys.