### PR TITLE
lint all outputs for stdlib-compilance

### DIFF
--- a/news/1941-multi-stdlib-lint.rst
+++ b/news/1941-multi-stdlib-lint.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Lint all outputs for required stdlib-fixes. (#1941)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Noticed that missing `{{ stdlib("c") }}`` in an output did not create a linter hint - this needs to be fixed, because the run-export from a global-level stdlib won't get transmitted to the outputs correctly (AFAIU).