### PR TITLE
Update Travis CI template

### DIFF
--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -10,7 +10,7 @@
     {%- do platformset.append(pfarchless) %}
   {%- endif %}
 {%- endfor %}
-language: generic
+language: shell
 
 {% if travis.secure -%}
 env:
@@ -32,7 +32,7 @@ git:
 {%- endif %}
 
 {% if configs[0] -%}
-matrix:
+jobs:
   include:
     {%- for data in configs %}
     {%- if data.build_platform.startswith("osx") %}

--- a/news/1942-travis-tmpl-update.rst
+++ b/news/1942-travis-tmpl-update.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Make recommended changes to Travis CI template. (#1942)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Travis CI **linux-ppc64le** jobs are currently failing (https://github.com/conda-forge/status/issues/178). Travis support recommended updating the config (#1940). This PR implements those changes.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords](https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes #1940.
Should resolve https://github.com/conda-forge/status/issues/178.

<!--
Please add any other relevant info below:
-->

### Testing
These changes have been tested in https://github.com/conda-forge/r-backbone-feedstock/pull/15. Some relevant documentation of the *partial* success (and previous failure):

- [full recent build history](https://app.travis-ci.com/github/conda-forge/r-backbone-feedstock/pull_requests?serverType=git)
- pre-update [example failure](https://app.travis-ci.com/github/conda-forge/r-backbone-feedstock/builds/270410159)
- post-update [example ppc64le-only passing](https://app.travis-ci.com/github/conda-forge/r-backbone-feedstock/builds/270680655?serverType=git)
- post-update [example partial passing](https://app.travis-ci.com/github/conda-forge/r-backbone-feedstock/builds/270682860?serverType=git) (1/2 ppc64le jobs ran on first try; restarted failed job led to proper start).

Also testing in https://github.com/conda-forge/r-pki-feedstock/pull/23. See [Travis CI jobs for the build](https://app.travis-ci.com/github/conda-forge/r-pki-feedstock/builds/270683890). Only 1/2 ppc64le jobs ran on first try. However, restarting individual failed job led to successful start on second try.

**Control Tests**
Just to make sure this wasn't a fluke of timing (maybe the changes weren't the cause?), I also restarted 4 failed jobs without the changes and they still all failed.

### Summary
These changes appear to only provide partial resolution. Half of the **linux-ppc64le** jobs pass, but that is a far better situation than 0% that has been the situation up to now. This seems like returning to the previous status quo where users may need to manually restart them.

I'd recommend we merge this since it at least appears to improve the situation.