### PR TITLE
BUG: fix linter failures on cb2 requirements

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -32,6 +32,7 @@ from conda_build.metadata import (
     FIELDS as cbfields,
 )
 from conda_smithy.validate_schema import validate_json_schema
+from ruamel.yaml import CommentedSeq
 
 from .utils import render_meta_yaml, get_yaml
 
@@ -899,6 +900,12 @@ def lintify_meta_yaml(
     )
     outputs = get_section(meta, "outputs", lints)
     output_reqs = [x.get("requirements", {}) for x in outputs]
+
+    # deal with cb2 recipes (no build/host/run distinction)
+    output_reqs = [
+        {"host": x, "run": x} if isinstance(x, CommentedSeq) else x
+        for x in output_reqs
+    ]
 
     # collect output requirements
     output_build_reqs = [x.get("build", []) or [] for x in output_reqs]

--- a/news/1946-lint-cb2.rst
+++ b/news/1946-lint-cb2.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Avoid linter failing on recipes using requirements without build/host/run distinction. (#1946)
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -124,6 +124,10 @@ def test_stdlib_hints_multi_output():
                     requirements:
                       run:
                         - __osx >=10.13
+                  # test that cb2-style requirements don't break linter
+                  - name: boing
+                    requirements:
+                      - bar
                 """
             )
 


### PR DESCRIPTION
The stdlib lints from #1909 that we expanded to #1941 don't work with old-style cb2 requirements. Fix it.