### PR TITLE
test: skip test that relies on GH_TOKEN if that is not set

### DIFF
--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1870,6 +1870,7 @@ class TestCLI_recipe_lint(unittest.TestCase):
             assert_jinja('{% set version= "0.27.3"%}', is_good=False)
 
 
+@unittest.skipUnless(is_gh_token_set(), "GH_TOKEN not set")
 def test_lint_no_builds():
     expected_message = "The feedstock has no `.ci_support` files and "
 


### PR DESCRIPTION
https://github.com/conda-forge/conda-smithy/commit/22a8a1dabcf81811efcf16db77563f2aeb5e1355#diff-509ad066722190140fc233360c53d9cc0e274542fe73d5a74ac76cb4dd2cc9e1R1775 introduced a new test function that calls code that relies on `GH_TOKEN` to be set and valid. The test fails when not run in GitHub actions. This PR adds the appropriate `skipUnless()` decorator. This fixes local test runs.

This is part of the STF work for Conda.