### PR TITLE
Prevent slowdown in yum due to high file descriptor count

### DIFF
--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -66,8 +66,7 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 # are drastically slowed down when the number of file descriptors is very high.
 # This can be visible during a `yum install` step of a feedstock build.
 ulimit -n 1024
-{{ yum_build_setup }}
-{% endif -%}
+{{ yum_build_setup }}{% endif -%}
 
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -62,7 +62,12 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 {% if build_setup -%}
 {{ build_setup }}{% endif -%}
 {% if yum_build_setup is defined -%}
-{{ yum_build_setup }}{% endif -%}
+# Due to https://bugzilla.redhat.com/show_bug.cgi?id=1537564 old versions of rpm
+# are drastically slowed down when the number of file descriptors is very high.
+# This can be visible during a `yum install` step of a feedstock build.
+ulimit -n 1024
+{{ yum_build_setup }}
+{% endif -%}
 
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -62,11 +62,14 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 {% if build_setup -%}
 {{ build_setup }}{% endif -%}
 {% if yum_build_setup is defined -%}
+(
 # Due to https://bugzilla.redhat.com/show_bug.cgi?id=1537564 old versions of rpm
 # are drastically slowed down when the number of file descriptors is very high.
 # This can be visible during a `yum install` step of a feedstock build.
+# => Set a lower limit in a subshell for the `yum install`s only.
 ulimit -n 1024
-{{ yum_build_setup }}{% endif -%}
+{{ yum_build_setup }}
+){% endif -%}
 
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/news/1958_yum_fix_ulimit.rst
+++ b/news/1958_yum_fix_ulimit.rst
@@ -1,0 +1,26 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Changed the build_steps.sh template so that it sets the number of maximum file
+  descriptors to 1024. This is done to mitigate a bug in old rpm versions (such
+  as the one shipped with the Centos7 container) that cause the yum install step
+  to take tremendously longer than necessary. See https://bugzilla.redhat.com/show_bug.cgi?id=1537564
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

I am one of the maintainers of the ROOT project conda-forge feedstock at https://github.com/conda-forge/root-feedstock . We make use of the `yum_requirements.txt` feature which triggers a `yum install` step in our build with the necessary package. I always noticed that this takes a huge amount of time due to [this bug](https://bugzilla.redhat.com/show_bug.cgi?id=1537564) and I always manually set the number of file descriptors when developing locally. I thought it would be a good idea to upstream this to conda-smithy. Let me know if it makes sense and if I'm missing anything relevant in the changes. Thank you so much for the great project!