### PR TITLE
HashableDict is removed in conda_build 24.7

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -17,7 +17,9 @@ from functools import lru_cache
 from itertools import chain, product
 from os import fspath
 from pathlib import Path, PurePath
+
 import requests
+from frozendict import deepfreeze
 
 try:
     from builtins import ExceptionGroup
@@ -495,7 +497,7 @@ def _merge_deployment_target(container_of_dicts, has_macdt):
         # we set MACOSX_DEPLOYMENT_TARGET to match c_stdlib_version,
         # for ease of use in conda-forge-ci-setup;
         # use new dictionary to avoid mutating existing var_dict in place
-        new_dict = conda_build.utils.HashableDict(
+        new_dict = deepfreeze(
             {
                 **var_dict,
                 "c_stdlib_version": v_stdlib,
@@ -537,11 +539,9 @@ def _collapse_subpackage_variants(
             all_used_vars.update(
                 ["mpich", "openmpi", "msmpi", "mpi_serial", "impi"]
             )
-        all_variants.update(
-            conda_build.utils.HashableDict(v) for v in meta.config.variants
-        )
+        all_variants.update(deepfreeze(v) for v in meta.config.variants)
 
-        all_variants.add(conda_build.utils.HashableDict(meta.config.variant))
+        all_variants.add(deepfreeze(meta.config.variant))
 
         if not meta.noarch:
             is_noarch = False
@@ -656,9 +656,7 @@ def _collapse_subpackage_variants(
     used_key_values = conda_build.variants.dict_of_lists_to_list_of_dicts(
         used_key_values
     )
-    used_key_values = {
-        conda_build.utils.HashableDict(variant) for variant in used_key_values
-    }
+    used_key_values = {deepfreeze(variant) for variant in used_key_values}
     used_key_values = conda_build.variants.list_of_dicts_to_dict_of_lists(
         list(used_key_values)
     )

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -19,7 +19,6 @@ from os import fspath
 from pathlib import Path, PurePath
 
 import requests
-from frozendict import deepfreeze
 
 try:
     from builtins import ExceptionGroup
@@ -61,6 +60,7 @@ from conda_smithy.validate_schema import (
 from conda_smithy.utils import (
     get_feedstock_about_from_meta,
     get_feedstock_name_from_meta,
+    HashableDict,
 )
 
 from . import __version__
@@ -497,7 +497,7 @@ def _merge_deployment_target(container_of_dicts, has_macdt):
         # we set MACOSX_DEPLOYMENT_TARGET to match c_stdlib_version,
         # for ease of use in conda-forge-ci-setup;
         # use new dictionary to avoid mutating existing var_dict in place
-        new_dict = deepfreeze(
+        new_dict = HashableDict(
             {
                 **var_dict,
                 "c_stdlib_version": v_stdlib,
@@ -539,9 +539,9 @@ def _collapse_subpackage_variants(
             all_used_vars.update(
                 ["mpich", "openmpi", "msmpi", "mpi_serial", "impi"]
             )
-        all_variants.update(deepfreeze(v) for v in meta.config.variants)
+        all_variants.update(HashableDict(v) for v in meta.config.variants)
 
-        all_variants.add(deepfreeze(meta.config.variant))
+        all_variants.add(HashableDict(meta.config.variant))
 
         if not meta.noarch:
             is_noarch = False
@@ -656,7 +656,7 @@ def _collapse_subpackage_variants(
     used_key_values = conda_build.variants.dict_of_lists_to_list_of_dicts(
         used_key_values
     )
-    used_key_values = {deepfreeze(variant) for variant in used_key_values}
+    used_key_values = {HashableDict(variant) for variant in used_key_values}
     used_key_values = conda_build.variants.list_of_dicts_to_dict_of_lists(
         list(used_key_values)
     )

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 import tempfile
 import io
@@ -149,3 +150,18 @@ def merge_dict(src, dest):
             dest[key] = value
 
     return dest
+
+
+def _json_default(obj):
+    """Accept sets for JSON"""
+    if isinstance(obj, set):
+        return sorted(obj)
+    else:
+        return obj
+
+
+class HashableDict(dict):
+    """Hashable dict so it can be in sets"""
+
+    def __hash__(self):
+        return hash(json.dumps(self, sort_keys=True, default=_json_default))

--- a/news/1967_conda-build-24.7.rst
+++ b/news/1967_conda-build-24.7.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Compatibility with conda-build 24.7, which removes HashableDict


### PR DESCRIPTION
HashableDict is [deprecated in conda-build 24.5.0](https://docs.conda.io/projects/conda-build/en/24.5.x/release-notes.html#id4) in favor of `frozendict.deepfreeze`, removed in 24.7.

ref: https://github.com/conda/conda-build/pull/5284

rerender's working for me with this change and conda-build 24.5.1.39_gc49182fe. Rerender time is reduced by about 90%  for me with 24.7.x, so I'm looking forward to this release.