### PR TITLE
Fix rattler build schema

### DIFF
--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -795,9 +795,6 @@
     "Nullable": {
       "const": null,
       "description": "Created to avoid issue with schema validation of null values in lists or dicts.",
-      "enum": [
-        null
-      ],
       "title": "Nullable"
     },
     "Platforms": {

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -42,6 +42,8 @@ conda_build_tools = Literal[
     "conda-build+conda-libmamba-solver",
     # will run 'conda mambabuild', as provided by boa
     "mambabuild",
+    # will run 'rattler-build',
+    "rattler-build",
 ]
 
 

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -42,7 +42,7 @@ conda_build_tools = Literal[
     "conda-build+conda-libmamba-solver",
     # will run 'conda mambabuild', as provided by boa
     "mambabuild",
-    # will run 'rattler-build',
+    # will run 'rattler-build build'
     "rattler-build",
 ]
 

--- a/news/1968_rattler_build_support.rst
+++ b/news/1968_rattler_build_support.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Add support for rattler-build and the new recipe format.
+* Add support for rattler-build and the new recipe format. (#1876, #1977)
 
 **Changed:**
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Added a ``news`` entry
* [X] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Follow up to https://github.com/conda-forge/conda-smithy/pull/1876, which was missing the `rattler-build` entry in `schema.py`. The change was made directly in the JSON file, which means that it will get lost in following schema regenerations.