### PR TITLE
BUG: Correctly render team urls in README Feedstock Maintainers

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2131,7 +2131,7 @@ def render_readme(jinja_env, forge_config, forge_dir, render_info=None):
     if len(forge_config["maintainers"]) > 0:
         with write_file(code_owners_file) as fh:
             line = "*"
-            for maintainer in forge_config["maintainers"]:
+            for maintainer, _ in forge_config["maintainers"]:
                 if "/" in maintainer:
                     _maintainer = maintainer.lower()
                 else:

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2092,9 +2092,12 @@ def render_readme(jinja_env, forge_config, forge_dir, render_info=None):
         )
     )
     forge_config["maintainer_urls"] = [
-        f"https://github.com/orgs/{split_name[0]}/teams/{split_name[1]}/"
-        if len(split_name) > 1
-        else f"https://github.com/{split_name[0]}/"
+        (
+            f"https://github.com/orgs/{split_name[0]}/teams/{split_name[1]}/"
+            if len(split_name) > 1
+            else f"https://github.com/{split_name[0]}/",
+            "/".join(split_name)
+        )
         for split_name in [name.split("/") for name in forge_config["maintainers"]]
     ]
 

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1998,6 +1998,14 @@ def azure_build_id_from_public(forge_config):
     forge_config["azure"]["build_id"] = build_def["id"]
 
 
+def get_maintainer_url(user_or_team):
+    if "/" in user_or_team:
+        org, team_name = user_or_team.split("/")
+        return f"https://github.com/orgs/{org}/teams/{team_name}/"
+    else:
+        return f"https://github.com/{user_or_team}/"
+
+
 def render_readme(jinja_env, forge_config, forge_dir, render_info=None):
     if "README.md" in forge_config["skip_render"]:
         logger.info("README.md rendering is skipped")
@@ -2091,18 +2099,10 @@ def render_readme(jinja_env, forge_config, forge_dir, render_info=None):
             )
         )
     )
+
     forge_config["maintainer_urls"] = [
-        (
-            (
-                f"https://github.com/orgs/{split_name[0]}/teams/{split_name[1]}/"
-                if len(split_name) > 1
-                else f"https://github.com/{split_name[0]}/"
-            ),
-            "/".join(split_name),
-        )
-        for split_name in [
-            name.split("/") for name in forge_config["maintainers"]
-        ]
+        (name, get_maintainer_url(name))
+        for name in forge_config["maintainers"]
     ]
 
     forge_config["channel_targets"] = channel_targets

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2093,12 +2093,16 @@ def render_readme(jinja_env, forge_config, forge_dir, render_info=None):
     )
     forge_config["maintainer_urls"] = [
         (
-            f"https://github.com/orgs/{split_name[0]}/teams/{split_name[1]}/"
-            if len(split_name) > 1
-            else f"https://github.com/{split_name[0]}/",
-            "/".join(split_name)
+            (
+                f"https://github.com/orgs/{split_name[0]}/teams/{split_name[1]}/"
+                if len(split_name) > 1
+                else f"https://github.com/{split_name[0]}/"
+            ),
+            "/".join(split_name),
         )
-        for split_name in [name.split("/") for name in forge_config["maintainers"]]
+        for split_name in [
+            name.split("/") for name in forge_config["maintainers"]
+        ]
     ]
 
     forge_config["channel_targets"] = channel_targets

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2091,7 +2091,8 @@ def render_readme(jinja_env, forge_config, forge_dir, render_info=None):
     forge_config["outputs"] = sorted(
         list(OrderedDict((meta.name(), None) for meta in metas))
     )
-    forge_config["maintainers"] = sorted(
+
+    maintainers = sorted(
         set(
             chain.from_iterable(
                 meta.meta["extra"].get("recipe-maintainers", [])
@@ -2100,9 +2101,9 @@ def render_readme(jinja_env, forge_config, forge_dir, render_info=None):
         )
     )
 
-    forge_config["maintainer_urls"] = [
+    forge_config["maintainers"] = [
         (name, get_maintainer_url(name))
-        for name in forge_config["maintainers"]
+        for name in mantainers
     ]
 
     forge_config["channel_targets"] = channel_targets

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2102,8 +2102,7 @@ def render_readme(jinja_env, forge_config, forge_dir, render_info=None):
     )
 
     forge_config["maintainers"] = [
-        (name, get_maintainer_url(name))
-        for name in mantainers
+        (name, get_maintainer_url(name)) for name in maintainers
     ]
 
     forge_config["channel_targets"] = channel_targets

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2091,6 +2091,13 @@ def render_readme(jinja_env, forge_config, forge_dir, render_info=None):
             )
         )
     )
+    forge_config["maintainer_urls"] = [
+        f"https://github.com/orgs/{split_name[0]}/teams/{split_name[1]}/"
+        if len(split_name) > 1
+        else f"https://github.com/{split_name[0]}/"
+        for split_name in [name.split("/") for name in forge_config["maintainers"]]
+    ]
+
     forge_config["channel_targets"] = channel_targets
 
     if forge_config["azure"].get("build_id") is None:

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -321,7 +321,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 {# this comment ensures a leading newline #}
-{%- for (maintainer, url) in maintainers|zip(maintainer_urls) %}
+{%- for (maintainer, url) in maintainer_urls %}
 * [@{{maintainer}}]({{maintainer_url}})
 {%- endfor %}
 {# this comment ensures a trailing newline #}

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -320,8 +320,8 @@ In order to produce a uniquely identifiable distribution:
 
 Feedstock Maintainers
 =====================
-{# this comment ensures a leading newline #}
-{%- for (maintainer, url) in maintainer_urls %}
+
+{% for (maintainer, url) in maintainer_urls -%}
 * [@{{maintainer}}]({{maintainer_url}})
-{%- endfor %}
+{% endfor %}
 {# this comment ensures a trailing newline #}

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -321,7 +321,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-{% for (maintainer, url) in maintainer_urls -%}
-* [@{{maintainer}}]({{maintainer_url}})
+{% for (maintainer, url) in maintainers -%}
+* [@{{maintainer}}]({{url}})
 {% endfor %}
 {# this comment ensures a trailing newline #}

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -320,8 +320,13 @@ In order to produce a uniquely identifiable distribution:
 
 Feedstock Maintainers
 =====================
-
-{% for maintainer in maintainers -%}
+{# this comment ensures a leading newline #}
+{%- for maintainer in maintainers %}
+  {%- if "/" in maintainer %}
+    {%- set team_parts = maintainer.split("/") %}
+* [@{{maintainer}}](https://github.com/orgs/{{team_parts[0]}}/teams/{{team_parts[1]}})
+  {%- else %}
 * [@{{maintainer}}](https://github.com/{{maintainer}}/)
-{% endfor %}
+  {%- endif %}
+{%- endfor %}
 {# this comment ensures a trailing newline #}

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -321,12 +321,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 {# this comment ensures a leading newline #}
-{%- for maintainer in maintainers %}
-  {%- if "/" in maintainer %}
-    {%- set team_parts = maintainer.split("/") %}
-* [@{{maintainer}}](https://github.com/orgs/{{team_parts[0]}}/teams/{{team_parts[1]}})
-  {%- else %}
-* [@{{maintainer}}](https://github.com/{{maintainer}}/)
-  {%- endif %}
+{%- for (maintainer, url) in maintainers|zip(maintainer_urls) %}
+* [@{{maintainer}}]({{maintainer_url}})
 {%- endfor %}
 {# this comment ensures a trailing newline #}

--- a/news/maintainer-urls.rst
+++ b/news/maintainer-urls.rst
@@ -1,3 +1,3 @@
 **Fixed:**
 
-* Generate correct URL for feedstock maintainer teams in feedstock READMEs
+* Generate correct URL for feedstock maintainer teams in feedstock READMEs. (#1990)

--- a/news/maintainer-urls.rst
+++ b/news/maintainer-urls.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Generate correct URL for feedstock maintainer teams in feedstock READMEs


### PR DESCRIPTION
GitHub team pages have a different URL structure than regular users. Add a conditional to the template for README Feedstock Maintainers to check for "/" and use the team URL for maintainers which contain "/" because regular user names cannot contain "/".

Closes #1989 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
