### PR TITLE
Add conda recipe format v2 stdlib lint support

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -348,7 +348,12 @@ def lintify_meta_yaml(
 
     # 5: stdlib-related lints
     lint_stdlib(
-        meta, requirements_section, conda_build_config_filename, lints, hints
+        meta,
+        requirements_section,
+        conda_build_config_filename,
+        lints,
+        hints,
+        is_rattler_build,
     )
 
     return lints, hints

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -349,6 +349,7 @@ def lintify_meta_yaml(
     # 5: stdlib-related lints
     lint_stdlib(
         meta,
+        recipe_dir,
         requirements_section,
         conda_build_config_filename,
         lints,

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -234,8 +234,12 @@ def lintify_meta_yaml(
 
     conda_build_config_filename = None
     if recipe_dir:
+        cbc_file = "conda_build_config.yaml"
+        if is_rattler_build:
+            cbc_file = "variants.yaml"
+
         conda_build_config_filename = find_local_config_file(
-            recipe_dir, "conda_build_config.yaml"
+            recipe_dir, cbc_file
         )
 
         if conda_build_config_filename:
@@ -349,7 +353,6 @@ def lintify_meta_yaml(
     # 5: stdlib-related lints
     lint_stdlib(
         meta,
-        recipe_dir,
         requirements_section,
         conda_build_config_filename,
         lints,

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -727,13 +727,15 @@ def lint_stdlib(
 ):
     global_build_reqs = requirements_section.get("build") or []
     global_run_reqs = requirements_section.get("run") or []
-    global_constraints = requirements_section.get("run_constrained") or []
     if is_rattler_build:
         global_constraints = requirements_section.get("run_constraints") or []
+    else:
+        global_constraints = requirements_section.get("run_constrained") or []
 
-    jinja_stdlib_c = '`{{ stdlib("c") }}`'
     if is_rattler_build:
         jinja_stdlib_c = '`${{ stdlib("c") }}`'
+    else:
+        jinja_stdlib_c = '`{{ stdlib("c") }}`'
 
     stdlib_lint = (
         "This recipe is using a compiler, which now requires adding a build "

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -772,13 +772,14 @@ def lint_stdlib(
     all_run_reqs_flat = global_run_reqs
     if not is_rattler_build:
         all_contraints_flat = global_constraints
-    [all_build_reqs_flat := all_build_reqs_flat + x for x in output_build_reqs]
-    [all_run_reqs_flat := all_run_reqs_flat + x for x in output_run_reqs]
+
+    def flatten_reqs(reqs):
+        return itertools.chain.from_iterable(reqs)
+
+    all_build_reqs_flat += flatten_reqs(output_build_reqs)
+    all_run_reqs_flat += flatten_reqs(output_run_reqs)
     if not is_rattler_build:
-        [
-            all_contraints_flat := all_contraints_flat + x
-            for x in output_contraints
-        ]
+        all_contraints_flat += flatten_reqs(output_contraints)
 
     # this check needs to be done per output --> use separate (unflattened) requirements
     for build_reqs in all_build_reqs:

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -763,12 +763,13 @@ def lint_stdlib(
     # collect output requirements
     output_build_reqs = [x.get("build", []) or [] for x in output_reqs]
     output_run_reqs = [x.get("run", []) or [] for x in output_reqs]
-    output_contraints = [
-        x.get("run_constrained", []) or [] for x in output_reqs
-    ]
     if is_rattler_build:
         output_contraints = [
             x.get("run_constraints", []) or [] for x in output_reqs
+        ]
+    else:
+        output_contraints = [
+            x.get("run_constrained", []) or [] for x in output_reqs
         ]
 
     # aggregate as necessary

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -892,7 +892,6 @@ def lint_stdlib(
                 "If your conda_build_config.yaml sets `MACOSX_DEPLOYMENT_TARGET`, "
                 "please change the name of that key to `c_stdlib_version`!\n"
                 "Continuing with `max(c_stdlib_version, MACOSX_DEPLOYMENT_TARGET)`."
-                "Continuing with `max(c_stdlib_version, MACOSX_DEPLOYMENT_TARGET)`."
             )
             merged_dt = []
             for v_std, v_mdt in zip(v_stdlib, macdt):

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -761,24 +761,26 @@ def lint_stdlib(
     # collect output requirements
     output_build_reqs = [x.get("build", []) or [] for x in output_reqs]
     output_run_reqs = [x.get("run", []) or [] for x in output_reqs]
-    output_contraints = [x.get("run_constrained", []) or [] for x in output_reqs]
+    output_contraints = [
+        x.get("run_constrained", []) or [] for x in output_reqs
+    ]
     if is_rattler_build:
-        output_contraints = [x.get("run_constraints", []) or [] for x in output_reqs]
+        output_contraints = [
+            x.get("run_constraints", []) or [] for x in output_reqs
+        ]
 
     # aggregate as necessary
     all_build_reqs = [global_build_reqs] + output_build_reqs
     all_build_reqs_flat = global_build_reqs
     all_run_reqs_flat = global_run_reqs
-    if not is_rattler_build:
-        all_contraints_flat = global_constraints
+    all_contraints_flat = global_constraints
 
     def flatten_reqs(reqs):
         return itertools.chain.from_iterable(reqs)
 
     all_build_reqs_flat += flatten_reqs(output_build_reqs)
     all_run_reqs_flat += flatten_reqs(output_run_reqs)
-    if not is_rattler_build:
-        all_contraints_flat += flatten_reqs(output_contraints)
+    all_contraints_flat += flatten_reqs(output_contraints)
 
     # this check needs to be done per output --> use separate (unflattened) requirements
     for build_reqs in all_build_reqs:
@@ -807,10 +809,8 @@ def lint_stdlib(
         "the respective platform as necessary. For further details, please see "
         "https://github.com/conda-forge/conda-forge.github.io/issues/2102."
     )
-    if not is_rattler_build:
-        to_check = all_run_reqs_flat + all_contraints_flat
-    else:
-        to_check = all_run_reqs_flat
+
+    to_check = all_run_reqs_flat + all_contraints_flat
     if any(req.startswith("__osx >") for req in to_check):
         if osx_lint not in lints:
             lints.append(osx_lint)

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -728,7 +728,7 @@ def lint_stdlib(
     global_build_reqs = requirements_section.get("build") or []
     global_run_reqs = requirements_section.get("run") or []
     global_constraints = requirements_section.get("run_constrained") or []
-    if not is_rattler_build:
+    if is_rattler_build:
         global_constraints = requirements_section.get("run_constraints") or []
 
     jinja_stdlib_c = '`{{ stdlib("c") }}`'
@@ -761,10 +761,9 @@ def lint_stdlib(
     # collect output requirements
     output_build_reqs = [x.get("build", []) or [] for x in output_reqs]
     output_run_reqs = [x.get("run", []) or [] for x in output_reqs]
-    if not is_rattler_build:
-        output_contraints = [
-            x.get("run_constrained", []) or [] for x in output_reqs
-        ]
+    output_contraints = [x.get("run_constrained", []) or [] for x in output_reqs]
+    if is_rattler_build:
+        output_contraints = [x.get("run_constraints", []) or [] for x in output_reqs]
 
     # aggregate as necessary
     all_build_reqs = [global_build_reqs] + output_build_reqs

--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -99,7 +99,7 @@ def get_list_section(parent, name, lints, allow_single=False):
         return [{}]
 
 
-def find_local_config_file(recipe_dir, filename):
+def find_local_config_file(recipe_dir: str, filename: str) -> Optional[str]:
     # support
     # 1. feedstocks
     # 2. staged-recipes with custom conda-forge.yaml in recipe

--- a/news/1992-lint-stdlib-v2.rst
+++ b/news/1992-lint-stdlib-v2.rst
@@ -1,0 +1,3 @@
+**Added:**
+
+* make `stdlib` linting work for v2 recipe format (#1992)

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -357,6 +357,7 @@ def test_license_file_empty(is_rattler_build):
     expected_message = "license_file entry is missing, but is required."
     assert expected_message in lints
 
+
 @pytest.mark.parametrize(
     "std_selector",
     ["unix", "linux or (osx and x86_64)"],

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -357,6 +357,143 @@ def test_license_file_empty(is_rattler_build):
     expected_message = "license_file entry is missing, but is required."
     assert expected_message in lints
 
+@pytest.mark.parametrize(
+    "std_selector",
+    ["unix", "linux or (osx and x86_64)"],
+    ids=["plain", "or-conjunction"],
+)
+@pytest.mark.parametrize("with_linux", [True, False])
+@pytest.mark.parametrize(
+    "reverse_arch",
+    # we reverse x64/arm64 separately per deployment target, stdlib & sdk
+    [(False, False, False), (True, True, True), (False, True, False)],
+    ids=["False", "True", "mixed"],
+)
+@pytest.mark.parametrize(
+    "macdt,v_std,sdk,exp_lint",
+    [
+        # matching -> no warning
+        (["10.9", "11.0"], ["10.9", "11.0"], None, None),
+        # mismatched length -> no warning (leave it to rerender)
+        (["10.9", "11.0"], ["10.9"], None, None),
+        # mismatch between stdlib and deployment target -> warn
+        (["10.9", "11.0"], ["10.13", "11.0"], None, "Conflicting spec"),
+        (["10.13", "11.0"], ["10.13", "12.3"], None, "Conflicting spec"),
+        # only deployment target -> warn
+        (["10.13", "11.0"], None, None, "In your conda_build_config.yaml"),
+        # only stdlib -> no warning
+        (None, ["10.13", "11.0"], None, None),
+        (None, ["10.15"], None, None),
+        # only stdlib, but outdated -> warn
+        (None, ["10.9", "11.0"], None, "You are"),
+        (None, ["10.9"], None, "You are"),
+        # sdk below stdlib / deployment target -> warn
+        (["10.13", "11.0"], ["10.13", "11.0"], ["10.12"], "You are"),
+        (["10.13", "11.0"], ["10.13", "11.0"], ["10.12", "12.0"], "You are"),
+        # sdk above stdlib / deployment target -> no warning
+        (["10.13", "11.0"], ["10.13", "11.0"], ["12.0", "12.0"], None),
+        # only one sdk version, not universally below deployment target
+        # -> no warning (because we don't know enough to diagnose)
+        (["10.13", "11.0"], ["10.13", "11.0"], ["10.15"], None),
+        # mismatched version + wrong sdk; requires merge logic to work before
+        # checking sdk version; to avoid unnecessary complexity in the exp_hint
+        # handling below, repeat same test twice with different expected hints
+        (["10.9", "11.0"], ["10.13", "11.0"], ["10.12"], "Conflicting spec"),
+        (["10.9", "11.0"], ["10.13", "11.0"], ["10.12"], "You are"),
+        # only sdk -> no warning
+        (None, None, ["10.13"], None),
+        (None, None, ["10.14", "12.0"], None),
+        # only sdk, but below global baseline -> warning
+        (None, None, ["10.12"], "You are"),
+        (None, None, ["10.12", "11.0"], "You are"),
+    ],
+)
+def test_rattler_cbc_osx_hints(
+    std_selector, with_linux, reverse_arch, macdt, v_std, sdk, exp_lint
+):
+    with tmp_directory() as recipe_dir:
+        recipe_dir = Path(recipe_dir)
+        recipe_dir.joinpath("recipe.yaml").write_text("package:\n   name: foo")
+
+        recipe_dir.joinpath("conda-forge.yml").write_text(
+            "conda_build_tool: rattler-build"
+        )
+
+        with open(recipe_dir / "variants.yaml", "a") as fh:
+            if macdt is not None:
+                fh.write(
+                    f"""\
+MACOSX_DEPLOYMENT_TARGET:
+  - if: osx
+    then:
+      - {macdt[0]}
+      - {macdt[1]}
+"""
+                )
+            if v_std is not None or with_linux:
+                arch1 = "arm64" if reverse_arch[1] else "x86_64"
+                arch2 = "x86_64" if reverse_arch[1] else "arm64"
+
+                fh.write("c_stdlib_version:")
+
+                if v_std is not None:
+                    fh.write(
+                        f"""
+  - if: {std_selector} and {arch1}
+    then: {v_std[0]}
+"""
+                    )
+                if v_std is not None and len(v_std) > 1:
+                    fh.write(
+                        f"""
+  - if: {std_selector} and {arch2}
+    then: {v_std[1]}
+"""
+                    )
+                if with_linux:
+                    fh.write(
+                        """
+  - if: linux
+    then: 2.17
+"""
+                    )
+            if sdk is not None:
+                # often SDK is set uniformly for osx; test this as well
+                fh.write(
+                    f"""
+MACOSX_SDK_VERSION:
+  - if: osx and {"arm64" if reverse_arch[2] else "x86_64"}
+    then: {sdk[0]}
+  - if: osx and {"x86_64" if reverse_arch[2] else "arm64"}
+    then: {sdk[1]}
+"""
+                    if len(sdk) == 2
+                    else f"""
+MACOSX_SDK_VERSION:
+  - if: osx
+    then: {sdk[0]}
+"""
+                )
+        # run the linter
+        lints, _ = linter.main(
+            recipe_dir, return_hints=True, feedstock_dir=recipe_dir
+        )
+        # show CBC/hints for debugging
+        lines = recipe_dir.joinpath("variants.yaml").read_text().splitlines()
+        print("".join(lines))
+        print(lints)
+
+        # validate against expectations
+        if exp_lint is None:
+            for slug in [
+                "Conflicting spec",
+                "You are",
+                "In your conda_build_config.yaml",
+            ]:
+                assert not any(lint.startswith(slug) for lint in lints)
+        else:
+            assert any(lint.startswith(exp_lint) for lint in lints)
+
 
 class TestLinter(unittest.TestCase):
     def test_bad_top_level(self):


### PR DESCRIPTION
~Note: the addition of `recipe_dir` in the lint_stdlib function breaks API.~

No API breaks here.