### PR TITLE
Revert "fix: regenerate schema"

### DIFF
--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -796,9 +796,6 @@
     "Nullable": {
       "const": null,
       "description": "Created to avoid issue with schema validation of null values in lists or dicts.",
-      "enum": [
-        null
-      ],
       "title": "Nullable"
     },
     "Platforms": {
@@ -1715,8 +1712,7 @@
             "conda-build",
             "conda-build+classic",
             "conda-build+conda-libmamba-solver",
-            "mambabuild",
-            "rattler-build"
+            "mambabuild"
           ],
           "type": "string"
         },

--- a/conda_smithy/data/conda-forge.yml
+++ b/conda_smithy/data/conda-forge.yml
@@ -11,19 +11,19 @@ azure:
     pool:
       vmImage: ubuntu-latest
     swapfile_size: 0GiB
-    timeout_in_minutes: 360
+    timeoutInMinutes: 360
     variables: {}
   settings_osx:
     pool:
       vmImage: macOS-12
     swapfile_size: null
-    timeout_in_minutes: 360
+    timeoutInMinutes: 360
     variables: {}
   settings_win:
     pool:
       vmImage: windows-2022
     swapfile_size: null
-    timeout_in_minutes: 360
+    timeoutInMinutes: 360
     variables:
       CONDA_BLD_PATH: D:\\bld\\
       UPLOAD_TEMP: D:\\tmp


### PR DESCRIPTION
These changes were incorrect because the azure runners expect the field name to be `timeoutInMinutes`, not `timeout_in_minutes`.