### PR TITLE
Fix: respect Pydantic aliases for default value parsing

### DIFF
--- a/conda_smithy/data/conda-forge.yml
+++ b/conda_smithy/data/conda-forge.yml
@@ -11,19 +11,19 @@ azure:
     pool:
       vmImage: ubuntu-latest
     swapfile_size: 0GiB
-    timeout_in_minutes: 360
+    timeoutInMinutes: 360
     variables: {}
   settings_osx:
     pool:
       vmImage: macOS-12
     swapfile_size: null
-    timeout_in_minutes: 360
+    timeoutInMinutes: 360
     variables: {}
   settings_win:
     pool:
       vmImage: windows-2022
     swapfile_size: null
-    timeout_in_minutes: 360
+    timeoutInMinutes: 360
     variables:
       CONDA_BLD_PATH: D:\\bld\\
       UPLOAD_TEMP: D:\\tmp

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -1277,4 +1277,4 @@ if __name__ == "__main__":
         f.write("\n")
 
     with CONDA_FORGE_YAML_DEFAULTS_FILE.open(mode="w+") as f:
-        f.write(yaml.dump(model.model_dump(), indent=2))
+        f.write(yaml.dump(model.model_dump(by_alias=True), indent=2))


### PR DESCRIPTION
This fixes the issue I have described in #1993 and adds a regression test for it.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry - nope, I think it is not necessary.
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
