### PR TITLE
remove deprecated, unused conda_interface import

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -30,7 +30,6 @@ except ImportError:
     import json
 
 import conda_build.api
-import conda_build.conda_interface
 import conda_build.render
 import conda_build.utils
 import conda_build.variants

--- a/news/2002-conda_interface.rst
+++ b/news/2002-conda_interface.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Remove import of deprecated ``conda_build.conda_interface``


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

removed in conda-build 24.7 https://github.com/conda/conda-build/pull/5333

#1868 removed this import, but it seems to have been reintroduced in the merge of #1876