### PR TITLE
Use `tlz` namespace from `toolz`

### DIFF
--- a/conda_smithy/variant_algebra.py
+++ b/conda_smithy/variant_algebra.py
@@ -17,7 +17,7 @@ from functools import partial
 from typing import Any, Dict, List, Optional, Union
 
 import conda_build.variants as variants
-import toolz
+import tlz
 import yaml
 from conda.exports import VersionOrder
 from conda_build.config import Config
@@ -344,8 +344,8 @@ def variant_add(v1: dict, v2: dict) -> Dict[str, Any]:
         )
 
     out = {
-        **toolz.keyfilter(lambda k: k in left, v1),
-        **toolz.keyfilter(lambda k: k in right, v2),
+        **tlz.keyfilter(lambda k: k in left, v1),
+        **tlz.keyfilter(lambda k: k in right, v2),
         **joint_variant,
         **special_variants,
     }

--- a/news/2006-use-tlz.rst
+++ b/news/2006-use-tlz.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Use ``tlz`` namespace from ``toolz`` ( #2006 )
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Within `toolz`, it provides a `tlz` namespace. This namespace will optionally use the performant `cytoolz` package and fallback to the pure Python `toolz` package if not.

Edit: More [details in `tlz`'s docstring]( https://github.com/pytoolz/toolz/blob/7a0382e326eb2549e4dc7b833dc666a877feca38/tlz/__init__.py#L1-L7 )

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
