### PR TITLE
fix: remove example recipe.yaml lint

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -483,19 +483,18 @@ def run_conda_forge_specific(
 
     # 4: Do not delete example recipe
     if is_staged_recipes and recipe_dir is not None:
-        for recipe_name in ("meta.yaml", "recipe.yaml"):
-            example_fname = os.path.abspath(
-                os.path.join(recipe_dir, "..", "example", recipe_name)
+        example_fname = os.path.abspath(
+            os.path.join(recipe_dir, "..", "example", "meta.yaml")
+        )
+
+        if not os.path.exists(example_fname):
+            msg = (
+                "Please do not delete the example recipe found in "
+                f"`recipes/example/{recipe_name}`."
             )
 
-            if not os.path.exists(example_fname):
-                msg = (
-                    "Please do not delete the example recipe found in "
-                    f"`recipes/example/{recipe_name}`."
-                )
-
-                if msg not in lints:
-                    lints.append(msg)
+            if msg not in lints:
+                lints.append(msg)
 
     # 5: Package-specific hints
     # (e.g. do not depend on matplotlib, only matplotlib-base)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Right now we don't have recipe.yaml in our example folder, but we lint for it. 
This lint should be removed.

Fixes https://github.com/conda-forge/staged-recipes/issues/27242
