### PR TITLE
ensure we refresh the linter hints regularly

### DIFF
--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -2,6 +2,7 @@ import copy
 import os
 import re
 import sys
+import time
 from collections.abc import Sequence
 from functools import lru_cache
 from glob import glob
@@ -208,8 +209,15 @@ def _lint_package_version(version: Optional[str]) -> Optional[str]:
         return invalid_version.format(ver=ver, err=e)
 
 
-@lru_cache(maxsize=1)
 def load_linter_toml_metdata():
+    # ensure we refresh the cache every hour
+    ttl = 3600
+    time_salt = int(time.time() / ttl)
+    return load_linter_toml_metdata_internal(time_salt)
+
+
+@lru_cache(maxsize=1)
+def load_linter_toml_metdata_internal(time_salt):
     hints_toml_url = "https://raw.githubusercontent.com/conda-forge/conda-forge-pinning-feedstock/main/recipe/linter_hints/hints.toml"
     hints_toml_req = requests.get(hints_toml_url)
     if hints_toml_req.status_code != 200:


### PR DESCRIPTION
I [noticed](https://github.com/conda-forge/conda-smithy/pull/2039#discussion_r1739942059) that the recently added `lru_cache` for getting the hints might lead to a very long time until new hints get pulled (also observed in the wild that more than 1h after merging https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6353, hints are not showing up).

Ensure we bust the cache every hour to keep things reasonably fresh.