### PR TITLE
Revert "build(deps): bump actions/upload-artifact from 4.3.4 to 4.4.0 in /.github/workflows in the github-actions group"

### DIFF
--- a/.github/workflows/_proxy-file-for-dependabot-tests.yml
+++ b/.github/workflows/_proxy-file-for-dependabot-tests.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3.0.4
-      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      - uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4


### PR DESCRIPTION
Reverts conda-forge/conda-smithy#2049