### PR TITLE
feat: enable repo branch protection by default for conda-forge

### DIFF
--- a/news/branch-protection.rst
+++ b/news/branch-protection.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Enabled branch protection for ``conda-forge`` feedstocks by default. (#)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR enables branch protection by default for conda-forge feedstocks.
