### PR TITLE
remove python 3.10 pin in `run_win_build.bat` template

### DIFF
--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -29,7 +29,7 @@ set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"
 
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
-{{ conda_install_tool }}.exe install "python=3.10" pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }} -c conda-forge --strict-channel-priority --yes
+{{ conda_install_tool }}.exe install pip {{ conda_install_tool_deps }} {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }} -c conda-forge --strict-channel-priority --yes
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 {%- if local_ci_setup %}


### PR DESCRIPTION
For https://github.com/conda-forge/google-cloud-cpp-feedstock, I need to use an older lief due to https://github.com/conda-forge/lief-feedstock/issues/45 causing the build to time out otherwise. This started failing recently, as our default python version in the image seems to have moved to 3.12, for which we have no `lief<0.14` builds. 

Once I add a `python=3.11` pin to `remote_ci_setup`, things work out again, except on windows. See the diff for https://github.com/conda-forge/google-cloud-cpp-feedstock/pull/183/commits/ae95a6d97d7e98e704b00d8a27cfa611a7a45371 in https://github.com/conda-forge/google-cloud-cpp-feedstock/pull/183

<details>

```diff
diff --git a/.scripts/build_steps.sh b/.scripts/build_steps.sh
index 4552b6d..e9a5f15 100755
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,9 +34,9 @@ CONDARC
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1

 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1" "py-lief<0.14"
+    pip mamba conda-build conda-forge-ci-setup=4 python=3.11 py-lief=0.12.3
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1" "py-lief<0.14"
+    pip mamba conda-build conda-forge-ci-setup=4 python=3.11 py-lief=0.12.3

 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
diff --git a/.scripts/run_osx_build.sh b/.scripts/run_osx_build.sh
index 9904c13..a247ce4 100755
--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,9 +26,9 @@ export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1

 mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1" "py-lief<0.14"
+    pip mamba conda-build conda-forge-ci-setup=4 python=3.11 py-lief=0.12.3
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1" "py-lief<0.14"
+    pip mamba conda-build conda-forge-ci-setup=4 python=3.11 py-lief=0.12.3



diff --git a/.scripts/run_win_build.bat b/.scripts/run_win_build.bat
index e7275f3..712b303 100755
--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -24,7 +24,7 @@ set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"

 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
-mamba.exe install "python=3.10" pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1" "py-lief<0.14" -c conda-forge --strict-channel-priority --yes
+mamba.exe install "python=3.10" pip mamba conda-build conda-forge-ci-setup=4 python=3.11 py-lief=0.12.3 -c conda-forge --strict-channel-priority --yes
 if !errorlevel! neq 0 exit /b !errorlevel!

 :: Set basic configuration
```

</details>

That's because the windows setup scripts are the only ones that contain a separate python version pin, which conflicts in this case. Remove the 3.10 pin so that this is uniform across platforms.