### PR TITLE
fix: add `--target-platform` for rattler-build invocation

### DIFF
--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -118,6 +118,7 @@ else
     {{ BUILD_CMD }} --recipe "${RECIPE_ROOT}" \
      -m "${CI_SUPPORT}/${CONFIG}.yaml" \
      ${EXTRA_CB_OPTIONS:-} \
+     --target-platform "${HOST_PLATFORM}" \
      --extra-meta flow_run_id="${flow_run_id:-}" \
      --extra-meta remote_url="${remote_url:-}" \
      --extra-meta sha="${sha:-}"

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -117,10 +117,11 @@ else
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
 
     {%- else %}
-
+    export SYSTEM_VERSION_COMPAT=0
     {{ BUILD_CMD }} --recipe ./{{ recipe_dir }} \
         -m ./.ci_support/${CONFIG}.yaml \
         --output-dir ${MINIFORGE_HOME}/conda-bld ${EXTRA_CB_OPTIONS:-} \
+        --target-platform "${HOST_PLATFORM}" \
         --extra-meta flow_run_id="$flow_run_id" \
         --extra-meta remote_url="$remote_url" \
         --extra-meta sha="$sha"

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -117,7 +117,6 @@ else
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
 
     {%- else %}
-    export SYSTEM_VERSION_COMPAT=0
     {{ BUILD_CMD }} --recipe ./{{ recipe_dir }} \
         -m ./.ci_support/${CONFIG}.yaml \
         --output-dir ${MINIFORGE_HOME}/conda-bld ${EXTRA_CB_OPTIONS:-} \

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -92,7 +92,7 @@ conda-build.exe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-varia
 {%- elif conda_build_tool == "conda-build" %}
 conda-build.exe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 {%- elif conda_build_tool == "rattler-build" %}
-conda.exe run rattler-build build --recipe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml %EXTRA_CB_OPTIONS%
+conda.exe run rattler-build build --recipe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml %EXTRA_CB_OPTIONS% --target-platform %HOST_PLATFORM%
 {%- endif %}
 if !errorlevel! neq 0 exit /b !errorlevel!
 

--- a/news/rattler-build-cross-compile.rst
+++ b/news/rattler-build-cross-compile.rst
@@ -1,4 +1,3 @@
 **Fixed:**
 
-* fix cross-compilation with rattler-build by setting `--target-platform=${HOST_PLATFORM}` and
-  exporting `SYSTEM_VERSION_COMPAT=0` in the build script.
+* fix cross-compilation with rattler-build by setting `--target-platform=${HOST_PLATFORM}`

--- a/news/rattler-build-cross-compile.rst
+++ b/news/rattler-build-cross-compile.rst
@@ -1,0 +1,4 @@
+**Fixed:**
+
+* fix cross-compilation with rattler-build by setting `--target-platform=${HOST_PLATFORM}` and
+  exporting `SYSTEM_VERSION_COMPAT=0` in the build script.


### PR DESCRIPTION
rattler-build does not read the `target_platform` from the variant config file. We need to explicitly pass it on the command line.