### PR TITLE
Bump Azure to macOS 13

### DIFF
--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -110,27 +110,15 @@
           "title": "Upload Packages"
         },
         "settings_linux": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/AzureRunnerSettings"
-            }
-          ],
+          "$ref": "#/$defs/AzureRunnerSettings",
           "description": "Linux-specific settings for runners"
         },
         "settings_osx": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/AzureRunnerSettings"
-            }
-          ],
+          "$ref": "#/$defs/AzureRunnerSettings",
           "description": "OSX-specific settings for runners"
         },
         "settings_win": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/AzureRunnerSettings"
-            }
-          ],
+          "$ref": "#/$defs/AzureRunnerSettings",
           "description": "Windows-specific settings for runners"
         },
         "user_or_org": {

--- a/conda_smithy/data/conda-forge.yml
+++ b/conda_smithy/data/conda-forge.yml
@@ -15,7 +15,7 @@ azure:
     variables: {}
   settings_osx:
     pool:
-      vmImage: macOS-12
+      vmImage: macOS-13
     swapfile_size: null
     timeoutInMinutes: 360
     variables: {}

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -198,7 +198,7 @@ class AzureConfig(BaseModel):
 
     settings_osx: AzureRunnerSettings = Field(
         default_factory=lambda: AzureRunnerSettings(
-            pool={"vmImage": "macOS-12"}
+            pool={"vmImage": "macOS-13"}
         ),
         description="OSX-specific settings for runners",
     )

--- a/news/2078-macos-13.rst
+++ b/news/2078-macos-13.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Bump Azure's ``vmImage`` to ``macOS-13``. (#2078)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry
* [X] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->


macos-12 is starting its deprecation period next Monday, and will be removed by December, with brownouts in between. See details at https://github.com/actions/runner-images/issues/10721.