### PR TITLE
Support skipping noarch selector lints

### DIFF
--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -110,15 +110,27 @@
           "title": "Upload Packages"
         },
         "settings_linux": {
-          "$ref": "#/$defs/AzureRunnerSettings",
+          "allOf": [
+            {
+              "$ref": "#/$defs/AzureRunnerSettings"
+            }
+          ],
           "description": "Linux-specific settings for runners"
         },
         "settings_osx": {
-          "$ref": "#/$defs/AzureRunnerSettings",
+          "allOf": [
+            {
+              "$ref": "#/$defs/AzureRunnerSettings"
+            }
+          ],
           "description": "OSX-specific settings for runners"
         },
         "settings_win": {
-          "$ref": "#/$defs/AzureRunnerSettings",
+          "allOf": [
+            {
+              "$ref": "#/$defs/AzureRunnerSettings"
+            }
+          ],
           "description": "Windows-specific settings for runners"
         },
         "user_or_org": {
@@ -781,12 +793,35 @@
       "title": "GithubConfig",
       "type": "object"
     },
+    "LinterConfig": {
+      "properties": {
+        "skip": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Lints"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "List of lints to skip",
+          "title": "Skip"
+        }
+      },
+      "title": "LinterConfig",
+      "type": "object"
+    },
+    "Lints": {
+      "const": "lint_noarch_selectors",
+      "title": "Lints",
+      "type": "string"
+    },
     "Nullable": {
       "const": null,
       "description": "Created to avoid issue with schema validation of null values in lists or dicts.",
-      "enum": [
-        null
-      ],
       "title": "Nullable"
     },
     "Platforms": {
@@ -1695,6 +1730,17 @@
         }
       ],
       "description": "Settings in this block are used to control how `conda build`\nruns and produces artifacts. An example of the such configuration is:\n\n```yaml\nconda_build:\n    pkg_format: 2\n    zstd_compression_level: 16\n    error_overlinking: False\n```"
+    },
+    "linter": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LinterConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Settings in this block are used to control how `conda smithy` lints\nAn example of the such configuration is:\n\n```yaml\nlinter:\n    skip:\n        - lint_noarch_selectors\n```"
     },
     "conda_build_tool": {
       "anyOf": [

--- a/conda_smithy/data/conda-forge.yml
+++ b/conda_smithy/data/conda-forge.yml
@@ -96,6 +96,8 @@ github_actions:
   triggers: []
   upload_packages: true
 idle_timeout_minutes: null
+linter:
+  skip: []
 max_py_ver: '37'
 max_r_ver: '34'
 min_py_ver: '27'

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -75,7 +75,7 @@ from conda_smithy.validate_schema import validate_json_schema
 NEEDED_FAMILIES = ["gpl", "bsd", "mit", "apache", "psf"]
 
 
-def lintify_forge_yaml(recipe_dir: Optional[str] = None) -> (list, list):
+def _get_forge_yaml(recipe_dir: Optional[str] = None) -> dict:
     if recipe_dir:
         forge_yaml_filename = (
             glob(os.path.join(recipe_dir, "..", "conda-forge.yml"))
@@ -94,6 +94,11 @@ def lintify_forge_yaml(recipe_dir: Optional[str] = None) -> (list, list):
     else:
         forge_yaml = {}
 
+    return forge_yaml
+
+
+def lintify_forge_yaml(recipe_dir: Optional[str] = None) -> (list, list):
+    forge_yaml = _get_forge_yaml(recipe_dir)
     # This is where we validate against the jsonschema and execute our custom validators.
     return validate_json_schema(forge_yaml)
 
@@ -107,6 +112,9 @@ def lintify_meta_yaml(
     lints = []
     hints = []
     major_sections = list(meta.keys())
+    lints_to_skip = (
+        _get_forge_yaml(recipe_dir).get("linter", {}).get("skip", [])
+    )
 
     # If the recipe_dir exists (no guarantee within this function) , we can
     # find the meta.yaml within it.
@@ -265,23 +273,24 @@ def lintify_meta_yaml(
 
     # 18: noarch doesn't work with selectors for runtime dependencies
     noarch_platforms = len(forge_yaml.get("noarch_platforms", [])) > 1
-    if recipe_version == 1:
-        raw_requirements_section = meta.get("requirements", {})
-        lint_recipe_v1_noarch_and_runtime_dependencies(
-            noarch_value,
-            raw_requirements_section,
-            build_section,
-            noarch_platforms,
-            lints,
-        )
-    else:
-        lint_noarch_and_runtime_dependencies(
-            noarch_value,
-            recipe_fname,
-            forge_yaml,
-            conda_build_config_keys,
-            lints,
-        )
+    if "lint_noarch_selectors" not in lints_to_skip:
+        if recipe_version == 1:
+            raw_requirements_section = meta.get("requirements", {})
+            lint_recipe_v1_noarch_and_runtime_dependencies(
+                noarch_value,
+                raw_requirements_section,
+                build_section,
+                noarch_platforms,
+                lints,
+            )
+        else:
+            lint_noarch_and_runtime_dependencies(
+                noarch_value,
+                recipe_fname,
+                forge_yaml,
+                conda_build_config_keys,
+                lints,
+            )
 
     # 19: check version
     if recipe_version == 1:

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -91,6 +91,10 @@ class BotConfigVersionUpdatesSourcesChoice(StrEnum):
     ROS_DISTRO = "rosdistro"
 
 
+class Lints(StrEnum):
+    LINT_NOARCH_SELECTORS = "lint_noarch_selectors"
+
+
 ##############################################
 ########## Model definitions #################
 ##############################################
@@ -446,6 +450,14 @@ class CondaBuildConfig(BaseModel):
     )
 
 
+class LinterConfig(BaseModel):
+
+    skip: Optional[List[Lints]] = Field(
+        default_factory=list,
+        description="List of lints to skip",
+    )
+
+
 class CondaForgeDocker(BaseModel):
     model_config: ConfigDict = ConfigDict(extra="forbid")
 
@@ -570,6 +582,22 @@ class ConfigModel(BaseModel):
             pkg_format: 2
             zstd_compression_level: 16
             error_overlinking: False
+        ```
+        """
+        ),
+    )
+
+    linter: Optional[LinterConfig] = Field(
+        default_factory=LinterConfig,
+        description=cleandoc(
+            """
+        Settings in this block are used to control how `conda smithy` lints
+        An example of the such configuration is:
+
+        ```yaml
+        linter:
+            skip:
+                - lint_noarch_selectors
         ```
         """
         ),

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1022,10 +1022,10 @@ class TestLinter(unittest.TestCase):
             def assert_noarch_selector(meta_string, is_good=False, skip=False):
                 with open(os.path.join(recipe_dir, "meta.yaml"), "w") as fh:
                     fh.write(meta_string)
-                with open(
-                    os.path.join(recipe_dir, "conda-forge.yml"), "w"
-                ) as fh:
-                    if skip:
+                if skip:
+                    with open(
+                        os.path.join(recipe_dir, "conda-forge.yml"), "w"
+                    ) as fh:
                         fh.write(
                             """
 linter:
@@ -1034,6 +1034,9 @@ linter:
 """
                         )
                 lints = linter.main(recipe_dir)
+                if skip:
+                    os.remove(os.path.join(recipe_dir, "conda-forge.yml"))
+
                 if is_good:
                     message = (
                         "Found lints when there shouldn't have "
@@ -1219,6 +1222,7 @@ linter:
                         )
 
                 lints = linter.main(recipe_dir, feedstock_dir=recipe_dir)
+                os.remove(os.path.join(recipe_dir, "conda-forge.yml"))
                 if is_good:
                     message = (
                         "Found lints when there shouldn't have "

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1019,9 +1019,20 @@ class TestLinter(unittest.TestCase):
 
         with tmp_directory() as recipe_dir:
 
-            def assert_noarch_selector(meta_string, is_good=False):
+            def assert_noarch_selector(meta_string, is_good=False, skip=False):
                 with open(os.path.join(recipe_dir, "meta.yaml"), "w") as fh:
                     fh.write(meta_string)
+                with open(
+                    os.path.join(recipe_dir, "conda-forge.yml"), "w"
+                ) as fh:
+                    if skip:
+                        fh.write(
+                            """
+linter:
+  skip:
+    - lint_noarch_selectors
+"""
+                        )
                 lints = linter.main(recipe_dir)
                 if is_good:
                     message = (
@@ -1052,6 +1063,15 @@ class TestLinter(unittest.TestCase):
                               noarch: generic
                               skip: true  # [win]
                             """
+            )
+            assert_noarch_selector(
+                """
+                            build:
+                              noarch: generic
+                              skip: true  # [win]
+                            """,
+                is_good=True,
+                skip=True,
             )
             assert_noarch_selector(
                 """
@@ -1169,7 +1189,10 @@ class TestLinter(unittest.TestCase):
         with tmp_directory() as recipe_dir:
 
             def assert_noarch_selector(
-                meta_string, is_good=False, has_noarch=False
+                meta_string,
+                is_good=False,
+                has_noarch=False,
+                skip=False,
             ):
                 with open(os.path.join(recipe_dir, "recipe.yaml"), "w") as fh:
                     fh.write(meta_string)
@@ -1184,6 +1207,14 @@ class TestLinter(unittest.TestCase):
 noarch_platforms:
   - win_64
   - linux_64
+"""
+                        )
+                    if skip:
+                        fh.write(
+                            """
+linter:
+  skip:
+    - lint_noarch_selectors
 """
                         )
 
@@ -1211,6 +1242,16 @@ noarch_platforms:
                               skip:
                                 - win
                 """
+            )
+            assert_noarch_selector(
+                """
+                            build:
+                              noarch: python
+                              skip:
+                                - win
+                """,
+                is_good=True,
+                skip=True,
             )
             assert_noarch_selector(
                 """


### PR DESCRIPTION
When building python recipes that builds a python version specific extensions and noarch python variants, the lint can be wrong. This gives a way for maintainers to skip that lint.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
