### PR TITLE
fix moji-bake with rattler-build on Windows

### DIFF
--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -92,7 +92,7 @@ conda-build.exe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-varia
 {%- elif conda_build_tool == "conda-build" %}
 conda-build.exe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 {%- elif conda_build_tool == "rattler-build" %}
-conda.exe run rattler-build build --recipe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml %EXTRA_CB_OPTIONS% --target-platform %HOST_PLATFORM%
+rattler-build.exe build --recipe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml %EXTRA_CB_OPTIONS% --target-platform %HOST_PLATFORM%
 {%- endif %}
 if !errorlevel! neq 0 exit /b !errorlevel!
 

--- a/news/gh2091.rst
+++ b/news/gh2091.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fix mojibake with rattler-build on Windows by calling the executable directly (#2091)


### PR DESCRIPTION
We were using `conda.exe run ...` to execute `rattler-build, but it does something undesirable to the current code page on Windows which leads to "Moji-bake".



When calling rattler-build directly, things seem to work much better for printing fancy tables.

Tested in https://github.com/conda-forge/jolt-physics-feedstock/pull/6

Before: 
<img width="915" alt="Screenshot 2024-10-13 at 12 08 26" src="https://github.com/user-attachments/assets/34dc4ed2-9bac-475f-b80c-4658d26d34a4">

After: 

<img width="984" alt="Screenshot 2024-10-13 at 12 08 32" src="https://github.com/user-attachments/assets/68da39e1-de13-47f8-9f0e-abd990ba141d">
