### PR TITLE
fix: add check for team existence

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -475,7 +475,9 @@ def run_conda_forge_specific(
                 )
         else:
             if not _maintainer_exists(maintainer):
-                lints.append(f'Recipe maintainer "{maintainer}" does not exist')
+                lints.append(
+                    f'Recipe maintainer "{maintainer}" does not exist'
+                )
 
     # 3: if the recipe dir is inside the example dir
     # moved to staged-recipes directly

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -473,8 +473,9 @@ def run_conda_forge_specific(
                 lints.append(
                     f'Recipe maintainer team "{maintainer}" does not exist'
                 )
-        if not _maintainer_exists(maintainer):
-            lints.append(f'Recipe maintainer "{maintainer}" does not exist')
+        else:
+            if not _maintainer_exists(maintainer):
+                lints.append(f'Recipe maintainer "{maintainer}" does not exist')
 
     # 3: if the recipe dir is inside the example dir
     # moved to staged-recipes directly

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -470,7 +470,9 @@ def run_conda_forge_specific(
     for maintainer in maintainers:
         if "/" in maintainer:
             if not _team_exists(maintainer):
-                lints.append(f'Recipe maintainer team "{maintainer}" does not exist')
+                lints.append(
+                    f'Recipe maintainer team "{maintainer}" does not exist'
+                )
         if not _maintainer_exists(maintainer):
             lints.append(f'Recipe maintainer "{maintainer}" does not exist')
 

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -413,6 +413,25 @@ def _maintainer_exists(maintainer: str) -> bool:
         )
 
 
+def _team_exists(org_team: str) -> bool:
+    """Check if a team exists on GitHub."""
+    if "GH_TOKEN" in os.environ:
+        _res = org_team.split("/", 1)
+        if len(_res) != 2:
+            return False
+        org, team = _res
+        gh = _cached_gh()
+        _org = gh.get_organization(org)
+        try:
+            _org.get_team_by_slug(team)
+        except github.UnknownObjectException:
+            return False
+        return True
+    else:
+        # we cannot check without a token
+        return True
+
+
 def run_conda_forge_specific(
     meta,
     recipe_dir,
@@ -450,8 +469,8 @@ def run_conda_forge_specific(
     # 2: Check that the recipe maintainers exists:
     for maintainer in maintainers:
         if "/" in maintainer:
-            # It's a team. Checking for existence is expensive. Skip for now
-            continue
+            if not _team_exists(maintainer):
+                lints.append(f'Recipe maintainer team "{maintainer}" does not exist')
         if not _maintainer_exists(maintainer):
             lints.append(f'Recipe maintainer "{maintainer}" does not exist')
 

--- a/news/team-exists.rst
+++ b/news/team-exists.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added check for team existence when linting. (#)
+* Added check for team existence when linting. (#2092)
 
 **Changed:**
 

--- a/news/team-exists.rst
+++ b/news/team-exists.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added check for team existence when linting. (#)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1886,11 +1886,11 @@ linter:
         self.assertIn(expected_message, lints)
 
         lints, _ = linter.lintify_meta_yaml(
-            {"extra": {"recipe-maintainers": ["conda-forge/core"]}},
+            {"extra": {"recipe-maintainers": ["conda-forge/Core"]}},
             conda_forge=True,
         )
         expected_message = (
-            'Recipe maintainer team "conda-forge/core" does not exist'
+            'Recipe maintainer team "conda-forge/Core" does not exist'
         )
         self.assertNotIn(expected_message, lints)
 

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1886,7 +1886,7 @@ linter:
         self.assertIn(expected_message, lints)
 
         lints, _ = linter.lintify_meta_yaml(
-            {"extra": {"recipe-maintainers": ["conda-forge/Core"]}},
+            {"extra": {"recipe-maintainers": ["conda-forge/core"]}},
             conda_forge=True,
         )
         expected_message = (

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1882,7 +1882,7 @@ linter:
             },
             conda_forge=True,
         )
-        expected_message = 'Recipe maintainer "conda-forge/blahblahblah-foobarblah" does not exist'
+        expected_message = 'Recipe maintainer team "conda-forge/blahblahblah-foobarblah" does not exist'
         self.assertIn(expected_message, lints)
 
         lints, _ = linter.lintify_meta_yaml(
@@ -1890,7 +1890,7 @@ linter:
             conda_forge=True,
         )
         expected_message = (
-            'Recipe maintainer "conda-forge/core" does not exist'
+            'Recipe maintainer team "conda-forge/core" does not exist'
         )
         self.assertNotIn(expected_message, lints)
 

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1871,6 +1871,29 @@ linter:
         expected_message = 'Recipe maintainer "isuruf" does not exist'
         self.assertNotIn(expected_message, lints)
 
+    def test_maintainer_team_exists(self):
+        lints, _ = linter.lintify_meta_yaml(
+            {
+                "extra": {
+                    "recipe-maintainers": [
+                        "conda-forge/blahblahblah-foobarblah"
+                    ]
+                }
+            },
+            conda_forge=True,
+        )
+        expected_message = 'Recipe maintainer "conda-forge/blahblahblah-foobarblah" does not exist'
+        self.assertIn(expected_message, lints)
+
+        lints, _ = linter.lintify_meta_yaml(
+            {"extra": {"recipe-maintainers": ["conda-forge/core"]}},
+            conda_forge=True,
+        )
+        expected_message = (
+            'Recipe maintainer "conda-forge/core" does not exist'
+        )
+        self.assertNotIn(expected_message, lints)
+
     def test_bad_subheader(self):
         expected_message = (
             "The {} section contained an unexpected "


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR adds a check for team existence when linting.

closes #2089 
