### PR TITLE
Add whey to list of known build backends for the linter

### DIFF
--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -66,6 +66,7 @@ VALID_PYTHON_BUILD_BACKENDS = [
     "scikit-build-core",
     "maturin",
     "jupyter_packaging",
+    "whey",
 ]
 
 

--- a/news/gh2094.rst
+++ b/news/gh2094.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add whey to list of known python build backends for the linter
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Follow up to #2039

I'm the maintainer of whey, and it's used by around 70 projects.
