### PR TITLE
Try to add hints pypi.io -> pypi.org.

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -29,6 +29,7 @@ from conda_smithy.linter.hints import (
     hint_pip_no_build_backend,
     hint_pip_usage,
     hint_shellcheck_usage,
+    hint_sources_should_not_mention_pypi_io_but_pypi_org,
     hint_suggest_noarch,
 )
 from conda_smithy.linter.lints import (
@@ -371,7 +372,12 @@ def lintify_meta_yaml(
     # 4: Check for SPDX
     hint_check_spdx(about_section, hints)
 
-    # 5: stdlib-related lints
+    # 5: hint pypi.io -> pypi.org
+    hint_sources_should_not_mention_pypi_io_but_pypi_org(
+        sources_section, hints
+    )
+
+    # 6: stdlib-related lints
     lint_stdlib(
         meta,
         requirements_section,

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -39,7 +39,9 @@ def hint_sources_should_not_mention_pypi_io_but_pypi_org(
     See https://github.com/conda-forge/staged-recipes/pull/27946
     """
     for source_section in sources_section:
-        if (source_section.get("url", "") or "").startswith("https://pypi.io/"):
+        if (source_section.get("url", "") or "").startswith(
+            "https://pypi.io/"
+        ):
             hints.append(
                 "PyPI default URL is now pypi.org, and not pypi.io."
                 " You may want to update the default source url."

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -39,7 +39,7 @@ def hint_sources_should_not_mention_pypi_io_but_pypi_org(
     See https://github.com/conda-forge/staged-recipes/pull/27946
     """
     for source_section in sources_section:
-        if source_section.get("url", "").startswith("https://pypi.io/"):
+        if (source_section.get("url", "") or "").startswith("https://pypi.io/"):
             hints.append(
                 "PyPI default URL is now pypi.org, and not pypi.io."
                 " You may want to update the default source url."

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 import sys
 from glob import glob
+from typing import Any, Dict, List
 
 from conda_smithy.linter import conda_recipe_v1_linter
 from conda_smithy.linter.errors import HINT_NO_ARCH
@@ -26,6 +27,25 @@ def hint_pip_usage(build_section, hints):
                     "Whenever possible python packages should use pip. "
                     "See https://conda-forge.org/docs/maintainer/adding_pkgs.html#use-pip"
                 )
+
+
+def hint_sources_should_not_mention_pypi_io_but_pypi_org(
+    sources_section: List[Dict[str, Any]], hints: List[str]
+):
+    """
+    Grayskull and conda-forge default recipe used to have pypi.io as a default,
+    but cannonical url is PyPI.org.
+
+    See https://github.com/conda-forge/staged-recipes/pull/27946
+    """
+    for source_section in sources_section:
+        if (source_section.get("url", None) is not None) and source_section[
+            "url"
+        ].startswith("https://pypi.io/"):
+            hints.append(
+                "Pypi default url is now pypi.org, and not pypi.io"
+                " you may want to update the default source url"
+            )
 
 
 def hint_suggest_noarch(

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -39,12 +39,10 @@ def hint_sources_should_not_mention_pypi_io_but_pypi_org(
     See https://github.com/conda-forge/staged-recipes/pull/27946
     """
     for source_section in sources_section:
-        if (source_section.get("url", None) is not None) and source_section[
-            "url"
-        ].startswith("https://pypi.io/"):
+        if source_section.get("url", "").startswith("https://pypi.io/"):
             hints.append(
-                "Pypi default url is now pypi.org, and not pypi.io"
-                " you may want to update the default source url"
+                "PyPI default URL is now pypi.org, and not pypi.io."
+                " You may want to update the default source url."
             )
 
 

--- a/news/gh2104-lint-pypi-io.rst
+++ b/news/gh2104-lint-pypi-io.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Hint: source url contains ``pypi.io``, and suggest ``pypi.org``
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/gh2104-lint-pypi-io.rst
+++ b/news/gh2104-lint-pypi-io.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Hint: source url contains ``pypi.io``, and suggest ``pypi.org``
+* Hint: if source url contains ``pypi.io``, suggest ``pypi.org``. (#2104)
 
 **Changed:**
 

--- a/tests/recipes/click-test-feedstock/recipe/meta.yaml
+++ b/tests/recipes/click-test-feedstock/recipe/meta.yaml
@@ -11,7 +11,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.{{ compress_type }}
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ compress_type }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ compress_type }}
   {{ hash_type }}: {{ hash_val }}
 
 build:

--- a/tests/recipes/noarch_platforms/recipe/meta.yaml
+++ b/tests/recipes/noarch_platforms/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/pytest/pytest-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/p/pytest/pytest-{{ version }}.tar.gz
   sha256: 4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39
 
 build:

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -2498,7 +2498,7 @@ def test_hint_recipe(tmp_path, yaml_block: str, expected_message: str):
     (tmp_path / "meta.yaml").write_text(yaml_block)
 
     _, hints = linter.main(tmp_path, conda_forge=False, return_hints=True)
-    assert any(list(expected_message in hint for hint in hints)
+    assert any(list(expected_message in hint for hint in hints))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -2463,7 +2463,7 @@ def test_lint_duplicate_cfyml():
 
 
 @pytest.mark.parametrize(
-    "yaml_block,annotation",
+    "yaml_block,expected_message",
     [
         pytest.param(
             """
@@ -2476,6 +2476,45 @@ def test_lint_duplicate_cfyml():
 
             source:
               url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/libconeangle-{{ version }}.tar.gz  # [unix]
+              sha256: bc828be92fdf2d2d353b5e8bb95644068220d92809276312ff2d7bca0aa8b2d1  # [unix]
+              url: https://pypi.org/packages/cp{{ CONDA_PY }}/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}-cp{{ CONDA_PY }}-cp{{ CONDA_PY }}-win_amd64.whl  # [win]
+              sha256: 467a444ca9a46675b12d43b00462052dc00a16bc322944df8053b1573a492dce  # [win and py==38]
+              sha256: b35c0643c9f1dd1c933c0a6d91b7368c32a3255e76594dea27d918b71c1166ed  # [win and py==39]
+              sha256: a32e28b3e321bdb802f28a5f04d1df65071ab42eef06a6dc15ed656780c0361e  # [win and py==310]
+            build:
+              skip: true  # [py<38 or python_impl == 'pypy' or (win and py==311)]
+              script: {{ PYTHON }} -m pip install . -vv  # [unix]
+              script_env:  # [osx and arm64]
+                - SKBUILD_CONFIGURE_OPTIONS=-DWITH_CBOOL_EXITCODE=0 -DWITH_CBOOL_EXITCODE__TRYRUN_OUTPUT='' -Df03real128_EXITCODE=1 -Df03real128_EXITCODE__TRYRUN_OUTPUT='' -Df18errorstop_EXITCODE=1 -Df18errorstop_EXITCODE__TRYRUN_OUTPUT=''  # [osx and arm64]
+              script: {{ PYTHON }} -m pip install {{ name }}-{{ version }}-cp{{ CONDA_PY }}-cp{{ CONDA_PY }}-win_amd64.whl -vv  # [win]
+              number: 3
+            """,
+            "Pypi default url is now pypi.org",
+            id="pypi.io",
+        )
+    ],
+)
+def test_hint_recipe(tmp_path, yaml_block: str, expected_message: str):
+    (tmp_path / "meta.yaml").write_text(yaml_block)
+
+    _, hints = linter.main(tmp_path, conda_forge=False, return_hints=True)
+    assert any(expected_message in hint for hint in hints)
+
+
+@pytest.mark.parametrize(
+    "yaml_block,annotation",
+    [
+        pytest.param(
+            """
+            {% set name = "libconeangle" %}
+            {% set version = "0.1.1" %}
+
+            package:
+              name: {{ name|lower }}
+              version: {{ version }}
+
+            source:
+              url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/libconeangle-{{ version }}.tar.gz  # [unix]
               sha256: bc828be92fdf2d2d353b5e8bb95644068220d92809276312ff2d7bca0aa8b2d1  # [unix]
               url: https://pypi.org/packages/cp{{ CONDA_PY }}/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}-cp{{ CONDA_PY }}-cp{{ CONDA_PY }}-win_amd64.whl  # [win]
               sha256: 467a444ca9a46675b12d43b00462052dc00a16bc322944df8053b1573a492dce  # [win and py==38]
@@ -2508,7 +2547,7 @@ def test_lint_duplicate_cfyml():
             - url: https://pypi.org/packages/{{ python_tag }}/{{ name[0] }}/{{ name }}/{{ name | replace('-', '_') }}-{{ version }}-{{ python_tag }}-none-any.whl
               sha256: "ec5ca1a55aefdd76d28fcc0b135251d156c7106fa979686a4b48d62b761b4732"
             {% else %}
-            - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+            - url: https://pypi.org.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
               sha256: ""
             {% endif %}
 

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -2489,7 +2489,7 @@ def test_lint_duplicate_cfyml():
               script: {{ PYTHON }} -m pip install {{ name }}-{{ version }}-cp{{ CONDA_PY }}-cp{{ CONDA_PY }}-win_amd64.whl -vv  # [win]
               number: 3
             """,
-            "Pypi default url is now pypi.org",
+            "PyPI default URL is now pypi.org",
             id="pypi.io",
         )
     ],

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -2547,7 +2547,7 @@ def test_hint_recipe(tmp_path, yaml_block: str, expected_message: str):
             - url: https://pypi.org/packages/{{ python_tag }}/{{ name[0] }}/{{ name }}/{{ name | replace('-', '_') }}-{{ version }}-{{ python_tag }}-none-any.whl
               sha256: "ec5ca1a55aefdd76d28fcc0b135251d156c7106fa979686a4b48d62b761b4732"
             {% else %}
-            - url: https://pypi.org.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+            - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
               sha256: ""
             {% endif %}
 

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -2498,7 +2498,7 @@ def test_hint_recipe(tmp_path, yaml_block: str, expected_message: str):
     (tmp_path / "meta.yaml").write_text(yaml_block)
 
     _, hints = linter.main(tmp_path, conda_forge=False, return_hints=True)
-    assert list(any(list(expected_message in hint for hint in hints))
+    assert any(list(expected_message in hint for hint in hints)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -2498,7 +2498,7 @@ def test_hint_recipe(tmp_path, yaml_block: str, expected_message: str):
     (tmp_path / "meta.yaml").write_text(yaml_block)
 
     _, hints = linter.main(tmp_path, conda_forge=False, return_hints=True)
-    assert any(expected_message in hint for hint in hints)
+    assert list(any(list(expected_message in hint for hint in hints))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
See also https://github.com/conda-forge/staged-recipes/pull/27946

Techically pypi.org also has a permanent redict to
files.pythonhosted.org, so we could avoid oen more redirect by hinting
pypi.org -> files.pythonhosted.org

Checklist
* [x] Added a ``news`` entry
* [x] ~Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)~

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
