### PR TITLE
Do not move micromamba cache to `%MINIFORGE_HOME%`

### DIFF
--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -30,13 +30,13 @@ certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 echo Creating environment
+{#- TODO: Set CONDA_PKGS_DIRS again when #2101 is fixed #}
+{#- set "CONDA_PKGS_DIRS=%MINIFORGE_HOME%\pkgs" #}
 call "%MICROMAMBA_EXE%" create --yes --root-prefix "%MAMBA_ROOT_PREFIX%" --prefix "%MINIFORGE_HOME%" ^
     --channel conda-forge ^
     pip {{ conda_build_tool_deps }} {{ " ".join(remote_ci_setup) }}
 if !errorlevel! neq 0 exit /b !errorlevel!
-echo Moving pkgs cache from %MAMBA_ROOT_PREFIX% to %MINIFORGE_HOME%
-move /Y "%MAMBA_ROOT_PREFIX%\pkgs" "%MINIFORGE_HOME%"
-if !errorlevel! neq 0 exit /b !errorlevel!
+{#- set "CONDA_PKGS_DIRS=" #}
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%"
 del /S /Q "%MICROMAMBA_TMPDIR%"

--- a/news/2107-micromamba-cache-windows.rst
+++ b/news/2107-micromamba-cache-windows.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Do not move ``micromamba`` cache to ``conda``'s location to avoid "permission denied" errors on Windows. (#2102 via #2107)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [X] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Patches symptom behind https://github.com/conda-forge/conda-smithy/issues/2101, but at the cost of not reusing the micromamba cache for conda-build on Windows. It should have a minor impact in the timings, given how fast the CI download is anyway. The mamba team has been notified of the issue and will be looking into it, so we can revert the workaround in the future, once fixed.

<!--
Please add any other relevant info below:
-->
