### PR TITLE
fix: only skip azure on PRs

### DIFF
--- a/conda_smithy/templates/azure-pipelines.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines.yml.tmpl
@@ -28,7 +28,7 @@ stages:
           echo "##vso[task.setvariable variable=log]$git_log"
         displayName: Obtain commit message
       - bash: echo "##vso[task.setvariable variable=RET]false"
-        condition: or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]'))
+        condition: and(eq(variables['Build.Reason'], 'PullRequest'), or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]')))
         displayName: Skip build?
       - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
         name: result

--- a/news/2110-azure-skip-only-pr.rst
+++ b/news/2110-azure-skip-only-pr.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed a bug where azure would skip commits on main if previous commit had '[ci skip]' or similar. (#2110)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

live tests:

 - tested that PR commits are skipped: https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock/pull/596/commits/ea56503a455d9a36409393ca5ac9bdde325d2e0d
 - tested that commits on main after a skipped commit run: https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock/commit/4f8106772b247f825ae9173c75c5758178ff8313 (previous commit was https://github.com/conda-forge/cf-autotick-bot-test-package-feedstock/commit/d2f8e0dd5810024e75ae1c8f082b0a654b14e5ff)
