### PR TITLE
handle source.url as list in pypi.org linter rule

### DIFF
--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -39,9 +39,9 @@ def hint_sources_should_not_mention_pypi_io_but_pypi_org(
     See https://github.com/conda-forge/staged-recipes/pull/27946
     """
     for source_section in sources_section:
-        if (source_section.get("url", "") or "").startswith(
-            "https://pypi.io/"
-        ):
+        source = source_section.get("url", "") or ""
+        sources = [source] if isinstance(source, str) else source
+        if any(s.startswith("https://pypi.io/") for s in sources):
             hints.append(
                 "PyPI default URL is now pypi.org, and not pypi.io."
                 " You may want to update the default source url."

--- a/news/2111-lint-src-url-pypi-bug.rst
+++ b/news/2111-lint-src-url-pypi-bug.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed a bug in linting rule for PyPI source urls. (#2111)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
The new linter rule (while great) doesn't take into account that a `source.url` can be a list of URLs (with fallback).

This is an issue for e.g. `selenium`, where the upstream git tag (bleargh) can be one of _either_:
- `4.26.0`
- `python-4.26.1`

Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
