### PR TITLE
feat: lint for new noarch: python syntax

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -131,10 +131,13 @@ def lintify_meta_yaml(
     )
     build_requirements = requirements_section.get("build", [])
     run_reqs = requirements_section.get("run", [])
+    host_reqs = requirements_section.get("host", [])
     if recipe_version == 1:
         test_section = get_section(meta, "tests", lints, recipe_version)
+        test_requires_section = []  # FIXME
     else:
         test_section = get_section(meta, "test", lints, recipe_version)
+        test_requires_section = test_section.get("requires", [])
     about_section = get_section(meta, "about", lints, recipe_version)
     extra_section = get_section(meta, "extra", lints, recipe_version)
     package_section = get_section(meta, "package", lints, recipe_version)
@@ -322,7 +325,13 @@ def lintify_meta_yaml(
 
     # 25: require a lower bound on python version
     lint_require_lower_bound_on_python_version(
+        host_reqs, outputs_section, noarch_value, lints
+    )
+    lint_require_lower_bound_on_python_version(
         run_reqs, outputs_section, noarch_value, lints
+    )
+    lint_require_lower_bound_on_python_version(
+        test_requires_section, outputs_section, noarch_value, lints
     )
 
     # 26: pin_subpackage is for subpackages and pin_compatible is for

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -547,17 +547,27 @@ def lint_jinja_var_references(meta_fname, hints, recipe_version: int = 0):
 def lint_require_lower_bound_on_python_version(
     run_reqs, outputs_section, noarch_value, lints
 ):
+    lint_text = (
+        "noarch: python recipes are required to follow the syntax in "
+        "[CFEP-25](https://conda-forge.org/docs/maintainer/knowledge_base/#noarch-python)."
+        "Usually, this means having `python {{ python_min }}.*` in the `host` section, "
+        "`python >={{ python_min }}` in the `run` section, and `python ={{ python_min }} "
+        "in the `requires` subsection in `test`. This syntax will be slightly different "
+        "for the newer v1 recipe format used with `recipe.yaml` files. However, you should check "
+        "upstream for the package's Python compatibility and possibhly override the `python_min` "
+        "variable if needed."
+    )
     if noarch_value == "python" and not outputs_section:
         for req in run_reqs:
-            if (req.strip().split()[0] == "python") and (req != "python"):
+            if (
+                (req.strip().split()[0] == "python")
+                and (req != "python")
+                and ("{{ python_min }}" in req)
+            ):
                 break
         else:
-            lints.append(
-                "noarch: python recipes are required to have a lower bound "
-                "on the python version. Typically this means putting "
-                "`python >=3.6` in **both** `host` and `run` but you should check "
-                "upstream for the package's Python compatibility."
-            )
+            if lint_text not in lints:
+                lints.append(lint_text)
 
 
 def lint_pin_subpackages(

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -551,7 +551,7 @@ def lint_require_lower_bound_on_python_version(
         "noarch: python recipes are required to follow the syntax in "
         "[CFEP-25](https://conda-forge.org/docs/maintainer/knowledge_base/#noarch-python)."
         "Usually, this means having `python {{ python_min }}.*` in the `host` section, "
-        "`python >={{ python_min }}` in the `run` section, and `python ={{ python_min }} "
+        "`python >={{ python_min }}` in the `run` section, and `python ={{ python_min }}` "
         "in the `requires` subsection in `test`. This syntax will be slightly different "
         "for the newer v1 recipe format used with `recipe.yaml` files. However, you should check "
         "upstream for the package's Python compatibility and possibhly override the `python_min` "

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -553,7 +553,7 @@ def lint_require_lower_bound_on_python_version(
         "Usually, this means having `python {{ python_min }}.*` in the `host` section, "
         "`python >={{ python_min }}` in the `run` section, and `python ={{ python_min }}` "
         "in the `requires` subsection in `test`. This syntax will be slightly different "
-        "for the newer v1 recipe format used with `recipe.yaml` files. However, you should check "
+        "for the newer v1 recipe format used with `recipe.yaml` files. You should check "
         "upstream for the package's Python compatibility and possibhly override the `python_min` "
         "variable if needed."
     )

--- a/news/2114-noarch_python_lint_cfep_25.rst
+++ b/news/2114-noarch_python_lint_cfep_25.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Changed the lints for ``noarch: python`` recipes to follow CFEP-25. (#2114)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1638,11 +1638,8 @@ linter:
         self.assertNotIn(expected_message, lints)
 
     def test_noarch_python_bound(self):
-        expected_message = (
-            "noarch: python recipes are required to have a lower bound "
-            "on the python version. Typically this means putting "
-            "`python >=3.6` in **both** `host` and `run` but you should check "
-            "upstream for the package's Python compatibility."
+        expected_message_start = (
+            "noarch: python recipes are required to follow the syntax in "
         )
         meta = {
             "build": {"noarch": "python"},
@@ -1656,7 +1653,9 @@ linter:
             },
         }
         lints, hints = linter.lintify_meta_yaml(meta)
-        self.assertIn(expected_message, lints)
+        self.assertTrue(
+            any(lint.startswith(expected_message_start) for lint in lints)
+        )
 
         meta = {
             "build": {"noarch": "python"},
@@ -1670,7 +1669,76 @@ linter:
             },
         }
         lints, hints = linter.lintify_meta_yaml(meta)
-        self.assertNotIn(expected_message, lints)
+        self.assertTrue(
+            any(lint.startswith(expected_message_start) for lint in lints)
+        )
+
+        meta = {
+            "build": {"noarch": "python"},
+            "requirements": {
+                "host": [
+                    "python {{ python_min }}.*",
+                ],
+                "run": [
+                    "python",
+                ],
+            },
+            "test": {"requires": ["python ={{ python_min }}"]},
+        }
+        lints, hints = linter.lintify_meta_yaml(meta)
+        self.assertTrue(
+            any(lint.startswith(expected_message_start) for lint in lints)
+        )
+
+        meta = {
+            "build": {"noarch": "python"},
+            "requirements": {
+                "host": [
+                    "python",
+                ],
+                "run": [
+                    "python >={{ python_min }}",
+                ],
+            },
+            "test": {"requires": ["python ={{ python_min }}"]},
+        }
+        lints, hints = linter.lintify_meta_yaml(meta)
+        self.assertTrue(
+            any(lint.startswith(expected_message_start) for lint in lints)
+        )
+
+        meta = {
+            "build": {"noarch": "python"},
+            "requirements": {
+                "host": [
+                    "python {{ python_min }}.*",
+                ],
+                "run": [
+                    "python >={{ python_min }}",
+                ],
+            },
+        }
+        lints, hints = linter.lintify_meta_yaml(meta)
+        self.assertTrue(
+            any(lint.startswith(expected_message_start) for lint in lints)
+        )
+
+        meta = {
+            "build": {"noarch": "python"},
+            "requirements": {
+                "host": [
+                    "python {{ python_min }}.*",
+                ],
+                "run": [
+                    "python >={{ python_min }}",
+                ],
+            },
+            "test": {"requires": ["python ={{ python_min }}"]},
+        }
+        lints, hints = linter.lintify_meta_yaml(meta)
+        self.assertFalse(
+            any(lint.startswith(expected_message_start) for lint in lints)
+        )
 
         meta = {
             "build": {"noarch": "generic"},
@@ -1684,7 +1752,9 @@ linter:
             },
         }
         lints, hints = linter.lintify_meta_yaml(meta)
-        self.assertNotIn(expected_message, lints)
+        self.assertFalse(
+            any(lint.startswith(expected_message_start) for lint in lints)
+        )
 
     def test_no_sha_with_dl(self):
         expected_message = (


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR adjust the linter for the new noarch: python syntax.
