### PR TITLE
fix: ensure noarch python hint is correct for v1 recipes

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -602,6 +602,7 @@ def run_conda_forge_specific(
         test_reqs,
         outputs_section,
         noarch_value,
+        recipe_version,
         hints,
     )
 

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -235,7 +235,13 @@ def hint_pip_no_build_backend(host_or_build_section, package_name, hints):
 
 
 def hint_noarch_python_use_python_min(
-    host_reqs, run_reqs, test_reqs, outputs_section, noarch_value, hints
+    host_reqs,
+    run_reqs,
+    test_reqs,
+    outputs_section,
+    noarch_value,
+    recipe_version,
+    hints,
 ):
     if noarch_value == "python" and not outputs_section:
         for section_name, syntax, reqs in [
@@ -243,6 +249,11 @@ def hint_noarch_python_use_python_min(
             ("run", "python >={{ python_min }}", run_reqs),
             ("test.requires", "python ={{ python_min }}", test_reqs),
         ]:
+            if recipe_version == 1:
+                syntax = syntax.replace(
+                    "{{ python_min }}", "${{ python_min }}"
+                )
+
             for req in reqs:
                 if (
                     req.strip().split()[0] == "python"

--- a/news/2119-fix-lint-noarch-python-v1.rst
+++ b/news/2119-fix-lint-noarch-python-v1.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed ``noarch: python`` hint for v1 recipes. (#2119)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

xref: https://github.com/conda-forge/staged-recipes/pull/28091