### PR TITLE
fix: use syntax for `noarch: python` min version that does not break conda-build

### DIFF
--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -244,10 +244,11 @@ def hint_noarch_python_use_python_min(
     hints,
 ):
     if noarch_value == "python" and not outputs_section:
+        hint = ""
         for section_name, syntax, reqs in [
-            ("host", "python {{ python_min }}.*", host_reqs),
+            ("host", "python {{ python_min }}", host_reqs),
             ("run", "python >={{ python_min }}", run_reqs),
-            ("test.requires", "python ={{ python_min }}", test_reqs),
+            ("test.requires", "python {{ python_min }}", test_reqs),
         ]:
             if recipe_version == 1:
                 syntax = syntax.replace(
@@ -262,10 +263,22 @@ def hint_noarch_python_use_python_min(
                 ):
                     break
             else:
-                hints.append(
-                    f"noarch: python recipes should almost always follow the syntax in "
-                    f"our [documentation](https://conda-forge.org/docs/maintainer/knowledge_base/#noarch-python). "
+                hint += (
                     f"For the `{section_name}` section of the recipe, you should almost always use `{syntax}` "
-                    f"for the `python` entry. You may need to override the `python_min` variable if the package "
-                    f"requires a newer Python version than the currently supported minimum version on `conda-forge`."
+                    f"for the `python` entry. "
                 )
+
+        if hint:
+            hint = (
+                (
+                    "noarch: python recipes should almost always follow the syntax in "
+                    "our [documentation](https://conda-forge.org/docs/maintainer/knowledge_base/#noarch-python). "
+                )
+                + hint
+                + (
+                    "You may need to override the `python_min` variable in the `conda_build_config.yaml`/`variants.yaml` "
+                    "if the package requires a newer Python version than the currently supported minimum "
+                    "version on `conda-forge`."
+                )
+            )
+            hints.append(hint)

--- a/news/2119-fix-lint-noarch-python-v1.rst
+++ b/news/2119-fix-lint-noarch-python-v1.rst
@@ -17,7 +17,7 @@
 **Fixed:**
 
 * Fixed ``noarch: python`` hint for v1 recipes. (#2119)
-* Fixed ``noarch: python`` syntax to be more compatible. (#2112)
+* Fixed ``noarch: python`` syntax to be more compatible. (#2122)
 
 **Security:**
 

--- a/news/2119-fix-lint-noarch-python-v1.rst
+++ b/news/2119-fix-lint-noarch-python-v1.rst
@@ -17,6 +17,7 @@
 **Fixed:**
 
 * Fixed ``noarch: python`` hint for v1 recipes. (#2119)
+* Fixed ``noarch: python`` syntax to be more compatible. (#2112)
 
 **Security:**
 

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -3033,9 +3033,8 @@ def test_hint_pip_no_build_backend(
                 """
             ),
             [
-                "python {{ python_min }}.*",
+                "python {{ python_min }}",
                 "python >={{ python_min }}",
-                "python ={{ python_min }}",
             ],
         ),
         (
@@ -3053,9 +3052,8 @@ def test_hint_pip_no_build_backend(
                 """
             ),
             [
-                "python {{ python_min }}.*",
+                "python {{ python_min }}",
                 "python >={{ python_min }}",
-                "python ={{ python_min }}",
             ],
         ),
         (
@@ -3073,9 +3071,8 @@ def test_hint_pip_no_build_backend(
                 """
             ),
             [
-                "python {{ python_min }}.*",
+                "python {{ python_min }}",
                 "python >={{ python_min }}",
-                "python ={{ python_min }}",
             ],
         ),
         (
@@ -3093,8 +3090,7 @@ def test_hint_pip_no_build_backend(
                 """
             ),
             [
-                "python {{ python_min }}.*",
-                "python ={{ python_min }}",
+                "python {{ python_min }}",
             ],
         ),
         (
@@ -3108,13 +3104,13 @@ def test_hint_pip_no_build_backend(
 
                 requirements:
                   host:
-                    - python {{ python_min }}.*
+                    - python {{ python_min }}
                   run:
                     - python >={{ python_min }}
                 """
             ),
             [
-                "python ={{ python_min }}",
+                "python {{ python_min }}",
             ],
         ),
         (
@@ -3128,13 +3124,13 @@ def test_hint_pip_no_build_backend(
 
                 requirements:
                   host:
-                    - python {{ python_min }}.*
+                    - python {{ python_min }}
                   run:
                     - python >={{ python_min }}
 
                 test:
                   requires:
-                    - python ={{ python_min }}
+                    - python {{ python_min }}
                 """
             ),
             [],
@@ -3150,13 +3146,13 @@ def test_hint_pip_no_build_backend(
 
                 requirements:
                   host:
-                    - python {{ python_min }}.*
+                    - python {{ python_min }}
                   run:
                     - python
 
                 test:
                   requires:
-                    - python ={{ python_min }}
+                    - python {{ python_min }}
                 """
             ),
             ["python >={{ python_min }}"],
@@ -3221,9 +3217,8 @@ def test_hint_noarch_python_use_python_min(
                 """
             ),
             [
-                "python ${{ python_min }}.*",
+                "python ${{ python_min }}",
                 "python >=${{ python_min }}",
-                "python =${{ python_min }}",
             ],
         ),
         (
@@ -3237,14 +3232,14 @@ def test_hint_noarch_python_use_python_min(
 
                 requirements:
                   host:
-                    - python ${{ python_min }}.*
+                    - python ${{ python_min }}
                   run:
                     - python >=${{ python_min }}
 
                 tests:
                   - requirements:
                       run:
-                        - python =${{ python_min }}
+                        - python ${{ python_min }}
                 """
             ),
             [],


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR moves the `noarch: python` syntax to a form that does not break older versions of conda-build. I have put in a [fix to conda-build](https://github.com/conda/conda-build/pull/5528), but we might as well use something more compatible and equivalent.
