### PR TITLE
don't log extremely verbose deletion of MAMBA_ROOT_PREFIX/MICROMAMBA_TMPDIR

### DIFF
--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -47,8 +47,8 @@ call "%MICROMAMBA_EXE%" create --yes --root-prefix "%MAMBA_ROOT_PREFIX%" --prefi
 if !errorlevel! neq 0 exit /b !errorlevel!
 {#- set "CONDA_PKGS_DIRS=" #}
 echo Removing %MAMBA_ROOT_PREFIX%
-del /S /Q "%MAMBA_ROOT_PREFIX%"
-del /S /Q "%MICROMAMBA_TMPDIR%"
+del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
+del /S /Q "%MICROMAMBA_TMPDIR%" >nul
 {%- elif conda_install_tool == "pixi" %}
 call :start_group "Provisioning base env with pixi"
 echo Installing pixi


### PR DESCRIPTION
This causes >20k lines of logs on windows that are completely pointless, e.g.
```
Removing D:\Miniforge-micromamba-1766
Deleted file - D:\Miniforge-micromamba-1766\condabin\activate.bat
Deleted file - D:\Miniforge-micromamba-1766\condabin\mamba_hook.bat
Deleted file - D:\Miniforge-micromamba-1766\condabin\micromamba.bat
Deleted file - D:\Miniforge-micromamba-1766\condabin\_mamba_activate.bat
Deleted file - D:\Miniforge-micromamba-1766\pkgs\anaconda-client-1.12.3-pyhd8ed1ab_1.conda
Deleted file - D:\Miniforge-micromamba-1766\pkgs\archspec-0.2.3-pyhd8ed1ab_0.conda
[goes on forever]
```