### PR TITLE
Make old GH action file removal relative to forge_dir

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2204,7 +2204,7 @@ def render_github_actions_services(jinja_env, forge_config, forge_dir):
         "webservices.yml",
     ]
     for filename in old_github_actions_files:
-        rel_target_fname = os.path.join(".github", "workflows", filename)
+        rel_target_fname = os.path.join(forge_dir, ".github", "workflows", filename)
         if _ignore_match(skip_files, rel_target_fname):
             continue
         remove_file(rel_target_fname)
@@ -2214,7 +2214,7 @@ def render_github_actions_services(jinja_env, forge_config, forge_dir):
     current_github_actions_files = []
     for template_file in current_github_actions_files:
         template = jinja_env.get_template(template_file + ".tmpl")
-        rel_target_fname = os.path.join(".github", "workflows", template_file)
+        rel_target_fname = os.path.join(forge_dir, ".github", "workflows", template_file)
         if _ignore_match(skip_files, rel_target_fname):
             continue
         target_fname = os.path.join(forge_dir, rel_target_fname)

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2204,7 +2204,9 @@ def render_github_actions_services(jinja_env, forge_config, forge_dir):
         "webservices.yml",
     ]
     for filename in old_github_actions_files:
-        rel_target_fname = os.path.join(forge_dir, ".github", "workflows", filename)
+        rel_target_fname = os.path.join(
+            forge_dir, ".github", "workflows", filename
+        )
         if _ignore_match(skip_files, rel_target_fname):
             continue
         remove_file(rel_target_fname)
@@ -2214,7 +2216,9 @@ def render_github_actions_services(jinja_env, forge_config, forge_dir):
     current_github_actions_files = []
     for template_file in current_github_actions_files:
         template = jinja_env.get_template(template_file + ".tmpl")
-        rel_target_fname = os.path.join(forge_dir, ".github", "workflows", template_file)
+        rel_target_fname = os.path.join(
+            forge_dir, ".github", "workflows", template_file
+        )
         if _ignore_match(skip_files, rel_target_fname):
             continue
         target_fname = os.path.join(forge_dir, rel_target_fname)

--- a/news/make-GHA-services-removal-relative.rst
+++ b/news/make-GHA-services-removal-relative.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Make old GHA removal relative to forge_dir
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
This removes the assumption that user is always
invoking conda-smithy from the repo root.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

This resolves the following issue:
```
WARNING: Setting build platform. This is only useful when pretending to be on another platform, such as for rendering necessary dependencies on a non-native platform. I trust that you know what you're doing.
WARNING: Setting build arch. This is only useful when pretending to be on another arch, such as for rendering necessary dependencies on a non-native arch. I trust that you know what you're doing.
WARNING: No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.22
Adding in variants from internal_defaults
Adding in variants from /path/to/.cache/conda-smithy/conda_build_config.yaml
Adding in variants from argument_variants
/path/to/repos/conda-forge/types-jack-client-feedstock
Traceback (most recent call last):
  File "/path/to/m3/envs/cf/bin/conda-smithy", line 10, in <module>
    sys.exit(main())
  File "/tmp/wani/1731399852/conda-smithy/conda_smithy/cli.py", line 758, in main
    args.subcommand_func(args)
  File "/tmp/wani/1731399852/conda-smithy/conda_smithy/cli.py", line 599, in __call__
    self._call(args, tmpdir)
  File "/tmp/wani/1731399852/conda-smithy/conda_smithy/cli.py", line 604, in _call
    configure_feedstock.main(
  File "/tmp/wani/1731399852/conda-smithy/conda_smithy/configure_feedstock.py", line 2836, in main
    render_github_actions_services(env, config, forge_dir)
  File "/tmp/wani/1731399852/conda-smithy/conda_smithy/configure_feedstock.py", line 2182, in render_github_actions_services
    remove_file(rel_target_fname)
  File "/tmp/wani/1731399852/conda-smithy/conda_smithy/feedstock_io.py", line 76, in remove_file
    touch_file(filename)
  File "/tmp/wani/1731399852/conda-smithy/conda_smithy/feedstock_io.py", line 62, in touch_file
    fh.write("")
  File "/path/to/m3/envs/cf/lib/python3.9/contextlib.py", line 126, in __exit__
    next(self.gen)
  File "/tmp/wani/1731399852/conda-smithy/conda_smithy/feedstock_io.py", line 57, in write_file
    repo.index.add([filename])
  File "/path/to/m3/envs/cf/lib/python3.9/site-packages/git/index/base.py", line 885, in add
    entries_added.extend(self._entries_for_paths(paths, path_rewriter, fprogress, entries))
  File "/path/to/m3/envs/cf/lib/python3.9/site-packages/git/util.py", line 176, in wrapper
    return func(self, *args, **kwargs)
  File "/path/to/m3/envs/cf/lib/python3.9/site-packages/git/index/util.py", line 111, in set_git_working_dir
    return func(self, *args, **kwargs)
  File "/path/to/m3/envs/cf/lib/python3.9/site-packages/git/index/base.py", line 745, in _entries_for_paths
    entries_added.append(self._store_path(filepath, fprogress))
  File "/path/to/m3/envs/cf/lib/python3.9/site-packages/git/index/base.py", line 689, in _store_path
    st = os.lstat(filepath)  # Handles non-symlinks as well.
FileNotFoundError: [Errno 2] No such file or directory: '.github/workflows/automerge.yml'
```
