### PR TITLE
fix: ensure linter works when python_min is set via jinja2

### DIFF
--- a/news/2132-more-noarch-bugs.rst
+++ b/news/2132-more-noarch-bugs.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed bug when linting for ``noarch: python`` syntax and using jinja2 set statements. (#2132)
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -3176,6 +3176,30 @@ def test_hint_pip_no_build_backend(
             ),
             ["python >={{ python_min }}"],
         ),
+        (
+            textwrap.dedent(
+                """
+                {% set python_min = '3.7' %}
+
+                package:
+                  name: python
+
+                build:
+                  noarch: python
+
+                requirements:
+                  host:
+                    - python {{ python_min }}
+                  run:
+                    - python >={{ python_min }}
+
+                test:
+                  requires:
+                    - python {{ python_min }}
+                """
+            ),
+            [],
+        ),
     ],
 )
 def test_hint_noarch_python_use_python_min(


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Fixing more bugz. Sigh.