### PR TITLE
fix: ensure we use CBC to parse recipe names for conda-forge

### DIFF
--- a/conda_smithy/github.py
+++ b/conda_smithy/github.py
@@ -8,7 +8,10 @@ from github.GithubException import GithubException
 from github.Organization import Organization
 from github.Team import Team
 
-from conda_smithy.configure_feedstock import _load_forge_config
+from conda_smithy.configure_feedstock import (
+    _load_forge_config,
+    get_cached_cfp_file_path,
+)
 from conda_smithy.utils import (
     _get_metadata_from_feedstock_dir,
     get_feedstock_name_from_meta,
@@ -150,7 +153,13 @@ def create_github_repo(args):
     # Load the conda-forge config and read metadata from the feedstock recipe
     forge_config = _load_forge_config(args.feedstock_directory, None)
     metadata = _get_metadata_from_feedstock_dir(
-        args.feedstock_directory, forge_config
+        args.feedstock_directory,
+        forge_config,
+        conda_forge_pinning_file=(
+            get_cached_cfp_file_path(".")
+            if args.organization == "conda-forge"
+            else None
+        ),
     )
 
     feedstock_name = get_feedstock_name_from_meta(metadata)

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -14,6 +14,7 @@ import jinja2
 import jinja2.sandbox
 import ruamel.yaml
 from conda_build.api import render as conda_build_render
+from conda_build.config import Config
 from conda_build.render import MetaData
 from rattler_build_conda_compat.render import MetaData as RattlerBuildMetaData
 
@@ -23,7 +24,9 @@ SET_PYTHON_MIN_RE = re.compile(r"{%\s+set\s+python_min\s+=")
 
 
 def _get_metadata_from_feedstock_dir(
-    feedstock_directory: Union[str, os.PathLike], forge_config: Dict[str, Any]
+    feedstock_directory: Union[str, os.PathLike],
+    forge_config: Dict[str, Any],
+    conda_forge_pinning_file: Union[str, os.PathLike, None] = None,
 ) -> Union[MetaData, RattlerBuildMetaData]:
     """
     Return either the conda-build metadata or rattler-build metadata from the feedstock directory
@@ -35,9 +38,15 @@ def _get_metadata_from_feedstock_dir(
             feedstock_directory,
         )
     else:
+        if conda_forge_pinning_file:
+            config = Config(
+                variant_config_files=[conda_forge_pinning_file],
+            )
+        else:
+            config = None
         meta = conda_build_render(
             feedstock_directory,
-            permit_undefined_jinja=True,
+            config=config,
             finalize=False,
             bypass_env_check=True,
             trim_skip=False,

--- a/news/noarch_create_feedstocks.rst
+++ b/news/noarch_create_feedstocks.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed a bug where creating feedstocks with `noarch: python` would not work correctly. (#2135)
+
+**Security:**
+
+* <news item>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,11 @@ def recipe_dirname():
 
 @pytest.fixture(scope="function", params=["conda-build", "rattler-build"])
 def config_yaml(testing_workdir, recipe_dirname, request):
-    config = {"python": ["2.7", "3.5"], "r_base": ["3.3.2", "3.4.2"]}
+    config = {
+        "python": ["2.7", "3.5"],
+        "r_base": ["3.3.2", "3.4.2"],
+        "python_min": ["2.7"],
+    }
     os.makedirs(os.path.join(testing_workdir, recipe_dirname))
     with open(os.path.join(testing_workdir, "config.yaml"), "w") as f:
         f.write("docker:\n")
@@ -138,6 +142,43 @@ requirements:
         - python
     run:
         - python
+    """
+        )
+    return RecipeConfigPair(
+        str(config_yaml.workdir),
+        _load_forge_config(
+            config_yaml.workdir,
+            exclusive_config_file=os.path.join(
+                config_yaml.workdir, recipe_dirname, "default_config.yaml"
+            ),
+        ),
+    )
+
+
+@pytest.fixture(scope="function")
+def noarch_recipe_with_python_min(config_yaml: ConfigYAML, recipe_dirname):
+    if config_yaml.type == "rattler-build":
+        jinjatxt = "${{ python_min }}"
+    else:
+        jinjatxt = "{{ python_min }}"
+    with open(
+        os.path.join(
+            config_yaml.workdir, recipe_dirname, config_yaml.recipe_name
+        ),
+        "w",
+    ) as fh:
+        fh.write(
+            f"""\
+package:
+    name: python-noarch-test
+    version: 1.0.0
+build:
+    noarch: python
+requirements:
+    host:
+        - python {jinjatxt}
+    run:
+        - python >={jinjatxt}
     """
         )
     return RecipeConfigPair(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,6 +23,32 @@ def test_get_metadata_from_feedstock_dir(noarch_recipe):
     assert isinstance(metadata, expected_metadata_type)
 
 
+def test_get_metadata_from_feedstock_dir_jinja2(noarch_recipe_with_python_min):
+    feedstock_dir = noarch_recipe_with_python_min[0]
+
+    build_tool = noarch_recipe_with_python_min[1]["conda_build_tool"]
+    metadata = _get_metadata_from_feedstock_dir(
+        feedstock_dir,
+        noarch_recipe_with_python_min[1],
+        conda_forge_pinning_file=noarch_recipe_with_python_min[1][
+            "exclusive_config_file"
+        ],
+    )
+
+    expected_metadata_type = (
+        RatlerBuildMetadata if build_tool == RATTLER_BUILD else MetaData
+    )
+
+    if build_tool == RATTLER_BUILD:
+        assert metadata.meta["requirements"]["host"] == [
+            "python ${{ python_min }}"
+        ]
+    else:
+        assert metadata.meta["requirements"]["host"] == ["python 2.7"]
+
+    assert isinstance(metadata, expected_metadata_type)
+
+
 def test_get_feedstock_name_from_metadata(noarch_recipe):
     feedstock_dir = noarch_recipe[0]
     metadata = _get_metadata_from_feedstock_dir(


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR ensures we use the pinnings file when parsing recipe names for conda-forge. It helps avoid undefined jinja2 errors and badly formatted spec errors.
