### PR TITLE
MNT: Default to '--no-deps --no-build-isolation' for Python build scripts

### DIFF
--- a/conda_smithy/templates/meta.yaml.ci-skel.tmpl
+++ b/conda_smithy/templates/meta.yaml.ci-skel.tmpl
@@ -26,7 +26,7 @@ build:
   # and for all major OSs. Add the line "skip: True  # [py<35]" (for example)
   # to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit
   # to Windows.
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
 
 requirements:
   build:

--- a/news/pip-no-deps-no-build-isolation.rst
+++ b/news/pip-no-deps-no-build-isolation.rst
@@ -1,0 +1,3 @@
+**Added:**
+
+* Add ``--no-deps --no-build-isolation`` ``pip`` install options to ensure all ``build-system`` dependencies are included as ``host`` requirements.

--- a/tests/test_ci_skeleton.py
+++ b/tests/test_ci_skeleton.py
@@ -42,7 +42,7 @@ build:
   # and for all major OSs. Add the line "skip: True  # [py<35]" (for example)
   # to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit
   # to Windows.
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
 
 requirements:
   build:

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -2502,10 +2502,10 @@ def test_lint_duplicate_cfyml():
               sha256: a32e28b3e321bdb802f28a5f04d1df65071ab42eef06a6dc15ed656780c0361e  # [win and py==310]
             build:
               skip: true  # [py<38 or python_impl == 'pypy' or (win and py==311)]
-              script: {{ PYTHON }} -m pip install . -vv  # [unix]
+              script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation  # [unix]
               script_env:  # [osx and arm64]
                 - SKBUILD_CONFIGURE_OPTIONS=-DWITH_CBOOL_EXITCODE=0 -DWITH_CBOOL_EXITCODE__TRYRUN_OUTPUT='' -Df03real128_EXITCODE=1 -Df03real128_EXITCODE__TRYRUN_OUTPUT='' -Df18errorstop_EXITCODE=1 -Df18errorstop_EXITCODE__TRYRUN_OUTPUT=''  # [osx and arm64]
-              script: {{ PYTHON }} -m pip install {{ name }}-{{ version }}-cp{{ CONDA_PY }}-cp{{ CONDA_PY }}-win_amd64.whl -vv  # [win]
+              script: {{ PYTHON }} -m pip install {{ name }}-{{ version }}-cp{{ CONDA_PY }}-cp{{ CONDA_PY }}-win_amd64.whl -vv --no-deps --no-build-isolation  # [win]
               number: 3
             """,
             "PyPI default URL is now pypi.org",
@@ -2541,10 +2541,10 @@ def test_hint_recipe(tmp_path, yaml_block: str, expected_message: str):
               sha256: a32e28b3e321bdb802f28a5f04d1df65071ab42eef06a6dc15ed656780c0361e  # [win and py==310]
             build:
               skip: true  # [py<38 or python_impl == 'pypy' or (win and py==311)]
-              script: {{ PYTHON }} -m pip install . -vv  # [unix]
+              script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation  # [unix]
               script_env:  # [osx and arm64]
                 - SKBUILD_CONFIGURE_OPTIONS=-DWITH_CBOOL_EXITCODE=0 -DWITH_CBOOL_EXITCODE__TRYRUN_OUTPUT='' -Df03real128_EXITCODE=1 -Df03real128_EXITCODE__TRYRUN_OUTPUT='' -Df18errorstop_EXITCODE=1 -Df18errorstop_EXITCODE__TRYRUN_OUTPUT=''  # [osx and arm64]
-              script: {{ PYTHON }} -m pip install {{ name }}-{{ version }}-cp{{ CONDA_PY }}-cp{{ CONDA_PY }}-win_amd64.whl -vv  # [win]
+              script: {{ PYTHON }} -m pip install {{ name }}-{{ version }}-cp{{ CONDA_PY }}-cp{{ CONDA_PY }}-win_amd64.whl -vv --no-deps --no-build-isolation  # [win]
               number: 3
             """,
             "lint",
@@ -2574,9 +2574,9 @@ def test_hint_recipe(tmp_path, yaml_block: str, expected_message: str):
               noarch: python
               number: 0
               {% if use_wheel %}
-              script: "{{ PYTHON }} -m pip install --no-deps --ignore-installed --no-cache-dir -vvv *.whl"
+              script: "{{ PYTHON }} -m pip install --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv *.whl"
               {% else %}
-              script: "{{ PYTHON }} -m pip install --no-deps --ignore-installed --no-cache-dir -vvv ."
+              script: "{{ PYTHON }} -m pip install --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv ."
               {% endif %}
             """,
             "hint",
@@ -2600,7 +2600,7 @@ def test_hint_recipe(tmp_path, yaml_block: str, expected_message: str):
               noarch: python
               entry_points:
                 - weasyprint = weasyprint.__main__:main
-              script: {{ PYTHON }} -m pip install {{ name|lower }}-{{ version }}-py3-none-any.whl -vv
+              script: {{ PYTHON }} -m pip install {{ name|lower }}-{{ version }}-py3-none-any.whl -vv --no-deps --no-build-isolation
             """,
             "hint",
             id="weasyprint",


### PR DESCRIPTION
Resolves #2136 

* Add `--no-deps --no-build-isolation` to pip installs for scripts to ensure that all `build-system` dependencies are included as `host` requirements.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [N/A] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
