### PR TITLE
feat: add lint+hint for recipe parsing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,12 +27,16 @@ jobs:
           environment-file: environment.yml
           cache-environment: true
           create-args: >-
-            python=3.8
+            python=3.11
             coverage
             coveralls
+            conda-recipe-manager
+            conda-souschef
+            conda-forge-tick
 
       - name: install conda-smithy
         run: |
+          conda uninstall --force --yes conda-smithy
           python -m pip install -v --no-build-isolation -e .
           git config --global user.email "smithy@smithy.smithy"
           git config --global user.name "smithy"

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -609,10 +609,10 @@ def run_conda_forge_specific(
 
     # 11: ensure we can parse the recipe
     if recipe_version == 1:
-        with open(os.path.join(recipe_dir, "recipe.yaml")) as fh:
+        with open(os.path.join(recipe_dir or "", "recipe.yaml")) as fh:
             recipe_text = fh.read()
     else:
-        with open(os.path.join(recipe_dir, "meta.yaml")) as fh:
+        with open(os.path.join(recipe_dir or "", "meta.yaml")) as fh:
             recipe_text = fh.read()
     lint_recipe_is_parsable(
         recipe_text,

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -609,17 +609,19 @@ def run_conda_forge_specific(
 
     # 11: ensure we can parse the recipe
     if recipe_version == 1:
-        with open(os.path.join(recipe_dir or "", "recipe.yaml")) as fh:
-            recipe_text = fh.read()
+        recipe_fname = os.path.join(recipe_dir or "", "recipe.yaml")
     else:
-        with open(os.path.join(recipe_dir or "", "meta.yaml")) as fh:
+        recipe_fname = os.path.join(recipe_dir or "", "meta.yaml")
+
+    if os.path.exists(recipe_fname):
+        with open() as fh:
             recipe_text = fh.read()
-    lint_recipe_is_parsable(
-        recipe_text,
-        lints,
-        hints,
-        recipe_version=recipe_version,
-    )
+        lint_recipe_is_parsable(
+            recipe_text,
+            lints,
+            hints,
+            recipe_version=recipe_version,
+        )
 
 
 def _format_validation_msg(error: jsonschema.ValidationError):

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -51,6 +51,7 @@ from conda_smithy.linter.lints import (
     lint_package_version,
     lint_pin_subpackages,
     lint_recipe_have_tests,
+    lint_recipe_is_parsable,
     lint_recipe_maintainers,
     lint_recipe_name,
     lint_recipe_v1_noarch_and_runtime_dependencies,
@@ -604,6 +605,20 @@ def run_conda_forge_specific(
         noarch_value,
         recipe_version,
         hints,
+    )
+
+    # 11: ensure we can parse the recipe
+    if recipe_version == 1:
+        with open(os.path.join(recipe_dir, "recipe.yaml")) as fh:
+            recipe_text = fh.read()
+    else:
+        with open(os.path.join(recipe_dir, "meta.yaml")) as fh:
+            recipe_text = fh.read()
+    lint_recipe_is_parsable(
+        recipe_text,
+        lints,
+        hints,
+        recipe_version=recipe_version,
     )
 
 

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -614,7 +614,7 @@ def run_conda_forge_specific(
         recipe_fname = os.path.join(recipe_dir or "", "meta.yaml")
 
     if os.path.exists(recipe_fname):
-        with open() as fh:
+        with open(recipe_fname) as fh:
             recipe_text = fh.read()
         lint_recipe_is_parsable(
             recipe_text,

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -1006,7 +1006,7 @@ def lint_recipe_is_parsable(
             pass
         else:
             try:
-                CondaMetaYAML(recipe_text, recipe_version)
+                CondaMetaYAML(recipe_text)
             except Exception as e:
                 logger.warning(
                     "Error parsing recipe with conda-forge-tick (the bot): %s",
@@ -1079,7 +1079,7 @@ def lint_recipe_is_parsable(
             for pv, parser_name in zip(parse_vars, parser_names):
                 if pv is False:
                     hints.append(
-                        f"The recipe is not parsable by `{parser_name}`. Your recipe "
+                        f"The recipe is not parsable by parser `{parser_name}`. Your recipe "
                         "may not receive automatic updates and/or may not be compatible "
                         "with conda-forge's infrastructure. Please check the logs for "
                         "more information and ensure your recipe can be parsed."

--- a/news/2141-recipe-parsing-lint-hint.rst
+++ b/news/2141-recipe-parsing-lint-hint.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added new ``conda-forge``-only hint+lint for recipe be able to be parsed. (#2141)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -3466,5 +3466,45 @@ def test_lint_recipe_parses_spacing():
         )
 
 
+def test_lint_recipe_parses_v1_spacing():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:
+            f.write(
+                textwrap.dedent(
+                    """
+                    package:
+                      name: blah
+
+                    build:
+                        number: ${{ build }}
+
+                    about:
+                      home: something
+                      license: MIT
+                      license_file: LICENSE
+                      summary: a test recipe
+
+                    extra:
+                      recipe-maintainers:
+                        - a
+                        - b
+                    """
+                )
+            )
+        lints, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
+        assert any(
+            lint.startswith(
+                "The recipe is not parsable by any of the known recipe parsers"
+            )
+            for lint in lints
+        )
+        assert any(
+            hint.startswith(
+                "The recipe is not parsable by parser `conda-recipe-manager"
+            )
+            for hint in hints
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -3351,11 +3351,11 @@ def test_lint_recipe_parses_ok():
                 "The recipe is not parsable by any of the known recipe parsers"
             )
             for lint in lints
-        )
+        ), lints
         assert not any(
             hint.startswith("The recipe is not parsable by parser")
             for hint in hints
-        )
+        ), hints
 
 
 def test_lint_recipe_parses_forblock():
@@ -3392,25 +3392,25 @@ def test_lint_recipe_parses_forblock():
                 "The recipe is not parsable by any of the known recipe parsers"
             )
             for lint in lints
-        )
+        ), lints
         assert not any(
             hint.startswith(
                 "The recipe is not parsable by parser `conda-forge-tick"
             )
             for hint in hints
-        )
+        ), hints
         assert any(
             hint.startswith(
                 "The recipe is not parsable by parser `conda-recipe-manager"
             )
             for hint in hints
-        )
+        ), hints
         assert not any(
             hint.startswith(
                 "The recipe is not parsable by parser `conda-souschef"
             )
             for hint in hints
-        )
+        ), hints
 
 
 def test_lint_recipe_parses_spacing():
@@ -3445,25 +3445,25 @@ def test_lint_recipe_parses_spacing():
                 "The recipe is not parsable by any of the known recipe parsers"
             )
             for lint in lints
-        )
+        ), lints
         assert not any(
             hint.startswith(
                 "The recipe is not parsable by parser `conda-forge-tick"
             )
             for hint in hints
-        )
+        ), hints
         assert any(
             hint.startswith(
                 "The recipe is not parsable by parser `conda-recipe-manager"
             )
             for hint in hints
-        )
+        ), hints
         assert not any(
             hint.startswith(
                 "The recipe is not parsable by parser `conda-souschef"
             )
             for hint in hints
-        )
+        ), hints
 
 
 def test_lint_recipe_parses_v1_spacing():
@@ -3497,13 +3497,13 @@ def test_lint_recipe_parses_v1_spacing():
                 "The recipe is not parsable by any of the known recipe parsers"
             )
             for lint in lints
-        )
+        ), lints
         assert any(
             hint.startswith(
                 "The recipe is not parsable by parser `conda-recipe-manager"
             )
             for hint in hints
-        )
+        ), hints
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR is a good step for moving towards v1 recipes. We'll need recipes to be able to be parsed by CRM in order to try automatic conversion. I also included the bot's parser and the one used by grayskull.

closes #2140 