### PR TITLE
Make sure $MINIFORGE_HOME exists during osx build

### DIFF
--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -8,6 +8,8 @@ set -xe
 
 MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
 MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
+mkdir -p ${MINIFORGE_HOME}
+
 {%- if conda_install_tool == "micromamba" %}
 
 ( startgroup "Provisioning base env with micromamba" ) 2> /dev/null

--- a/news/pixi_osx.rst
+++ b/news/pixi_osx.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Make sure $MINIFORGE_HOME folder exists during build.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I noticed this issue when using pixi as conda install tool. The `mkdir` command is outside the pixi condition but I can also move it inside it if you prefer. Let me know.