### PR TITLE
add option to install ATL components

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1837,6 +1837,7 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
 
     azure_settings = deepcopy(forge_config["azure"][f"settings_{platform}"])
     azure_settings.pop("swapfile_size", None)
+    azure_settings.pop("install_atl", None)
     azure_settings.setdefault("strategy", {})
     azure_settings["strategy"].setdefault("matrix", {})
 

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -124,6 +124,11 @@ class AzureRunnerSettings(BaseModel):
         default_factory=dict, description="Variables"
     )
 
+    # windows only
+    install_atl: Optional[bool] = Field(
+        default=False, description="Whether to install ATL components for MSVC"
+    )
+
 
 class AzureFreeDiskSpaceConfig(StrEnum):
     CACHE = "cache"
@@ -209,6 +214,7 @@ class AzureConfig(BaseModel):
 
     settings_win: AzureRunnerSettings = Field(
         default_factory=lambda: AzureRunnerSettings(
+            install_atl=False,
             pool={"vmImage": "windows-2022"},
             variables={
                 "MINIFORGE_HOME": "D:\\Miniforge",
@@ -218,7 +224,12 @@ class AzureConfig(BaseModel):
         ),
         description=cleandoc(
             """
-            Windows-specific settings for runners. Some important variables you can set are:
+            Windows-specific settings for runners. Aside from overriding the `vmImage`,
+            you can also specify `install_atl: true` in case you need the ATL components
+            for MSVC; these don't get installed by default anymore, see
+            https://github.com/actions/runner-images/issues/9873
+
+            Finally, under `variables`, some important things you can set are:
 
             - `CONDA_BLD_PATH`: Location of the conda-build workspace. Defaults to `D:\\bld`
             - `MINIFORGE_HOME`: Location of the base environment installation. Defaults to

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -16,6 +16,38 @@ jobs:
       displayName: "Install Chocolatey Package: {{ choco_pkg }}"
 {% endfor %}
 
+{%- if azure.settings_win.install_atl %}
+    - powershell: |
+        Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+        $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+        $componentsToRemove= @(
+            "Microsoft.VisualStudio.Component.VC.ATL"
+            "Microsoft.VisualStudio.Component.VC.ATLMFC"
+            "Microsoft.VisualStudio.Component.VC.ATLMFC.Spectre"
+        )
+        [string]$workloadArgs = $componentsToRemove | ForEach-Object {" --remove " +  $_}
+        $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
+        # should be run twice
+        $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+        $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+
+    - powershell: |
+        Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+        $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+        $componentsToRemove= @(
+          "Microsoft.VisualStudio.Component.VC.v141.ATL"
+          "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL"
+          "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL.Spectre"
+          "Microsoft.VisualStudio.Component.VC.14.29.16.11.MFC"
+          "Microsoft.VisualStudio.Component.VC.14.29.16.11.MFC.Spectre"
+        )
+        [string]$workloadArgs = $componentsToRemove | ForEach-Object {" --add " +  $_}
+        $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
+        # should be run twice
+        $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+        $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+{%- endif %}
+
     - script: |
         call ".scripts\run_win_build.bat"
       displayName: Run Windows build

--- a/news/2062-atl.rst
+++ b/news/2062-atl.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Provide option `azure.settings_win.install_atl` (false by default), which can be used to install components that are necessary for some builds, but not present in the Azure images anymore
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Fixes #2062

This breaks on only a handful of feedstocks, but where it does happen it's very annoying to fix for every rerender (and non-obvious for those who don't know). Initially my hope was that MSFT would solve https://github.com/actions/runner-images/issues/9873, but after many months, it's time to admit that that won't happen.