### PR TITLE
fix: need pinnings for register ci too

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -17,7 +17,10 @@ from ruamel.yaml import YAML
 import conda_smithy.cirun_utils
 from conda_smithy import __version__, configure_feedstock, feedstock_io
 from conda_smithy import lint_recipe as linter
-from conda_smithy.configure_feedstock import _load_forge_config
+from conda_smithy.configure_feedstock import (
+    _load_forge_config,
+    get_cached_cfp_file_path,
+)
 from conda_smithy.utils import (
     CONDA_BUILD,
     RATTLER_BUILD,
@@ -333,7 +336,13 @@ class RegisterCI(Subcommand):
         # Load the conda-forge config and read metadata from the feedstock recipe
         forge_config = _load_forge_config(args.feedstock_directory, None)
         metadata = _get_metadata_from_feedstock_dir(
-            args.feedstock_directory, forge_config
+            args.feedstock_directory,
+            forge_config,
+            conda_forge_pinning_file=(
+                get_cached_cfp_file_path(".")[0]
+                if args.user is None and args.organization == "conda-forge"
+                else None
+            ),
         )
 
         feedstock_name = get_feedstock_name_from_meta(metadata)

--- a/news/2144-noarch-py-min.rst
+++ b/news/2144-noarch-py-min.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed a bug where the ``register-ci`` command fails for recipes with the ``python_min`` variable being used. (#2144)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR fixes a bug that is blocking staged-recipes. The value of `python_min` is needed in order to get the recipe name in conda-build. I fixed a similar bug before, but missed this version of it. 
