### PR TITLE
Move `MINIFORGE_HOME` fix to `pixi` block

### DIFF
--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -8,7 +8,6 @@ set -xe
 
 MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
 MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
-mkdir -p ${MINIFORGE_HOME}
 
 {%- if conda_install_tool == "micromamba" %}
 
@@ -36,6 +35,7 @@ rm -rf "${MAMBA_ROOT_PREFIX}" "${micromamba_exe}" || true
 ( endgroup "Provisioning base env with micromamba" ) 2> /dev/null
 {%- elif conda_install_tool == "pixi" %}
 ( startgroup "Provisioning base env with pixi" ) 2> /dev/null
+mkdir -p ${MINIFORGE_HOME}
 curl -fsSL https://pixi.sh/install.sh | bash
 export PATH="~/.pixi/bin:$PATH"
 arch=$(uname -m)

--- a/news/pixi_osx.rst
+++ b/news/pixi_osx.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Make sure $MINIFORGE_HOME folder exists during build.
+* Make sure $MINIFORGE_HOME folder exists during build. (#2142) (#2146)
 
 **Security:**
 


### PR DESCRIPTION
Creating `MINIFORGE_HOME` up top breaks the Miniforge install step. As this appears this is only needed for `pixi` move to that block to limit the effect.

cc @hadim @beckermr

xref: https://github.com/conda-forge/conda-smithy/pull/2142#discussion_r1849286289

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
