### PR TITLE
Set CONDA_BLD_PATH when using pixi during osx build

### DIFF
--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -53,6 +53,7 @@ jobs:
       displayName: Run Windows build
       env:
         MINIFORGE_HOME: $(MINIFORGE_HOME)
+        CONDA_BLD_PATH: $(CONDA_BLD_PATH)
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -20,6 +20,7 @@ export PYTHONUNBUFFERED=1
 export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
 export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
+{#- We are not handling CONDA_BLD_PATH here because it's already set in the condarc below #}
 
 cat >~/.condarc <<CONDARC
 

--- a/conda_smithy/templates/pixi.toml.tmpl
+++ b/conda_smithy/templates/pixi.toml.tmpl
@@ -40,7 +40,7 @@ conda-smithy = "*"
 build-locally = "python ./build-locally.py"
 smithy = "conda-smithy"
 rerender = "conda-smithy rerender"
-lint = "conda-smithy lint {{ recipe_dir}}"
+lint = "conda-smithy lint {{ recipe_dir }}"
 
 [environments]
 smithy = ["smithy"]

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -6,17 +6,9 @@ source .scripts/logging_utils.sh
 
 set -xe
 
-MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
-MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
-
-# Set CONDA_BLD_PATH when using pixi
-# to prevent the pixi env path from being used
-# during validation when looking for the built packages.
-# The export is required for the variable to propagate to
-#inspect_artifacts.
-{%- if conda_install_tool == "pixi" %}
-export CONDA_BLD_PATH="${MINIFORGE_HOME}/conda-bld"
-{%- endif %}
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
 
 {%- if conda_install_tool == "micromamba" %}
 
@@ -44,7 +36,7 @@ rm -rf "${MAMBA_ROOT_PREFIX}" "${micromamba_exe}" || true
 ( endgroup "Provisioning base env with micromamba" ) 2> /dev/null
 {%- elif conda_install_tool == "pixi" %}
 ( startgroup "Provisioning base env with pixi" ) 2> /dev/null
-mkdir -p ${MINIFORGE_HOME}
+mkdir -p "${MINIFORGE_HOME}"
 curl -fsSL https://pixi.sh/install.sh | bash
 export PATH="~/.pixi/bin:$PATH"
 arch=$(uname -m)
@@ -173,7 +165,7 @@ else
     {%- else %}
     {{ BUILD_CMD }} --recipe ./{{ recipe_dir }} \
         -m ./.ci_support/${CONFIG}.yaml \
-        --output-dir ${CONDA_BLD_PATH} ${EXTRA_CB_OPTIONS:-} \
+        ${EXTRA_CB_OPTIONS:-} \
         --target-platform "${HOST_PLATFORM}" \
         --extra-meta flow_run_id="$flow_run_id" \
         --extra-meta remote_url="$remote_url" \

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -16,7 +16,7 @@ MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
 #inspect_artifacts.
 {%- if conda_install_tool == "pixi" %}
 export CONDA_BLD_PATH="${MINIFORGE_HOME}/conda-bld"
-{%- else %}
+{%- endif %}
 
 {%- if conda_install_tool == "micromamba" %}
 

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -9,6 +9,15 @@ set -xe
 MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
 MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
 
+# Set CONDA_BLD_PATH when using pixi
+# to prevent the pixi env path from being used
+# during validation when looking for the built packages.
+# The export is required for the variable to propagate to
+#inspect_artifacts.
+{%- if conda_install_tool == "pixi" %}
+export CONDA_BLD_PATH="${MINIFORGE_HOME}/conda-bld"
+{%- else %}
+
 {%- if conda_install_tool == "micromamba" %}
 
 ( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
@@ -164,7 +173,7 @@ else
     {%- else %}
     {{ BUILD_CMD }} --recipe ./{{ recipe_dir }} \
         -m ./.ci_support/${CONFIG}.yaml \
-        --output-dir ${MINIFORGE_HOME}/conda-bld ${EXTRA_CB_OPTIONS:-} \
+        --output-dir ${CONDA_BLD_PATH} ${EXTRA_CB_OPTIONS:-} \
         --target-platform "${HOST_PLATFORM}" \
         --extra-meta flow_run_id="$flow_run_id" \
         --extra-meta remote_url="$remote_url" \

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -25,6 +25,8 @@ if "%MINIFORGE_HOME%"=="" set "MINIFORGE_HOME=%USERPROFILE%\Miniforge3"
 :: Remove trailing backslash, if present
 if "%MINIFORGE_HOME:~-1%"=="\" set "MINIFORGE_HOME=%MINIFORGE_HOME:~0,-1%"
 
+{#- NOTE: We are NOT setting a default CONDA_BLD_PATH here; that's done in conda-forge-ci-setup #}
+
 {%- if conda_install_tool == "micromamba" %}
 call :start_group "Provisioning base env with micromamba"
 set "MAMBA_ROOT_PREFIX=%MINIFORGE_HOME%-micromamba-%RANDOM%"

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -51,6 +51,7 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
 del /S /Q "%MICROMAMBA_TMPDIR%" >nul
+call :end_group
 {%- elif conda_install_tool == "pixi" %}
 call :start_group "Provisioning base env with pixi"
 echo Installing pixi

--- a/news/pixi_osx_conda_bld_path.rst
+++ b/news/pixi_osx_conda_bld_path.rst
@@ -16,7 +16,8 @@
 
 **Fixed:**
 
-* Set CONDA_BLD_PATH when using pixi to prevent the pixi env path from being used during validation when looking for the built packages.
+* Ensure ``CONDA_BLD_PATH`` is properly exported in macOS. (#2145 via #2148)
+* Close logging group for ``micromamba`` installs in Windows. (#2148)
 
 **Security:**
 

--- a/news/pixi_osx_conda_bld_path.rst
+++ b/news/pixi_osx_conda_bld_path.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Set CONDA_BLD_PATH when using pixi to prevent the pixi env path from being used during validation when looking for the built packages.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This is an attempt to fix https://github.com/conda-forge/conda-smithy/issues/2145. You can see it in action at https://github.com/conda-forge/docling-parse-feedstock/pull/3

Note the fix is a simple and naive patch but looks fragile to me. Please let me know if you can think of another solution.
