### PR TITLE
Make the `python_min` linter check robust against if-else syntax

### DIFF
--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -11,6 +11,7 @@ from conda_smithy.linter.errors import HINT_NO_ARCH
 from conda_smithy.linter.utils import (
     VALID_PYTHON_BUILD_BACKENDS,
     find_local_config_file,
+    flatten_v1_if_else,
     is_selector_line,
 )
 from conda_smithy.utils import get_yaml
@@ -245,6 +246,11 @@ def hint_noarch_python_use_python_min(
     hints,
 ):
     if noarch_value == "python" and not outputs_section:
+        if recipe_version == 1:
+            host_reqs = flatten_v1_if_else(host_reqs)
+            run_reqs = flatten_v1_if_else(run_reqs)
+            test_reqs = flatten_v1_if_else(test_reqs)
+
         hint = ""
         for section_name, syntax, report_syntax, reqs in [
             (
@@ -278,9 +284,7 @@ def hint_noarch_python_use_python_min(
                 test_syntax = syntax.replace("{{ python_min }}", "9999")
 
             for req in reqs:
-                # `req` may be a string or a CommentedMap. The latter is
-                # produced by if: then: syntax in recipe.yaml.
-                if hasattr(req, "split") and (
+                if (
                     req.strip().split()[0] == "python"
                     and req != "python"
                     and re.search(test_syntax, req)

--- a/news/2154-fix-python_min-v1-hint.rst
+++ b/news/2154-fix-python_min-v1-hint.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed a bug where the ``python_min`` hint failed on v1 recipes. (#2154)
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -3358,6 +3358,66 @@ def test_hint_noarch_python_use_python_min(
             ),
             [],
         ),
+        (
+            textwrap.dedent(
+                """
+                package:
+                  name: python
+
+                requirements:
+                  run:
+                    - if: blah
+                      then: python
+                      else: python 3.7
+                """
+            ),
+            [],
+        ),
+        (
+            textwrap.dedent(
+                """
+                package:
+                  name: python
+
+                build:
+                  noarch: python
+
+                requirements:
+                  run:
+                    - if: blah
+                      then: python
+                """
+            ),
+            [
+                "python ${{ python_min }}",
+                "python >=${{ python_min }}",
+            ],
+        ),
+        (
+            textwrap.dedent(
+                """
+                package:
+                  name: python
+
+                build:
+                  noarch: python
+
+                requirements:
+                  host:
+                    - if: blah
+                      then: blahblah
+                      else: python ${{ python_min }}
+                  run:
+                    - python >=${{ python_min }}
+
+                tests:
+                  - requirements:
+                      run:
+                        - python ${{ python_min }}
+                """
+            ),
+            [],
+        ),
     ],
 )
 def test_hint_noarch_python_use_python_min_v1(


### PR DESCRIPTION
In `noarch: python` recipes, the thing being checked here should always have `python` as a string and not in an `if:` block, so it should be safe to skip the check. Fixes the linter failing on rattler-build recipes with conditional requirements.

Closes gh-2153
