### PR TITLE
ENH: lint incorrect distro names in `os_version`

### DIFF
--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -110,28 +110,16 @@
           "title": "Upload Packages"
         },
         "settings_linux": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/AzureRunnerSettings"
-            }
-          ],
+          "$ref": "#/$defs/AzureRunnerSettings",
           "description": "Linux-specific settings for runners"
         },
         "settings_osx": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/AzureRunnerSettings"
-            }
-          ],
+          "$ref": "#/$defs/AzureRunnerSettings",
           "description": "OSX-specific settings for runners"
         },
         "settings_win": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/AzureRunnerSettings"
-            }
-          ],
-          "description": "Windows-specific settings for runners. Some important variables you can set are:\n\n- `CONDA_BLD_PATH`: Location of the conda-build workspace. Defaults to `D:\\bld`\n- `MINIFORGE_HOME`: Location of the base environment installation. Defaults to\n  `D:\\Miniforge`.\n- `SET_PAGEFILE`: `\"True\"` to increase the pagefile size via conda-forge-ci-setup.\n\nIf you are running out of space in `D:`, consider changing to `C:`.\nIt's a slower drive but has more space available. We recommend you keep\nboth `CONDA_BLD_PATH` and `MINIFORGE_HOME` in the same drive for performance."
+          "$ref": "#/$defs/AzureRunnerSettings",
+          "description": "Windows-specific settings for runners. Aside from overriding the `vmImage`,\nyou can also specify `install_atl: true` in case you need the ATL components\nfor MSVC; these don't get installed by default anymore, see\nhttps://github.com/actions/runner-images/issues/9873\n\nFinally, under `variables`, some important things you can set are:\n\n- `CONDA_BLD_PATH`: Location of the conda-build workspace. Defaults to `D:\\bld`\n- `MINIFORGE_HOME`: Location of the base environment installation. Defaults to\n  `D:\\Miniforge`.\n- `SET_PAGEFILE`: `\"True\"` to increase the pagefile size via conda-forge-ci-setup.\n\nIf you are running out of space in `D:`, consider changing to `C:`.\nIt's a slower drive but has more space available. We recommend you keep\nboth `CONDA_BLD_PATH` and `MINIFORGE_HOME` in the same drive for performance."
         },
         "user_or_org": {
           "anyOf": [
@@ -244,6 +232,19 @@
           ],
           "description": "Variables",
           "title": "Variables"
+        },
+        "install_atl": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "description": "Whether to install ATL components for MSVC",
+          "title": "Install Atl"
         }
       },
       "title": "AzureRunnerSettings",
@@ -815,13 +816,17 @@
       "type": "object"
     },
     "Lints": {
-      "const": "lint_noarch_selectors",
+      "enum": [
+        "lint_noarch_selectors"
+      ],
       "title": "Lints",
       "type": "string"
     },
     "Nullable": {
-      "const": null,
       "description": "Created to avoid issue with schema validation of null values in lists or dicts.",
+      "enum": [
+        null
+      ],
       "title": "Nullable"
     },
     "Platforms": {
@@ -1070,10 +1075,13 @@
         "linux_32": {
           "anyOf": [
             {
+              "enum": [
+                "cos7",
+                "alma8",
+                "alma9",
+                "ubi8"
+              ],
               "type": "string"
-            },
-            {
-              "$ref": "#/$defs/Nullable"
             },
             {
               "type": "null"
@@ -1085,10 +1093,13 @@
         "linux_64": {
           "anyOf": [
             {
+              "enum": [
+                "cos7",
+                "alma8",
+                "alma9",
+                "ubi8"
+              ],
               "type": "string"
-            },
-            {
-              "$ref": "#/$defs/Nullable"
             },
             {
               "type": "null"
@@ -1100,10 +1111,13 @@
         "linux_aarch64": {
           "anyOf": [
             {
+              "enum": [
+                "cos7",
+                "alma8",
+                "alma9",
+                "ubi8"
+              ],
               "type": "string"
-            },
-            {
-              "$ref": "#/$defs/Nullable"
             },
             {
               "type": "null"
@@ -1115,10 +1129,13 @@
         "linux_armv6l": {
           "anyOf": [
             {
+              "enum": [
+                "cos7",
+                "alma8",
+                "alma9",
+                "ubi8"
+              ],
               "type": "string"
-            },
-            {
-              "$ref": "#/$defs/Nullable"
             },
             {
               "type": "null"
@@ -1130,10 +1147,13 @@
         "linux_armv7l": {
           "anyOf": [
             {
+              "enum": [
+                "cos7",
+                "alma8",
+                "alma9",
+                "ubi8"
+              ],
               "type": "string"
-            },
-            {
-              "$ref": "#/$defs/Nullable"
             },
             {
               "type": "null"
@@ -1145,10 +1165,13 @@
         "linux_ppc64": {
           "anyOf": [
             {
+              "enum": [
+                "cos7",
+                "alma8",
+                "alma9",
+                "ubi8"
+              ],
               "type": "string"
-            },
-            {
-              "$ref": "#/$defs/Nullable"
             },
             {
               "type": "null"
@@ -1160,10 +1183,13 @@
         "linux_ppc64le": {
           "anyOf": [
             {
+              "enum": [
+                "cos7",
+                "alma8",
+                "alma9",
+                "ubi8"
+              ],
               "type": "string"
-            },
-            {
-              "$ref": "#/$defs/Nullable"
             },
             {
               "type": "null"
@@ -1175,10 +1201,13 @@
         "linux_riscv64": {
           "anyOf": [
             {
+              "enum": [
+                "cos7",
+                "alma8",
+                "alma9",
+                "ubi8"
+              ],
               "type": "string"
-            },
-            {
-              "$ref": "#/$defs/Nullable"
             },
             {
               "type": "null"
@@ -1190,10 +1219,13 @@
         "linux_s390x": {
           "anyOf": [
             {
+              "enum": [
+                "cos7",
+                "alma8",
+                "alma9",
+                "ubi8"
+              ],
               "type": "string"
-            },
-            {
-              "$ref": "#/$defs/Nullable"
             },
             {
               "type": "null"
@@ -1928,7 +1960,7 @@
           "type": "null"
         }
       ],
-      "description": "This key is used to set the OS versions for `linux_*` platforms. Valid entries\nmap a linux platform and arch to either `cos6` or `cos7`.\nCurrently `cos6` is the default for `linux-64`.\nAll other linux architectures use CentOS 7.\nHere is an example that enables CentOS 7 on `linux-64` builds\n\n```yaml\nos_version:\n    linux_64: cos7\n```"
+      "description": "This key is used to set the OS versions for `linux_*` platforms. Valid entries\nmap a linux platform and arch to either `cos7`, `alma8`, `alma9` or `ubi8`.\n\nCurrently `alma9` is the default, which should work out-of-the-box for the vast\nmajority of uses.\n\nNote that the image version does not imply a matching `glibc` requirement (which\ncan be set using `c_stdlib_version` in `recipe/conda_build_config.yaml`).\n\nIf you need to opt into older images, here's an example how to do it:\n```yaml\nos_version:\n    linux_64: cos7\n    linux_aarch64: cos7\n    linux_ppc64le: cos7\n```"
     },
     "provider": {
       "anyOf": [

--- a/conda_smithy/data/conda-forge.yml
+++ b/conda_smithy/data/conda-forge.yml
@@ -8,18 +8,21 @@ azure:
   project_id: 84710dde-1620-425b-80d0-4cf5baca359d
   project_name: feedstock-builds
   settings_linux:
+    install_atl: false
     pool:
       vmImage: ubuntu-latest
     swapfile_size: 0GiB
     timeoutInMinutes: 360
     variables: {}
   settings_osx:
+    install_atl: false
     pool:
       vmImage: macOS-13
     swapfile_size: null
     timeoutInMinutes: 360
     variables: {}
   settings_win:
+    install_atl: false
     pool:
       vmImage: windows-2022
     swapfile_size: null

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -46,6 +46,9 @@ conda_build_tools = Literal[
 ]
 
 
+image_tags = Literal["cos7", "alma8", "alma9", "ubi8"]
+
+
 class CIservices(StrEnum):
     azure = "azure"
     circle = "circle"
@@ -556,7 +559,7 @@ BuildPlatform = create_model(
 OSVersion = create_model(
     "os_version",
     **{
-        platform.value: (Optional[Union[str, Nullable]], Field(default=None))
+        platform.value: (Optional[image_tags], Field(default=None))
         for platform in Platforms
         if platform.value.startswith("linux")
     },
@@ -864,14 +867,20 @@ class ConfigModel(BaseModel):
         description=cleandoc(
             """
         This key is used to set the OS versions for `linux_*` platforms. Valid entries
-        map a linux platform and arch to either `cos6` or `cos7`.
-        Currently `cos6` is the default for `linux-64`.
-        All other linux architectures use CentOS 7.
-        Here is an example that enables CentOS 7 on `linux-64` builds
+        map a linux platform and arch to either `cos7`, `alma8`, `alma9` or `ubi8`.
 
+        Currently `alma9` is the default, which should work out-of-the-box for the vast
+        majority of uses.
+
+        Note that the image version does not imply a matching `glibc` requirement (which
+        can be set using `c_stdlib_version` in `recipe/conda_build_config.yaml`).
+
+        If you need to opt into older images, here's an example how to do it:
         ```yaml
         os_version:
             linux_64: cos7
+            linux_aarch64: cos7
+            linux_ppc64le: cos7
         ```
         """
         ),

--- a/news/2155-distro-lint.rst
+++ b/news/2155-distro-lint.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Added linting for incorrect values under `os_version:` in `conda-forge.yml`
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -2481,6 +2481,37 @@ def test_lint_duplicate_cfyml():
         assert not any(lint.startswith(expected_message) for lint in lints)
 
 
+def test_cfyml_wrong_os_version():
+    expected_message = (
+        "{'linux_64': 'wrong'} is not valid under any of the given schemas"
+    )
+
+    with tmp_directory() as feedstock_dir:
+        cfyml = os.path.join(feedstock_dir, "conda-forge.yml")
+        recipe_dir = os.path.join(feedstock_dir, "recipe")
+        os.makedirs(recipe_dir, exist_ok=True)
+        with open(os.path.join(recipe_dir, "meta.yaml"), "w") as fh:
+            fh.write(
+                """
+                package:
+                  name: foo
+                """
+            )
+
+        with open(cfyml, "w") as fh:
+            fh.write(
+                textwrap.dedent(
+                    """
+                    os_version:
+                      linux_64: wrong
+                    """
+                )
+            )
+
+        lints = linter.main(recipe_dir, conda_forge=True)
+        assert any(expected_message in lint for lint in lints)
+
+
 @pytest.mark.parametrize(
     "yaml_block,expected_message",
     [


### PR DESCRIPTION
This is for linting wrong distro values used in `os_version` (which becomes more important after https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6626, as it might lead to zipping problems and thus rerender errors).

With this PR, a `conda-forge.yml` of
```yaml
os_version:
  linux_64: wrong
```
would lead to
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for ConfigModel
os_version.linux_64
  Input should be 'cos7', 'ubi8', 'alma8' or 'alma9' [type=literal_error, input_value='wrong', input_type=str]
    For further information visit https://errors.pydantic.dev/2.10/v/literal_error
```
We'll certainly want to polish this further (e.g. into a concrete hint/lint), hence this is a draft. It's also a draft because by themselves, the changes in dc74f555ef90a16113732f7015a1f1507f9e5c66 do not work. It needs #1920 (or something similar) to actually work, see #2152. Currently it includes that PR, which should be merged first.