### PR TITLE
Bugfix ignore_run_exports for v1 recipes

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -310,7 +310,9 @@ def lintify_meta_yaml(
     lint_legacy_usage_of_compilers(build_requirements, lints)
 
     # 22: Single space in pinned requirements
-    lint_single_space_in_pinned_requirements(requirements_section, lints)
+    lint_single_space_in_pinned_requirements(
+        requirements_section, lints, recipe_version
+    )
 
     # 23: non noarch builds shouldn't use version constraints on python and r-base
     lint_non_noarch_builds(

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -428,6 +428,12 @@ def lint_single_space_in_pinned_requirements(
     recipe_version: int = 0,
 ):
     for section, requirements in requirements_section.items():
+        if (
+            recipe_version == 1
+            and section == "ignore_run_exports"
+            and requirements
+        ):
+            requirements = requirements[0].get("from_package", [])
         for requirement in requirements or []:
             if recipe_version == 1:
                 req = requirement

--- a/news/2157-bugfix-ignore_run_exports-for-v1-recipes.rst
+++ b/news/2157-bugfix-ignore_run_exports-for-v1-recipes.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed a bug that caused the linter to fail when a v1 recipe had the `ignore_run_exports` key. (#2157, #2153)
+
+**Security:**
+
+* <news item>

--- a/tests/recipes/v1_recipes/recipe-ignore_run_exports-no-lint.yaml
+++ b/tests/recipes/v1_recipes/recipe-ignore_run_exports-no-lint.yaml
@@ -1,0 +1,32 @@
+package:
+  name: foo
+  version: 1.2.3
+
+source:
+  url: https://example.com/foo.tar.gz
+  sha256: b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
+
+build:
+  number: 0
+
+requirements:
+  host:
+    - has_run_export
+  ignore_run_exports:
+    from_package:
+    - has_run_export
+
+tests:
+  - script:
+      - echo "Hello, world!"
+
+about:
+  license: BSD-3-Clause
+  license_file: LICENSE.txt
+  homepage: https://example.com/foo
+  summary: A package that does foo.
+
+extra:
+  recipe-maintainers:
+    - Alice
+    - Bob

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -2688,6 +2688,14 @@ def test_v1_recipes():
         assert not lints
 
 
+def test_v1_recipes_ignore_run_exports():
+    with get_recipe_in_dir(
+        "v1_recipes/recipe-ignore_run_exports-no-lint.yaml"
+    ) as recipe_dir:
+        lints, hints = linter.main(str(recipe_dir), return_hints=True)
+        assert not lints
+
+
 def test_v1_no_test():
     with get_recipe_in_dir("v1_recipes/recipe-no-tests.yaml") as recipe_dir:
         lints, hints = linter.main(str(recipe_dir), return_hints=True)


### PR DESCRIPTION
The ignore_run_exports directive for v1 recipes has a different format, attempt to support it for the lint_single_space_in_pinned_requirements.

I only run the lint for the `from_package` section, should we also run it over the `from_name` section if that exists?

Should I also add a test-case with the recipe which failed?

Closes #2153 
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
