### PR TITLE
fix: try two public urls for maintainer exists lint

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -426,10 +426,10 @@ def _maintainer_exists(maintainer: str) -> bool:
         # )
         # so we check two public URLs instead.
         # 1. github.com/<maintainer> - this URL works for all users and all orgs
-        # 2. https://github.com/orgs/<maintainer> - this URL only works for
+        # 2. https://github.com/orgs/<maintainer>/teams - this URL only works for
         #    orgs so we make sure it fails
         req_profile = requests.get(f"https://github.com/{maintainer}")
-        req_org = requests.get(f"https://github.com/orgs/{maintainer}")
+        req_org = requests.get(f"https://github.com/orgs/{maintainer}/teams")
         return req_profile.status_code == 200 and req_org.status_code != 200
 
 

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -417,12 +417,20 @@ def _maintainer_exists(maintainer: str) -> bool:
             return False
         return True
     else:
-        return (
-            requests.get(
-                f"https://api.github.com/users/{maintainer}"
-            ).status_code
-            == 200
-        )
+        # this API request has no token and so has a restrictive rate limit
+        # return (
+        #     requests.get(
+        #         f"https://api.github.com/users/{maintainer}"
+        #     ).status_code
+        #     == 200
+        # )
+        # so we check two public URLs instead.
+        # 1. github.com/<maintainer> - this URL works for all users and all orgs
+        # 2. https://github.com/orgs/<maintainer> - this URL only works for
+        #    orgs so we make sure it fails
+        req_profile = requests.get(f"https://github.com/{maintainer}")
+        req_org = requests.get(f"https://github.com/orgs/{maintainer}")
+        return req_profile.status_code == 200 and req_org.status_code != 200
 
 
 @lru_cache(maxsize=1)

--- a/news/2171-fix-maintainer_exists.rst
+++ b/news/2171-fix-maintainer_exists.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed a bug in checking in recipe maintainers exist without a GitHub token
+  where the anonymous API would run out of requests. (#2171)
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1871,6 +1871,12 @@ linter:
         expected_message = 'Recipe maintainer "isuruf" does not exist'
         self.assertNotIn(expected_message, lints)
 
+        lints, _ = linter.lintify_meta_yaml(
+            {"extra": {"recipe-maintainers": ["conda-forge"]}}, conda_forge=True
+        )
+        expected_message = 'Recipe maintainer "conda-forge" does not exist'
+        self.assertIn(expected_message, lints)
+
     def test_maintainer_team_exists(self):
         lints, _ = linter.lintify_meta_yaml(
             {

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1878,6 +1878,35 @@ linter:
         expected_message = 'Recipe maintainer "conda-forge" does not exist'
         self.assertIn(expected_message, lints)
 
+    def test_maintainer_exists_no_token(self):
+        gh_token = os.environ.get("GH_TOKEN", None)
+        try:
+            if "GH_TOKEN" in os.environ:
+                del os.environ["GH_TOKEN"]
+
+            lints, _ = linter.lintify_meta_yaml(
+                {"extra": {"recipe-maintainers": ["support"]}},
+                conda_forge=True,
+            )
+            expected_message = 'Recipe maintainer "support" does not exist'
+            self.assertIn(expected_message, lints)
+
+            lints, _ = linter.lintify_meta_yaml(
+                {"extra": {"recipe-maintainers": ["isuruf"]}}, conda_forge=True
+            )
+            expected_message = 'Recipe maintainer "isuruf" does not exist'
+            self.assertNotIn(expected_message, lints)
+
+            lints, _ = linter.lintify_meta_yaml(
+                {"extra": {"recipe-maintainers": ["conda-forge"]}},
+                conda_forge=True,
+            )
+            expected_message = 'Recipe maintainer "conda-forge" does not exist'
+            self.assertIn(expected_message, lints)
+        finally:
+            if gh_token is not None:
+                os.environ["GH_TOKEN"] = gh_token
+
     def test_maintainer_team_exists(self):
         lints, _ = linter.lintify_meta_yaml(
             {

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1872,7 +1872,8 @@ linter:
         self.assertNotIn(expected_message, lints)
 
         lints, _ = linter.lintify_meta_yaml(
-            {"extra": {"recipe-maintainers": ["conda-forge"]}}, conda_forge=True
+            {"extra": {"recipe-maintainers": ["conda-forge"]}},
+            conda_forge=True,
         )
         expected_message = 'Recipe maintainer "conda-forge" does not exist'
         self.assertIn(expected_message, lints)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR fixes #2164 by using two public URLs to check if the maintainer exists instead of using the github API anonymously. Hopefully it is more robust since the anonymous API has pretty restructive rate limits.
