### PR TITLE
Add flit to list of valid build backends

### DIFF
--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -57,6 +57,7 @@ RATTLER_BUILD_TOOL = "rattler-build"
 
 VALID_PYTHON_BUILD_BACKENDS = [
     "setuptools",
+    "flit",
     "flit-core",
     "hatchling",
     "poetry",

--- a/news/add-flit.rst
+++ b/news/add-flit.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Add `flit` (previously only `flit-core`) to the list of valid build backends (#2187)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
It's confusing that `flit-core` is valid, but `flit` is not.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
