### PR TITLE
Always pass POSIX paths to pygit2 index (#2185)

### DIFF
--- a/conda_smithy/feedstock_io.py
+++ b/conda_smithy/feedstock_io.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import stat
 from contextlib import contextmanager
+from pathlib import Path
 
 
 def get_repo(path, search_parent_directories=True):
@@ -38,7 +39,10 @@ def set_exe_file(filename, set_exe=True):
 
     repo = get_repo(filename)
     if repo:
-        index_entry = repo.index[os.path.relpath(filename, repo.workdir)]
+        index_path = (
+            Path(filename).resolve().relative_to(repo.workdir).as_posix()
+        )
+        index_entry = repo.index[index_path]
         if set_exe:
             index_entry.mode |= all_execute_permissions
         else:
@@ -65,7 +69,10 @@ def write_file(filename):
 
     repo = get_repo(filename)
     if repo:
-        repo.index.add(os.path.relpath(filename, repo.workdir))
+        index_path = (
+            Path(filename).resolve().relative_to(repo.workdir).as_posix()
+        )
+        repo.index.add(index_path)
         repo.index.write()
 
 
@@ -91,7 +98,10 @@ def remove_file(filename):
     repo = get_repo(filename)
     if repo:
         try:
-            repo.index.remove(os.path.relpath(filename, repo.workdir))
+            index_path = (
+                Path(filename).resolve().relative_to(repo.workdir).as_posix()
+            )
+            repo.index.remove(index_path)
             repo.index.write()
         except OSError:  # this is specifically "file not in index"
             pass
@@ -123,5 +133,6 @@ def copy_file(src, dst):
 
     repo = get_repo(dst)
     if repo:
-        repo.index.add(os.path.relpath(dst, repo.workdir))
+        index_path = Path(dst).resolve().relative_to(repo.workdir).as_posix()
+        repo.index.add(index_path)
         repo.index.write()

--- a/conda_smithy/feedstock_tokens.py
+++ b/conda_smithy/feedstock_tokens.py
@@ -31,6 +31,7 @@ import subprocess
 import tempfile
 import time
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from pathlib import Path
 
 import pygit2
 import requests
@@ -425,7 +426,10 @@ def register_feedstock_token(
                 json.dump(token_data, fp)
 
             # push
-            repo.index.add(os.path.relpath(token_file, tmpdir))
+            index_path = (
+                Path(token_file).resolve().relative_to(tmpdir).as_posix()
+            )
+            repo.index.add(index_path)
             repo.index.write()
             subprocess.run(
                 [

--- a/news/2185-fix-pygit2-windows.rst
+++ b/news/2185-fix-pygit2-windows.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix passing paths to ``pygit2`` on Windows (#2185)
+
+**Security:**
+
+* <news item>

--- a/news/2185-fix-pygit2-windows.rst
+++ b/news/2185-fix-pygit2-windows.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Fix passing paths to ``pygit2`` on Windows (#2185)
+* Fix passing paths to ``pygit2`` on Windows. (#2192)
 
 **Security:**
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
libgit2 expects internal git paths to be passed in git convention, that is using forward slashes.  Use pathlib.Path.as_posix() to ensure that the correct conversion is used when passing paths to index operations.

Fixes #2185

