### PR TITLE
Add sphinx-theme-builder as valid Python build backend

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Conda env
-        uses: mamba-org/setup-micromamba@06375d89d211a1232ef63355742e9e2e564bc7f7
+        uses: mamba-org/setup-micromamba@068f1ab4b37ed9b3d9f73da7db90a0cda0a48d29
         with:
           environment-file: environment.yml
           cache-environment: true

--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -67,6 +67,7 @@ VALID_PYTHON_BUILD_BACKENDS = [
     "pymsbuild",
     "meson-python",
     "scikit-build-core",
+    "sphinx-theme-builder",
     "maturin",
     "jupyter_packaging",
     "whey",

--- a/news/pr-2204-sphinx-build-backend.rst
+++ b/news/pr-2204-sphinx-build-backend.rst
@@ -1,0 +1,3 @@
+**Added:**
+
+* Added ``sphinx-theme-builder`` as a valid ``pip`` build backend. (2204)

--- a/news/pr-2204-sphinx-build-backend.rst
+++ b/news/pr-2204-sphinx-build-backend.rst
@@ -1,3 +1,3 @@
 **Added:**
 
-* Added ``sphinx-theme-builder`` as a valid ``pip`` build backend. (2204)
+* Added ``sphinx-theme-builder`` as a valid ``pip`` build backend. (#2204)


### PR DESCRIPTION
See [here](https://sphinx-theme-builder.readthedocs.io/en/latest/filesystem-layout/#how-to-get-this-right) in the documentation, for example, for confirmation that sphinx-theme-builder is a Python build backend.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
