### PR TITLE
Support skipping `python_min` and `pip_no_build_backend` hints

### DIFF
--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -818,6 +818,7 @@
     "Lints": {
       "enum": [
         "lint_noarch_selectors",
+        "hint_pip_no_build_backend",
         "hint_python_min"
       ],
       "title": "Lints",

--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -817,7 +817,8 @@
     },
     "Lints": {
       "enum": [
-        "lint_noarch_selectors"
+        "lint_noarch_selectors",
+        "hint_python_min"
       ],
       "title": "Lints",
       "type": "string"

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -487,6 +487,10 @@ def run_conda_forge_specific(
     hints,
     recipe_version: int = 0,
 ):
+    lints_to_skip = (
+        _get_forge_yaml(recipe_dir).get("linter", {}).get("skip", [])
+    )
+
     # Retrieve sections from meta
     package_section = get_section(
         meta, "package", lints, recipe_version=recipe_version
@@ -627,15 +631,16 @@ def run_conda_forge_specific(
             )
 
     # 10: check for proper noarch python syntax
-    hint_noarch_python_use_python_min(
-        requirements_section.get("host") or [],
-        requirements_section.get("run") or [],
-        test_reqs,
-        outputs_section,
-        noarch_value,
-        recipe_version,
-        hints,
-    )
+    if "hint_python_min" not in lints_to_skip:
+        hint_noarch_python_use_python_min(
+            requirements_section.get("host") or [],
+            requirements_section.get("run") or [],
+            test_reqs,
+            outputs_section,
+            noarch_value,
+            recipe_version,
+            hints,
+        )
 
     # 11: ensure we can parse the recipe
     if recipe_version == 1:

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -593,26 +593,27 @@ def run_conda_forge_specific(
             )
 
     # 8: Ensure the recipe specifies a Python build backend if needed
-    host_or_build_reqs = (requirements_section.get("host") or []) or (
-        requirements_section.get("build") or []
-    )
-    hint_pip_no_build_backend(host_or_build_reqs, recipe_name, hints)
-    for out in outputs_section:
-        if recipe_version == 1:
-            output_requirements = rattler_loader.load_all_requirements(out)
-            build_reqs = output_requirements.get("build") or []
-            host_reqs = output_requirements.get("host") or []
-        else:
-            _req = out.get("requirements") or {}
-            if isinstance(_req, Mapping):
-                build_reqs = _req.get("build") or []
-                host_reqs = _req.get("host") or []
+    if "hint_pip_no_build_backend" not in lints_to_skip:
+        host_or_build_reqs = (requirements_section.get("host") or []) or (
+            requirements_section.get("build") or []
+        )
+        hint_pip_no_build_backend(host_or_build_reqs, recipe_name, hints)
+        for out in outputs_section:
+            if recipe_version == 1:
+                output_requirements = rattler_loader.load_all_requirements(out)
+                build_reqs = output_requirements.get("build") or []
+                host_reqs = output_requirements.get("host") or []
             else:
-                build_reqs = []
-                host_reqs = []
+                _req = out.get("requirements") or {}
+                if isinstance(_req, Mapping):
+                    build_reqs = _req.get("build") or []
+                    host_reqs = _req.get("host") or []
+                else:
+                    build_reqs = []
+                    host_reqs = []
 
-        name = out.get("name", "").strip()
-        hint_pip_no_build_backend(host_reqs or build_reqs, name, hints)
+            name = out.get("name", "").strip()
+            hint_pip_no_build_backend(host_reqs or build_reqs, name, hints)
 
     # 9: No duplicates in conda-forge.yml
     if (

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -117,9 +117,9 @@ def lintify_meta_yaml(
     lints = []
     hints = []
     major_sections = list(meta.keys())
-    lints_to_skip = (
-        _get_forge_yaml(recipe_dir).get("linter", {}).get("skip", [])
-    )
+    lints_to_skip = (_get_forge_yaml(recipe_dir).get("linter") or {}).get(
+        "skip"
+    ) or []
 
     # If the recipe_dir exists (no guarantee within this function) , we can
     # find the meta.yaml within it.
@@ -487,9 +487,9 @@ def run_conda_forge_specific(
     hints,
     recipe_version: int = 0,
 ):
-    lints_to_skip = (
-        _get_forge_yaml(recipe_dir).get("linter", {}).get("skip", [])
-    )
+    lints_to_skip = (_get_forge_yaml(recipe_dir).get("linter") or {}).get(
+        "skip"
+    ) or []
 
     # Retrieve sections from meta
     package_section = get_section(

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -96,6 +96,7 @@ class BotConfigVersionUpdatesSourcesChoice(StrEnum):
 
 class Lints(StrEnum):
     LINT_NOARCH_SELECTORS = "lint_noarch_selectors"
+    HINT_PYTHON_MIN = "hint_python_min"
 
 
 ##############################################

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -96,6 +96,7 @@ class BotConfigVersionUpdatesSourcesChoice(StrEnum):
 
 class Lints(StrEnum):
     LINT_NOARCH_SELECTORS = "lint_noarch_selectors"
+    HINT_PIP_NO_BUILD_BACKEND = "hint_pip_no_build_backend"
     HINT_PYTHON_MIN = "hint_python_min"
 
 

--- a/news/skip-python-hints.rst
+++ b/news/skip-python-hints.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add ``hint_python_min`` and ``hint_pip_no_build_backend`` values to ``linter.skip`` key, allowing to skip respective checks. (#2206)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix a ``TypeError`` when either the ``linter`` key or the ``skip`` subkey is empty. (#2206)
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -3313,23 +3313,38 @@ def test_hint_pip_no_build_backend(
         ),
     ],
 )
+@pytest.mark.parametrize("skip", [False, True])
 def test_hint_noarch_python_use_python_min(
     meta_str,
     expected_hints,
+    skip,
+    tmp_path,
 ):
+    if skip:
+        if not expected_hints:
+            pytest.skip("No hints expected")
+        with open(tmp_path / "conda-forge.yml", "w") as fh:
+            fh.write(
+                """
+linter:
+  skip:
+    - hint_python_min
+"""
+            )
+
     meta = get_yaml().load(render_meta_yaml(meta_str))
     lints = []
     hints = []
     linter.run_conda_forge_specific(
         meta,
-        None,
+        str(tmp_path),
         lints,
         hints,
         recipe_version=0,
     )
 
     # make sure we have the expected hints
-    if expected_hints:
+    if expected_hints and not skip:
         for expected_hint in expected_hints:
             assert any(expected_hint in hint for hint in hints), hints
     else:

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -3067,10 +3067,6 @@ def test_hint_pip_no_build_backend(
     tmp_path,
 ):
     if skip:
-        if (
-            not expected_hints or remove_top_level
-        ) and not outputs_expected_hints:
-            pytest.skip("No hints expected")
         with open(tmp_path / "conda-forge.yml", "w") as fh:
             fh.write(
                 """
@@ -3341,8 +3337,6 @@ def test_hint_noarch_python_use_python_min(
     tmp_path,
 ):
     if skip:
-        if not expected_hints:
-            pytest.skip("No hints expected")
         with open(tmp_path / "conda-forge.yml", "w") as fh:
             fh.write(
                 """


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #2170 

<!--
Please add any other relevant info below:
-->
Add options to skip linter checks for `python_min` and missing build backend, both requested in #2170. While at it, fix a `TypeError` that occurs when `conda-forge.yml` contains empty `linter:` or `skip:` keys.