### PR TITLE
Allow and validate `schema_version` key in v1 recipes

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -126,6 +126,14 @@ def lintify_meta_yaml(
     recipe_name = "meta.yaml" if recipe_version == 0 else "recipe.yaml"
     recipe_fname = os.path.join(recipe_dir or "", recipe_name)
 
+    if recipe_version == 1:
+        schema_version = meta.get("schema_version", 1)
+        if schema_version != 1:
+            lints.append(
+                f"Unsupported recipe.yaml schema version {schema_version}"
+            )
+            return lints, hints
+
     sources_section = get_section(meta, "source", lints, recipe_version)
     build_section = get_section(meta, "build", lints, recipe_version)
     requirements_section = get_section(

--- a/conda_smithy/linter/conda_recipe_v1_linter.py
+++ b/conda_smithy/linter/conda_recipe_v1_linter.py
@@ -15,6 +15,7 @@ from conda_smithy.linter.utils import (
 REQUIREMENTS_ORDER = ["build", "host", "run"]
 
 EXPECTED_SINGLE_OUTPUT_SECTION_ORDER = [
+    "schema_version",
     "context",
     "package",
     "source",
@@ -26,6 +27,7 @@ EXPECTED_SINGLE_OUTPUT_SECTION_ORDER = [
 ]
 
 EXPECTED_MULTIPLE_OUTPUT_SECTION_ORDER = [
+    "schema_version",
     "context",
     "recipe",
     "source",

--- a/news/schema_version.rst
+++ b/news/schema_version.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added validation for ``schema_version`` key. (#2207)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``schema_version`` key no longer causes linting failures. (#2207)
+
+**Security:**
+
+* <news item>

--- a/tests/recipes/v1_recipes/torchvision.yaml
+++ b/tests/recipes/v1_recipes/torchvision.yaml
@@ -1,3 +1,5 @@
+schema_version: 1
+
 context:
   version: 0.20.1
   build_number: 2

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -3865,5 +3865,22 @@ def test_lint_recipe_parses_v1_duplicate_keys():
         ), hints
 
 
+def test_lint_recipe_v1_invalid_schema_version():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:
+            f.write(
+                textwrap.dedent(
+                    """
+                    schema_version: 2
+
+                    package:
+                      name: blah
+                    """
+                )
+            )
+        lints, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
+        assert lints == ["Unsupported recipe.yaml schema version 2"]
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Allow the `schema_version` key in v1 recipes, and validate that it has a value of 1.

For testing:
- lack of `schema_version` is covered by most of the existing tests
- for `schema_version: 1`, I've modified our `torchvision.recipe`
- for invalid `schema_version`, I've added an explicit test