### PR TITLE
Consider `tests[].python.python_version` when linting for cfep25 on v1

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -523,6 +523,9 @@ def run_conda_forge_specific(
             test_reqs += (test_element.get("requirements") or {}).get(
                 "run"
             ) or []
+
+            if "python" in test_element and test_element["python"].get("python_version") is not None:
+                test_reqs.append(f"python {test_element["python"]['python_version']}")
     else:
         test_section = get_section(meta, "test", lints, recipe_version)
         test_reqs = test_section.get("requires") or []

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -529,7 +529,7 @@ def run_conda_forge_specific(
                 and test_element["python"].get("python_version") is not None
             ):
                 test_reqs.append(
-                    f"python {test_element["python"]['python_version']}"
+                    f"python {test_element['python']['python_version']}"
                 )
     else:
         test_section = get_section(meta, "test", lints, recipe_version)

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -524,8 +524,13 @@ def run_conda_forge_specific(
                 "run"
             ) or []
 
-            if "python" in test_element and test_element["python"].get("python_version") is not None:
-                test_reqs.append(f"python {test_element["python"]['python_version']}")
+            if (
+                "python" in test_element
+                and test_element["python"].get("python_version") is not None
+            ):
+                test_reqs.append(
+                    f"python {test_element["python"]['python_version']}"
+                )
     else:
         test_section = get_section(meta, "test", lints, recipe_version)
         test_reqs = test_section.get("requires") or []

--- a/news/v1_cfep25_test.rst
+++ b/news/v1_cfep25_test.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Consider `tests[].python.python_version`` when linting for cfep25 on v1.
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -3882,5 +3882,34 @@ def test_lint_recipe_v1_invalid_schema_version():
         assert lints == ["Unsupported recipe.yaml schema version 2"]
 
 
+def test_lint_recipe_v1_python_min_in_python_version():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:
+            f.write(
+                textwrap.dedent(
+                    """
+                package:
+                  name: python
+
+                build:
+                  noarch: python
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}
+                  run:
+                    - python >=${{ python_min }}
+
+                tests:
+                - python:
+                    imports:
+                        - mypackage
+                    python_version: ${{ python_min }}.*
+                """
+                )
+            )
+        _, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
+        assert hints == []
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -3911,5 +3911,6 @@ def test_lint_recipe_v1_python_min_in_python_version():
         _, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
         assert hints == []
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
