### PR TITLE
fix lint error for v1 recipes with conditionals in run_exports

### DIFF
--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -605,9 +605,8 @@ def lint_pin_subpackages(
         if pinning_section is None:
             return
         filter_pin = "compatible_pin "
-        for pin in (
-            pin for pin in pinning_section if pin.startswith(filter_pin)
-        ):
+        all_pins = flatten_v1_if_else(pinning_section)
+        for pin in (pin for pin in all_pins if pin.startswith(filter_pin)):
             if pin.split()[1] in subpackage_names:
                 lints.append(
                     "pin_subpackage should be used instead of"
@@ -617,9 +616,7 @@ def lint_pin_subpackages(
                 )
 
         filter_pin = "subpackage_pin "
-        for pin in (
-            pin for pin in pinning_section if pin.startswith(filter_pin)
-        ):
+        for pin in (pin for pin in all_pins if pin.startswith(filter_pin)):
             if pin.split()[1] not in subpackage_names:
                 lints.append(
                     "pin_compatible should be used instead of"

--- a/news/v1-flatten-pins.rst
+++ b/news/v1-flatten-pins.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix linter error in check_pins for v1 recipes with conditional run_exports (#2211)
+
+**Security:**
+
+* <news item>

--- a/tests/recipes/v1_recipes/recipe-fenics-dolfinx.yaml
+++ b/tests/recipes/v1_recipes/recipe-fenics-dolfinx.yaml
@@ -1,0 +1,208 @@
+context:
+  name: fenics-dolfinx
+  version: 0.9.0
+  major_minor: ${{ version | split(".") | slice(2) | first | join(".") }}.*
+  ufl_version: "2024.2.*"
+  build: 8
+
+recipe:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/fenics/dolfinx/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: b266c74360c2590c5745d74768c04568c965b44739becca4cd6b5aa58cdbbbd1
+  patches:
+    # cffi is pinned down for a bug
+    # but 1.17 is needed for Windows, CPython 3.13
+    - unpin-cffi.patch
+
+build:
+  number: ${{ (build | int + 100) if scalar == 'real' else build }}
+  skip: win # temporarily
+
+outputs:
+  - package:
+      name: fenics-libdolfinx
+    build:
+      script: build-libdolfinx
+    requirements:
+      build:
+        - ${{ compiler("c") }}
+        - ${{ stdlib("c") }}
+        - ${{ compiler("cxx") }}
+        - cmake
+        - ninja
+        - if: not win
+          then:
+            - pkg-config
+        - if: "mpi == 'openmpi' and build_platform != target_platform"
+          then: ${{ mpi }}
+      host:
+        - ${{ mpi | replace("impi", "impi-devel") }}
+        - if: not win
+          then:
+            - libadios2
+            - libadios2 * mpi_${{ mpi }}_*
+            - kahip
+            - parmetis
+            - petsc
+            - petsc * ${{ scalar }}_*
+            - slepc
+        - libboost-devel
+        - hdf5 ${{ hdf5 }}.* mpi_${{ mpi }}_*
+        - libscotch
+        - libptscotch
+        - pugixml
+        - fmt
+        - spdlog
+        - fenics-libbasix ${{ major_minor }}
+        - fenics-ufcx ${{ major_minor }}
+        - if: win
+          # these shouldn't be required,
+          # but are in INTERFACE_LINK_LIBRARIES for libscotch
+          then:
+            - zlib
+            - liblzma-devel
+      run:
+        # these don't have run_exports
+        # but are needed at runtime for code generation
+        - fenics-ufcx ${{ major_minor }}
+        - if: not win
+          then:
+            - ${{ pin_compatible("parmetis", upper_bound="x.x") }}
+        # needs boost metadata just to CMake-load fenix-libdolfinx
+        - libboost-devel
+        # need these to resolve cmake dependencies of libscotch
+        # (only on windows)
+        - if: win
+          then:
+            - zlib
+            - liblzma-devel
+      run_exports:
+        - ${{ pin_subpackage("fenics-libdolfinx", upper_bound="x.x.x") }}
+        - if: not win
+          then:
+            - petsc * ${{ scalar }}_*
+        - ${{ mpi | replace("impi", "impi_rt") }}
+    tests:
+      - script: test-libdolfinx
+        files:
+          recipe:
+            - if: win
+              then: impi-toolchain.cmake
+          source:
+            - cpp/test/
+        requirements:
+          run:
+            - ${{ compiler("c") }}
+            - ${{ compiler("cxx") }}
+            - if: win
+              then: impi-devel
+            - pkg-config
+            - cmake
+            - catch2 3.*
+            - ninja
+            - fenics-ffcx ${{ major_minor }}
+
+  - package:
+      name: fenics-dolfinx
+    build:
+      script: build-dolfinx
+    requirements:
+      build:
+        - ${{ compiler("c") }}
+        - ${{ stdlib("c") }}
+        - ${{ compiler("cxx") }}
+        - cmake
+        - ninja
+        - pkg-config
+        - if: build_platform != target_platform
+          then: python
+        - if: build_platform != target_platform
+          then: cross-python_${{ target_platform }}
+        - if: build_platform != target_platform
+          then: nanobind
+        - if: mpi == 'openmpi' and build_platform != target_platform
+          then: ${{ mpi }}
+      host:
+        - ${{ mpi | replace("impi", "impi-devel") }}
+        # hdf5 shouldn't be needed here, but solver fails without it
+        - hdf5 ${{ hdf5 }}.* mpi_${{ mpi }}_*
+        - ${{ pin_subpackage("fenics-libdolfinx", exact=True) }}
+        - python
+        - pip
+        - scikit-build-core
+        - wheel
+        - nanobind
+        - fenics-basix ${{ major_minor }}
+        - fenics-basix-nanobind-abi
+        - mpi4py
+        - if: not win
+          then:
+            - petsc * ${{ scalar }}_*
+            - petsc4py
+            - slepc
+            - slepc4py
+        # not actually a dependency of the Python part, but having it here
+        # seems to fix a solver error on libxml2's noicu build
+        - libboost-devel
+      run:
+        # code generation only needs c, not cxx
+        - ${{ compiler("c") }}
+        - pkg-config
+        - python
+        - ${{ pin_subpackage("fenics-libdolfinx", exact=True) }}
+        - cffi
+        - if: not (win or match(python, ">=3.13"))
+          then: cffi <1.17
+        - mpi4py
+        - numpy >=1.21
+        - if: not win
+          then:
+            - petsc4py
+            - slepc4py
+        - fenics-basix ${{ major_minor }}
+        - fenics-ffcx ${{ major_minor }}
+        - fenics-ufl ${{ ufl_version }}
+    tests:
+      - python:
+          pip_check: true
+          imports:
+            - dolfinx
+      - script:
+          file: test-dolfinx
+          env:
+            scalar: ${{ scalar }}
+        files:
+          recipe:
+            - test_dolfinx.py
+          source:
+            - python/demo/
+            - python/test/
+        requirements:
+          run:
+            - pip
+            - pytest >=6
+            - python-gmsh
+            - if: linux and aarch64
+              then: cairo
+            - sympy
+            - scipy
+            - matplotlib-base
+
+about:
+  summary: The computational environment of FEniCSx
+  description: |
+    DOLFINx is the computational environment of FEniCSx
+    and implements the FEniCS Problem Solving Environment in Python and C++.
+  license: LGPL-3.0-or-later
+  license_file: COPYING.LESSER
+  homepage: https://fenicsproject.org
+  repository: https://github.com/fenics/dolfinx
+  documentation: https://docs.fenicsproject.org/dolfinx/v${{ version }}/
+
+extra:
+  feedstock-name: fenics-dolfinx
+  recipe-maintainers:
+    - minrk

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -2754,6 +2754,12 @@ def test_v1_recipes():
         lints, hints = linter.main(str(recipe_dir), return_hints=True)
         assert not lints
 
+    with get_recipe_in_dir(
+        "v1_recipes/recipe-fenics-dolfinx.yaml"
+    ) as recipe_dir:
+        lints, hints = linter.main(str(recipe_dir), return_hints=True)
+        assert not lints
+
     with get_recipe_in_dir("v1_recipes/torchaudio.yaml") as recipe_dir:
         lints, hints = linter.main(str(recipe_dir), return_hints=True)
         assert not lints


### PR DESCRIPTION
Checklist
* [x] Added a ``news`` entry

prior to this, `recipe-lint` failed on a recipe with:

```
  File "/Users/minrk/dev/conda-forge/conda-smithy/conda_smithy/lint_recipe.py", line 749, in main
    results, hints = lintify_meta_yaml(
                     ^^^^^^^^^^^^^^^^^^
  File "/Users/minrk/dev/conda-forge/conda-smithy/conda_smithy/lint_recipe.py", line 343, in lintify_meta_yaml
    lint_pin_subpackages(
  File "/Users/minrk/dev/conda-forge/conda-smithy/conda_smithy/linter/lints.py", line 661, in lint_pin_subpackages
    check_pins_build_and_requirements(meta)
  File "/Users/minrk/dev/conda-forge/conda-smithy/conda_smithy/linter/lints.py", line 659, in check_pins_build_and_requirements
    check_pins(run_export_section)
  File "/Users/minrk/dev/conda-forge/conda-smithy/conda_smithy/linter/lints.py", line 610, in check_pins
    for pin in (
  File "/Users/minrk/dev/conda-forge/conda-smithy/conda_smithy/linter/lints.py", line 611, in <genexpr>
    pin for pin in all_pins if pin.startswith(filter_pin)
                               ^^^^^^^^^^^^^^
AttributeError: 'CommentedMap' object has no attribute 'startswith'
```

Same as #2197, but adds a case not yet covered by that one. Test covered by adding recipe from https://github.com/conda-forge/fenics-dolfinx-feedstock/pull/99