### PR TITLE
more calls to flatten_v1_if_else

### DIFF
--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -497,11 +497,14 @@ def lint_single_space_in_pinned_requirements(
 
 
 def lint_non_noarch_builds(
-    requirements_section, outputs_section, noarch_value, lints
+    requirements_section, outputs_section, noarch_value, lints, recipe_version
 ):
     check_languages = ["python", "r-base"]
     host_reqs = requirements_section.get("host") or []
     run_reqs = requirements_section.get("run") or []
+    if recipe_version == 1:
+        host_reqs = flatten_v1_if_else(host_reqs)
+        run_reqs = flatten_v1_if_else(run_reqs)
     for language in check_languages:
         if noarch_value is None and not outputs_section:
             filtered_host_reqs = [

--- a/news/v1-flatten-pins-more.rst
+++ b/news/v1-flatten-pins-more.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix more linter errors for v1 recipes with conditional dependencies (#2212)
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -2754,12 +2754,6 @@ def test_v1_recipes():
         lints, hints = linter.main(str(recipe_dir), return_hints=True)
         assert not lints
 
-    with get_recipe_in_dir(
-        "v1_recipes/recipe-fenics-dolfinx.yaml"
-    ) as recipe_dir:
-        lints, hints = linter.main(str(recipe_dir), return_hints=True)
-        assert not lints
-
     with get_recipe_in_dir("v1_recipes/torchaudio.yaml") as recipe_dir:
         lints, hints = linter.main(str(recipe_dir), return_hints=True)
         assert not lints
@@ -2771,6 +2765,18 @@ def test_v1_recipes():
     with get_recipe_in_dir("v1_recipes/ada-url.yaml") as recipe_dir:
         lints, hints = linter.main(str(recipe_dir), return_hints=True)
         assert not lints
+
+
+def test_v1_recipes_conda_forge():
+    with get_recipe_in_dir(
+        "v1_recipes/recipe-fenics-dolfinx.yaml"
+    ) as recipe_dir:
+        lints, hints = linter.main(
+            str(recipe_dir), return_hints=True, conda_forge=True
+        )
+        assert lints == [
+            "The feedstock has no `.ci_support` files and thus will not build any packages."
+        ]
 
 
 def test_v1_recipes_ignore_run_exports():


### PR DESCRIPTION
and test a recipe with full conda_forge lint to make sure they are covered

Checklist
* [x] Added a ``news`` entry

follow-up to #2211 which covered `recipe-lint` but missed cases covered by `recipe-lint --conda-forge`

I'm not sure how to get the test run to lose the `.ci_support` hint.