### PR TITLE
Fix handling package version 0, refactor and deduplicate

### DIFF
--- a/conda_smithy/linter/conda_recipe_v1_linter.py
+++ b/conda_smithy/linter/conda_recipe_v1_linter.py
@@ -122,13 +122,11 @@ def get_recipe_version(recipe_content: RecipeWithContext) -> Optional[str]:
     package_version = rendered_context_recipe.get("package", {}).get("version")
     recipe_version = rendered_context_recipe.get("recipe", {}).get("version")
 
-    if not package_version and not recipe_version:
-        return None
-
-    if package_version:
+    if package_version is not None:
         return str(package_version).strip()
-
-    return str(recipe_version).strip()
+    if recipe_version is not None:
+        return str(recipe_version).strip()
+    return None
 
 
 def lint_recipe_name(

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -395,7 +395,11 @@ def lint_noarch_and_runtime_dependencies(
 
 def lint_package_version(package_section, lints):
     version = package_section.get("version")
-    _lint_package_version(str(version) if version is not None else None)
+    lint_msg = _lint_package_version(
+        str(version) if version is not None else None
+    )
+    if lint_msg:
+        lints.append(lint_msg)
 
 
 def lint_jinja_variables_definitions(meta_fname, lints):

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -20,6 +20,7 @@ from conda_smithy.linter.utils import (
     REQUIREMENTS_ORDER,
     TEST_FILES,
     TEST_KEYS,
+    _lint_package_version,
     _lint_recipe_name,
     flatten_v1_if_else,
     get_section,
@@ -395,17 +396,7 @@ def lint_noarch_and_runtime_dependencies(
 
 def lint_package_version(package_section, lints):
     version = package_section.get("version")
-    if not version:
-        lints.append("Package version is missing.")
-        return
-    if package_section.get("version") is not None:
-        ver = str(package_section.get("version"))
-        try:
-            VersionOrder(ver)
-        except InvalidVersionSpec as e:
-            lints.append(
-                f"Package version {ver} doesn't match conda spec: {e}"
-            )
+    _lint_package_version(str(version) if version is not None else None)
 
 
 def lint_jinja_variables_definitions(meta_fname, lints):

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -6,7 +6,6 @@ import tempfile
 from collections.abc import Sequence
 from typing import Any, Literal, Optional
 
-from conda.exceptions import InvalidVersionSpec
 from conda.models.version import VersionOrder
 from rattler_build_conda_compat.jinja.jinja import render_recipe_with_context
 from rattler_build_conda_compat.loader import parse_recipe_config_file

--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -208,7 +208,7 @@ def _lint_package_version(version: Optional[str]) -> Optional[str]:
     no_package_version = "Package version is missing."
     invalid_version = "Package version {ver} doesn't match conda spec: {err}"
 
-    if not version:
+    if version is None:
         return no_package_version
 
     ver = str(version)

--- a/news/fix-version-0.rst
+++ b/news/fix-version-0.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed "missing package version" false positives for version "0". (#2217)
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -3972,5 +3972,22 @@ def test_lint_recipe_v1_comment_selectors():
         ]
 
 
+@pytest.mark.parametrize("filename", ["meta.yaml", "recipe.yaml"])
+def test_version_zero(filename: str):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, filename), "w") as f:
+            f.write(
+                textwrap.dedent(
+                    """
+                package:
+                  name: test
+                  version: 0
+                """
+                )
+            )
+        lints, _ = linter.main(tmpdir, return_hints=True, conda_forge=True)
+        assert "Package version is missing." not in lints
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Fix the boolean logic that caused version of 0 (that is a valid package version) to be incorrectly interpreted as missing, and emit linter errors.  While at it, deduplicate the recipe v0 linter to reuse the utility code added along with v1 lints, and refactor the v1 linter to reduce the number of redundant conditions and make the logic easier to follow.

Fixes #2215

