### PR TITLE
Support outputs in `hint_noarch_python_use_python_min`, also fix if/then/else flattening for non-list clauses

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -73,6 +73,7 @@ from conda_smithy.linter.utils import (
     RATTLER_BUILD_TOOL,
     find_local_config_file,
     flatten_v1_if_else,
+    get_all_test_requirements,
     get_section,
     load_linter_toml_metdata,
 )
@@ -525,25 +526,7 @@ def run_conda_forge_specific(
 
     build_section = get_section(meta, "build", lints, recipe_version)
     noarch_value = build_section.get("noarch")
-
-    if recipe_version == 1:
-        test_section = get_section(meta, "tests", lints, recipe_version)
-        test_reqs = []
-        for test_element in test_section:
-            test_reqs += (test_element.get("requirements") or {}).get(
-                "run"
-            ) or []
-
-            if (
-                "python" in test_element
-                and test_element["python"].get("python_version") is not None
-            ):
-                test_reqs.append(
-                    f"python {test_element['python']['python_version']}"
-                )
-    else:
-        test_section = get_section(meta, "test", lints, recipe_version)
-        test_reqs = test_section.get("requires") or []
+    test_reqs = get_all_test_requirements(meta, lints, recipe_version)
 
     # Fetch list of recipe maintainers
     maintainers = extra_section.get("recipe-maintainers", [])

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -238,7 +238,7 @@ def hint_pip_no_build_backend(host_or_build_section, package_name, hints):
             )
 
 
-def hint_noarch_python_use_python_min_inner(
+def _hint_noarch_python_use_python_min_inner(
     host_reqs,
     run_reqs,
     test_reqs,
@@ -321,11 +321,11 @@ def hint_noarch_python_use_python_min(
                 output_host_reqs = requirements.get("host")
                 output_run_reqs = requirements.get("run")
             else:
-                output_host_reqs = requirements
+                output_host_reqs = None
                 output_run_reqs = requirements
 
             hint.extend(
-                hint_noarch_python_use_python_min_inner(
+                _hint_noarch_python_use_python_min_inner(
                     output_host_reqs or [],
                     output_run_reqs or [],
                     get_all_test_requirements(output, [], recipe_version),
@@ -338,7 +338,7 @@ def hint_noarch_python_use_python_min(
             )
     else:
         hint.extend(
-            hint_noarch_python_use_python_min_inner(
+            _hint_noarch_python_use_python_min_inner(
                 host_reqs,
                 run_reqs,
                 test_reqs,

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -320,21 +320,25 @@ def hint_noarch_python_use_python_min(
                 output_host_reqs = requirements
                 output_run_reqs = requirements
 
-            hint.update(hint_noarch_python_use_python_min_inner(
-                output_host_reqs or [],
-                output_run_reqs or [],
-                get_all_test_requirements(output, [], recipe_version),
-                output.get("build", {}).get("noarch"),
-                recipe_version,
-            ))
+            hint.update(
+                hint_noarch_python_use_python_min_inner(
+                    output_host_reqs or [],
+                    output_run_reqs or [],
+                    get_all_test_requirements(output, [], recipe_version),
+                    output.get("build", {}).get("noarch"),
+                    recipe_version,
+                )
+            )
     else:
-        hint.update(hint_noarch_python_use_python_min_inner(
-            host_reqs,
-            run_reqs,
-            test_reqs,
-            noarch_value,
-            recipe_version,
-        ))
+        hint.update(
+            hint_noarch_python_use_python_min_inner(
+                host_reqs,
+                run_reqs,
+                test_reqs,
+                noarch_value,
+                recipe_version,
+            )
+        )
 
     if hint:
         hint = (

--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -256,7 +256,9 @@ def flatten_v1_if_else(requirements: list[str | dict] | str) -> list[str]:
     return flattened_requirements
 
 
-def get_all_test_requirements(meta: dict, lints: list[str], recipe_version: int) -> list[str]:
+def get_all_test_requirements(
+    meta: dict, lints: list[str], recipe_version: int
+) -> list[str]:
     if recipe_version == 1:
         test_section = get_section(meta, "tests", lints, recipe_version)
         test_reqs = []

--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -248,3 +248,25 @@ def flatten_v1_if_else(requirements: list[str | dict]) -> list[str]:
         else:
             flattened_requirements.append(req)
     return flattened_requirements
+
+
+def get_all_test_requirements(meta: dict, lints: list[str], recipe_version: int) -> list[str]:
+    if recipe_version == 1:
+        test_section = get_section(meta, "tests", lints, recipe_version)
+        test_reqs = []
+        for test_element in test_section:
+            test_reqs += (test_element.get("requirements") or {}).get(
+                "run"
+            ) or []
+
+            if (
+                "python" in test_element
+                and test_element["python"].get("python_version") is not None
+            ):
+                test_reqs.append(
+                    f"python {test_element['python']['python_version']}"
+                )
+    else:
+        test_section = get_section(meta, "test", lints, recipe_version)
+        test_reqs = test_section.get("requires") or []
+    return test_reqs

--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -267,9 +267,7 @@ def get_all_test_requirements(
                 "run"
             ) or []
 
-            if (
-                "python" in test_element
-            ):
+            if "python" in test_element:
                 if test_element["python"].get("python_version") is not None:
                     test_reqs.append(
                         f"python {test_element['python']['python_version']}"

--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -237,13 +237,19 @@ def load_linter_toml_metdata_internal(time_salt):
     return tomllib.loads(hints_toml_str)
 
 
-def flatten_v1_if_else(requirements: list[str | dict]) -> list[str]:
+def flatten_v1_if_else(requirements: list[str | dict] | str) -> list[str]:
     flattened_requirements = []
     for req in requirements:
         if isinstance(req, dict):
-            flattened_requirements.extend(flatten_v1_if_else(req["then"]))
             flattened_requirements.extend(
-                flatten_v1_if_else(req.get("else") or [])
+                flatten_v1_if_else(req["then"])
+                if isinstance(req["then"], list)
+                else [req["then"]]
+            )
+            flattened_requirements.extend(
+                flatten_v1_if_else(req.get("else", []))
+                if isinstance(req.get("else", []), list)
+                else [req["else"]]
             )
         else:
             flattened_requirements.append(req)

--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -269,11 +269,13 @@ def get_all_test_requirements(
 
             if (
                 "python" in test_element
-                and test_element["python"].get("python_version") is not None
             ):
-                test_reqs.append(
-                    f"python {test_element['python']['python_version']}"
-                )
+                if test_element["python"].get("python_version") is not None:
+                    test_reqs.append(
+                        f"python {test_element['python']['python_version']}"
+                    )
+                else:
+                    test_reqs.append("python")
     else:
         test_section = get_section(meta, "test", lints, recipe_version)
         test_reqs = test_section.get("requires") or []

--- a/news/python-min-multi-output.rst
+++ b/news/python-min-multi-output.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added support for multi-output recipes in ``hint_noarch_python_use_python_min`` check. (#2218)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed flattening ``if / then / else`` clauses in v1 recipes with string values of ``then`` and ``else`` keys. (#2218)
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -3374,11 +3374,7 @@ linter:
         for expected_hint in expected_hints:
             assert any(expected_hint in hint for hint in hints), hints
     else:
-        assert all(
-            "noarch: python recipes should almost always follow the syntax in"
-            not in hint
-            for hint in hints
-        )
+        assert all("python_min" not in hint for hint in hints)
 
 
 @pytest.mark.parametrize(
@@ -3551,11 +3547,7 @@ def test_hint_noarch_python_use_python_min_v1(
         for expected_hint in expected_hints:
             assert any(expected_hint in hint for hint in hints), hints
     else:
-        assert all(
-            "noarch: python recipes should almost always follow the syntax in"
-            not in hint
-            for hint in hints
-        )
+        assert all("python_min" not in hint for hint in hints)
 
 
 def test_hint_noarch_python_from_main_v1():

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -3339,6 +3339,123 @@ linter:
             ),
             [],
         ),
+        (
+            textwrap.dedent(
+                """
+                package:
+                  name: python
+
+                outputs:
+                  - name: python-foo
+                    build:
+                      noarch: python
+
+                    requirements:
+                      host:
+                        - python {{ python_min }}
+                      run:
+                        - python >={{ python_min }}
+
+                    test:
+                      requires:
+                        - python {{ python_min }}
+                """
+            ),
+            [],
+        ),
+        (
+            textwrap.dedent(
+                """
+                package:
+                  name: python
+
+                outputs:
+                  - name: python-foo
+                    build:
+                      noarch: python
+
+                    requirements:
+                      host:
+                        - python {{ python_min }}
+                      run:
+                        - python
+
+                    test:
+                      requires:
+                        - python {{ python_min }}
+                """
+            ),
+            ["python >={{ python_min }}"],
+        ),
+        (
+            textwrap.dedent(
+                """
+                package:
+                  name: python
+
+                outputs:
+                  - name: python-foo
+                    build:
+                      noarch: python
+
+                    requirements:
+                      host:
+                        - python {{ python_min }}
+                      run:
+                        - python >={{ python_min }}
+
+                    test:
+                      requires:
+                        - python {{ python_min }}
+                  - name: python-bar
+                    build:
+                      noarch: python
+
+                    requirements:
+                      - python
+
+                    test:
+                      requires:
+                        - python
+                """
+            ),
+            ["python {{ python_min }}"],
+        ),
+        (
+            textwrap.dedent(
+                """
+                package:
+                  name: python
+
+                outputs:
+                  - name: python-foo
+                    build:
+                      noarch: python
+
+                    requirements:
+                      host:
+                        - python {{ python_min }}
+                      run:
+                        - python >={{ python_min }}
+
+                    test:
+                      requires:
+                        - python {{ python_min }}
+                  - name: python-bar
+
+                    requirements:
+                      host:
+                        - python
+                      run:
+                        - python
+
+                    test:
+                      requires:
+                        - python
+                """
+            ),
+            [],
+        ),
     ],
 )
 @pytest.mark.parametrize("skip", [False, True])
@@ -3523,6 +3640,120 @@ tests:
       run:
         - python ${{ python_min }}
 """,
+            [],
+        ),
+        (
+            textwrap.dedent(
+                """
+                recipe:
+                  name: python
+
+                outputs:
+                  - package:
+                      name: python-foo
+                    build:
+                      noarch: python
+                    requirements:
+                      host:
+                        - if: blah
+                          then: blahblah
+                          else: python ${{ python_min }}
+                      run:
+                        - python >=${{ python_min }}
+
+                    tests:
+                      - requirements:
+                          run:
+                            - python ${{ python_min }}
+                """
+            ),
+            [],
+        ),
+        (
+            textwrap.dedent(
+                """
+                recipe:
+                  name: python
+
+                outputs:
+                  - package:
+                      name: python-foo
+                    build:
+                      noarch: python
+                    requirements:
+                      host:
+                        - if: blah
+                          then: blahblah
+                          else: python
+                      run:
+                        - python >=${{ python_min }}
+
+                    tests:
+                      - requirements:
+                          run:
+                            - python ${{ python_min }}
+                  - package:
+                      name: python-bar
+                    build:
+                      noarch: python
+                    requirements:
+                      host:
+                        - if: blah
+                          then: blahblah
+                          else: python ${{ python_min }}
+                      run:
+                        - python
+
+                    tests:
+                      - requirements:
+                          run:
+                            - python ${{ python_min }}
+                """
+            ),
+            [
+                "python ${{ python_min }}",
+                "python >=${{ python_min }}",
+            ],
+        ),
+        (
+            textwrap.dedent(
+                """
+                recipe:
+                  name: python
+
+                outputs:
+                  - package:
+                      name: python-foo
+                    build:
+                      noarch: python
+                    requirements:
+                      host:
+                        - if: blah
+                          then: blahblah
+                          else: python ${{ python_min }}
+                      run:
+                        - python >=${{ python_min }}
+
+                    tests:
+                      - requirements:
+                          run:
+                            - python ${{ python_min }}
+                  - package:
+                      name: python-bar
+                    requirements:
+                      host:
+                        - if: blah
+                          then: blahblah
+                          else: python
+                      run:
+                        - python
+
+                    tests:
+                      - requirements:
+                          run:
+                            - python
+                """
+            ),
             [],
         ),
     ],


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Add support for checking `python_min` use in multi-output recipes (#2188). This involves some minimal refactoring to move shared code into common functions.

While at it, accidentally discovered a bug that the following dependency:

```yaml
- if: foo
  then: bar
  else: baz
```

would be incorrectly flattened (`bar` would be iterated over as a list).