### PR TITLE
`get_repo_root` returns `os.path.realpath`

### DIFF
--- a/news/fix-macos-path-comparison.rst
+++ b/news/fix-macos-path-comparison.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix `tests/test_feedstock_io.py::TestFeedstockIO::test_repo` path comparison to use `os.path.realpath`. (#2220)
+
+**Security:**
+
+* <news item>

--- a/tests/test_feedstock_io.py
+++ b/tests/test_feedstock_io.py
@@ -75,7 +75,9 @@ class TestFeedstockIO(unittest.TestCase):
                     ),
                 )
                 os.makedirs(possible_repo_subdir)
-                assert fio.get_repo_root(possible_repo_subdir) == os.path.realpath(tmp_dir)
+                assert fio.get_repo_root(
+                    possible_repo_subdir
+                ) == os.path.realpath(tmp_dir)
 
     def test_set_exe_file(self):
         perms = [stat.S_IXUSR, stat.S_IXGRP, stat.S_IXOTH]

--- a/tests/test_feedstock_io.py
+++ b/tests/test_feedstock_io.py
@@ -75,7 +75,7 @@ class TestFeedstockIO(unittest.TestCase):
                     ),
                 )
                 os.makedirs(possible_repo_subdir)
-                assert fio.get_repo_root(possible_repo_subdir) == tmp_dir
+                assert fio.get_repo_root(possible_repo_subdir) == os.path.realpath(tmp_dir)
 
     def test_set_exe_file(self):
         perms = [stat.S_IXUSR, stat.S_IXGRP, stat.S_IXOTH]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Resolves macOS test failures uncovered in conda-feedstock & conda-build-feedstock downstream tests:

- https://github.com/conda-forge/conda-feedstock/pull/248#issuecomment-2555819613
- https://github.com/conda-forge/conda-feedstock/pull/248/commits/d28a86ffd666f1b11854ac87d733827a4ed14936
- https://github.com/conda-forge/conda-build-feedstock/pull/238/commits/f316c88dfa193ce03198e27994b09c1144880150

Since the CI doesn't test macOS I'm including screenshots showing I replicated the test failure on my local macOS and confirmed the fix:

<img width="1383" alt="Screenshot 2025-01-15 at 10 38 27" src="https://github.com/user-attachments/assets/91649f1e-19b9-41fe-9e97-f1001ac0d37b" />
<img width="1383" alt="Screenshot 2025-01-15 at 10 38 49" src="https://github.com/user-attachments/assets/d7671066-038a-4fd9-b321-1256317f3691" />
