### PR TITLE
always keep python_min as used variable (if it's present in the recipe)

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -560,9 +560,9 @@ def _collapse_subpackage_variants(
         recipe_path = os.path.join(recipe_dir, "recipe.yaml")
     # either v0 or v1 recipe must exist; no fall-back if missing
     with open(recipe_path) as f:
-        lines = f.readlines()
+        meta_text = f.read()
     pm_pat = re.compile(r".*\{\{ python_min \}\}")
-    if any(pm_pat.match(x) for x in lines):
+    if pm_pat.match(meta_text):
         all_used_vars.add("python_min")
 
     # on osx, merge MACOSX_DEPLOYMENT_TARGET & c_stdlib_version to max of either; see #1884

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -548,9 +548,8 @@ def _collapse_subpackage_variants(
     has_macdt = False
     if os.path.exists(cbc_path):
         with open(cbc_path) as f:
-            lines = f.readlines()
-        dt_pat = re.compile(r"^\s*MACOSX_DEPLOYMENT_TARGET:")
-        if any(dt_pat.match(x) for x in lines):
+            cbc_text = f.read()
+        if re.match(r"^\s*MACOSX_DEPLOYMENT_TARGET:", cbc_text):
             has_macdt = True
 
     # check if recipe contains `python_min`; add it to used_vars if so; we cannot use
@@ -561,8 +560,7 @@ def _collapse_subpackage_variants(
     # either v0 or v1 recipe must exist; no fall-back if missing
     with open(recipe_path) as f:
         meta_text = f.read()
-    pm_pat = re.compile(r".*\{\{ python_min \}\}")
-    if pm_pat.match(meta_text):
+    if re.match(r".*\{\{ python_min \}\}", meta_text):
         all_used_vars.add("python_min")
 
     # on osx, merge MACOSX_DEPLOYMENT_TARGET & c_stdlib_version to max of either; see #1884

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -549,7 +549,8 @@ def _collapse_subpackage_variants(
     if os.path.exists(cbc_path):
         with open(cbc_path) as f:
             lines = f.readlines()
-        if any(re.match(r"^\s*MACOSX_DEPLOYMENT_TARGET:", x) for x in lines):
+        dt_pat = re.compile(r"^\s*MACOSX_DEPLOYMENT_TARGET:")
+        if any(dt_pat.match(x) for x in lines):
             has_macdt = True
 
     # check if recipe contains `python_min`; add it to used_vars if so; we cannot use
@@ -560,7 +561,8 @@ def _collapse_subpackage_variants(
     # either v0 or v1 recipe must exist; no fall-back if missing
     with open(recipe_path) as f:
         lines = f.readlines()
-    if any(re.match(r".*\{\{ python_min \}\}", x) for x in lines):
+    pm_pat = re.compile(r".*\{\{ python_min \}\}")
+    if any(pm_pat.match(x) for x in lines):
         all_used_vars.add("python_min")
 
     # on osx, merge MACOSX_DEPLOYMENT_TARGET & c_stdlib_version to max of either; see #1884

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -599,6 +599,7 @@ def _collapse_subpackage_variants(
         "channel_targets",
         "docker_image",
         "build_number_decrement",
+        "python_min",
         # The following keys are required for some of our aarch64 builds
         # Added in https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/180
         "cdt_arch",

--- a/news/python_min.rst
+++ b/news/python_min.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Always populate variant configs with `python_min`, if present
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -293,6 +293,22 @@ def test_stdlib_deployment_target(
     assert re.match(r"(?s).*MACOSX_SDK_VERSION:\s*- ['\"]?10\.14", content)
 
 
+def test_mixed_python_min(mixed_python_min_recipe, jinja_env, caplog, request):
+    with caplog.at_level(logging.WARNING):
+        configure_feedstock.render_azure(
+            jinja_env=jinja_env,
+            forge_config=mixed_python_min_recipe.config,
+            forge_dir=mixed_python_min_recipe.recipe,
+        )
+    matrix_dir = os.path.join(mixed_python_min_recipe.recipe, ".ci_support")
+    assert os.path.isdir(matrix_dir)
+    for file in os.listdir(matrix_dir):
+        with open(os.path.join(matrix_dir, file)) as f:
+            lines = f.readlines()
+    # ensure python_min is set for all platforms
+    assert any(re.match(r"^python_min:.*", x) for x in lines)
+
+
 def test_upload_on_branch_azure(upload_on_branch_recipe, jinja_env):
     configure_feedstock.render_azure(
         jinja_env=jinja_env,

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -312,6 +312,22 @@ def test_mixed_python_min(mixed_python_min_recipe, jinja_env, caplog, request):
     assert any(re.match(r"^python_min:.*", x) for x in lines)
 
 
+def test_no_python_min_if_not_present(py_recipe, jinja_env, caplog, request):
+    with caplog.at_level(logging.WARNING):
+        configure_feedstock.render_azure(
+            jinja_env=jinja_env,
+            forge_config=py_recipe.config,
+            forge_dir=py_recipe.recipe,
+        )
+    matrix_dir = os.path.join(py_recipe.recipe, ".ci_support")
+    assert os.path.isdir(matrix_dir)
+    for file in os.listdir(matrix_dir):
+        with open(os.path.join(matrix_dir, file)) as f:
+            lines = f.readlines()
+    # ensure python_min does NOT appear all platforms
+    assert all(not re.match(r"^python_min:.*", x) for x in lines)
+
+
 def test_upload_on_branch_azure(upload_on_branch_recipe, jinja_env):
     configure_feedstock.render_azure(
         jinja_env=jinja_env,

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -264,8 +264,7 @@ def test_stdlib_deployment_target(
 ):
     conda_build_param = request.node.callspec.params["config_yaml"]
     if conda_build_param == "rattler-build":
-        # stdlib is not yet implemented in rattler-build
-        # https://github.com/prefix-dev/rattler-build/issues/239
+        # stdlib_deployment_target_recipe fixture doesn't have a recipe.yaml variant
         pytest.skip("skipping test for rattler-build usecase")
 
     with caplog.at_level(logging.WARNING):
@@ -294,6 +293,10 @@ def test_stdlib_deployment_target(
 
 
 def test_mixed_python_min(mixed_python_min_recipe, jinja_env, caplog, request):
+    conda_build_param = request.node.callspec.params["config_yaml"]
+    if conda_build_param == "rattler-build":
+        # mixed_python_min_recipe fixture doesn't have a recipe.yaml variant
+        pytest.skip("skipping test for rattler-build usecase")
     with caplog.at_level(logging.WARNING):
         configure_feedstock.render_azure(
             jinja_env=jinja_env,


### PR DESCRIPTION
For recipes that have noarch-outputs as well as non-noarch outputs, the use of `{{ python_min }}` causes the recipe to fail for all platforms that don't build the noarch output, because smithy doesn't populate `python_min` for them, and then conda-build cannot parse something like
```yaml
  - name: lit
    build:
      noarch: python
      script: python -m pip install llvm/utils/lit --no-deps -vv
      skip: true  # [not linux64]
    requirements:
      host:
        - python {{ python_min }}
```
despite the fact that that output would be skipped on other platforms. It's possible to [work around](https://github.com/conda-forge/brial-feedstock/pull/37) this with something like
```yaml
{% if python_min is undefined %}
{% set python_min = "3.9" %}
{% endif %}
```
but that's ugly. To avoid these shenanigans, just always populate `python_min` in the variant configs when it's present.

I've rerendered https://github.com/conda-forge/llvmdev-feedstock/pull/308 with a smithy installed from this PR and it works as expected.