### PR TITLE
Hint against `=`-separated match specs

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -413,12 +413,13 @@ def lintify_meta_yaml(
 
     # 7: warn of `name =version=build` specs, suggest `name version build`
     # see https://github.com/conda/conda-build/issues/5571#issuecomment-2604505922
-    hint_space_separated_specs(
-        requirements_section,
-        [test_section] if hasattr(test_section, "items") else test_section,
-        outputs_section,
-        hints,
-    )
+    if recipe_version == 0:
+        hint_space_separated_specs(
+            requirements_section,
+            test_section,
+            outputs_section,
+            hints,
+        )
 
     return lints, hints
 

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -415,7 +415,7 @@ def lintify_meta_yaml(
     # see https://github.com/conda/conda-build/issues/5571#issuecomment-2604505922
     hint_space_separated_specs(
         requirements_section,
-        test_section,
+        [test_section] if hasattr(test_section, "items") else test_section,
         outputs_section,
         hints,
     )

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -31,6 +31,7 @@ from conda_smithy.linter.hints import (
     hint_pip_usage,
     hint_shellcheck_usage,
     hint_sources_should_not_mention_pypi_io_but_pypi_org,
+    hint_space_separated_specs,
     hint_suggest_noarch,
 )
 from conda_smithy.linter.lints import (
@@ -408,6 +409,15 @@ def lintify_meta_yaml(
         lints,
         hints,
         recipe_version=recipe_version,
+    )
+
+    # 7: warn of `name =version=build` specs, suggest `name version build`
+    # see https://github.com/conda/conda-build/issues/5571#issuecomment-2604505922
+    hint_space_separated_specs(
+        requirements_section,
+        test_section,
+        outputs_section,
+        hints,
     )
 
     return lints, hints

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -368,18 +368,14 @@ def hint_noarch_python_use_python_min(
 
 def hint_space_separated_specs(
     requirements_section,
-    test_sections,
+    test_section,
     outputs_section,
     hints,
 ):
     report = {}
     for req_type, reqs in {
         **requirements_section,
-        "test": [
-            req
-            for section in test_sections
-            for req in section.get("requires", ())
-        ],
+        "test": test_section.get("requires", []),
     }.items():
         bad_specs = [
             req for req in reqs if not _ensure_spec_space_separated(req)

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -368,14 +368,18 @@ def hint_noarch_python_use_python_min(
 
 def hint_space_separated_specs(
     requirements_section,
-    test_section,
+    test_sections,
     outputs_section,
     hints,
 ):
     report = {}
     for req_type, reqs in {
         **requirements_section,
-        "test": test_section.get("requires", []),
+        "test": [
+            req
+            for section in test_sections
+            for req in section.get("requires", ())
+        ],
     }.items():
         bad_specs = [
             req for req in reqs if not _ensure_spec_space_separated(req)

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -375,22 +375,25 @@ def hint_space_separated_specs(
     report = {}
     for req_type, reqs in {
         **requirements_section,
-        "test": test_section.get("requires", []),
+        "test": test_section.get("requires") or (),
     }.items():
         bad_specs = [
-            req for req in reqs if not _ensure_spec_space_separated(req)
+            req
+            for req in (reqs or ())
+            if not _ensure_spec_space_separated(req)
         ]
         if bad_specs:
             report.setdefault("top-level", {})[req_type] = bad_specs
     for output in outputs_section:
+        requirements_section = output.get("requirements") or {}
+        if not hasattr(requirements_section, "items"):
+            # not a dict, but a list (CB2 style)
+            requirements_section = {"run": requirements_section}
         for req_type, reqs in {
-            "build": output.get("requirements", {}).get("build") or [],
-            "host": output.get("requirements", {}).get("host") or [],
-            "run": output.get("requirements", {}).get("run") or [],
-            "test": output.get("requirements", {})
-            .get("test", {})
-            .get("requires")
-            or [],
+            "build": requirements_section.get("build") or [],
+            "host": requirements_section.get("host") or [],
+            "run": requirements_section.get("run") or [],
+            "test": output.get("test", {}).get("requires") or [],
         }.items():
             bad_specs = [
                 req for req in reqs if not _ensure_spec_space_separated(req)

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -374,10 +374,12 @@ def hint_space_separated_specs(
 ):
     report = {}
     for req_type, reqs in {
-        **requirements_section, 
+        **requirements_section,
         "test": test_section.get("requires", []),
     }.items():
-        bad_specs = [req for req in reqs if not _ensure_spec_space_separated(req)]
+        bad_specs = [
+            req for req in reqs if not _ensure_spec_space_separated(req)
+        ]
         if bad_specs:
             report.setdefault("top-level", {})[req_type] = bad_specs
     for output in outputs_section:
@@ -385,9 +387,14 @@ def hint_space_separated_specs(
             "build": output.get("requirements", {}).get("build") or [],
             "host": output.get("requirements", {}).get("host") or [],
             "run": output.get("requirements", {}).get("run") or [],
-            "test": output.get("requirements", {}).get("test", {}).get("requires") or [],
+            "test": output.get("requirements", {})
+            .get("test", {})
+            .get("requires")
+            or [],
         }.items():
-            bad_specs = [req for req in reqs if not _ensure_spec_space_separated(req)]
+            bad_specs = [
+                req for req in reqs if not _ensure_spec_space_separated(req)
+            ]
             if bad_specs:
                 report.setdefault(output, {})[req_type] = bad_specs
 

--- a/news/2232-matchspecs-equal
+++ b/news/2232-matchspecs-equal
@@ -1,0 +1,23 @@
+**Added:**
+
+* Linter: Report hint if some of the requirements in a ``meta.yaml`` recipe are not using space-separated ``MatchSpec`` syntax. (#2232)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 import conda_smithy.lint_recipe as linter
+from conda_smithy.linter import hints
 from conda_smithy.linter.utils import VALID_PYTHON_BUILD_BACKENDS
 from conda_smithy.utils import get_yaml, render_meta_yaml
 
@@ -4209,6 +4210,52 @@ def test_version_zero(filename: str):
             )
         lints, _ = linter.main(tmpdir, return_hints=True, conda_forge=True)
         assert "Package version is missing." not in lints
+
+
+@pytest.mark.parametrize(
+    "spec, result",
+    [
+        ("python", True),
+        ("python 3.9", True),
+        ("python 3.9 *cpython*", True),
+        ("python 3.9=*cpython*", False),
+        ("python =3.9=*cpython*", False),
+        ("python=3.9=*cpython*", False),
+        ("python malformed=*cpython*", False),
+    ]
+)
+def test_bad_specs(spec, result):
+    assert hints._ensure_spec_space_separated(spec) is result
+
+
+@pytest.mark.parametrize(
+    "spec, ok",
+    [
+        ("python", True),
+        ("python 3.9", True),
+        ("python 3.9 *cpython*", True),
+        ("python 3.9=*cpython*", False),
+        ("python =3.9=*cpython*", False),
+        ("python=3.9=*cpython*", False),
+        ("python malformed=*cpython*", False),
+    ]
+)
+def test_bad_specs_report(tmp_path, spec, ok):
+    (tmp_path / "meta.yaml").write_text(
+        textwrap.dedent(
+            f"""
+            package:
+                name: foo
+            requirements:
+                run:
+                - {spec}
+            """
+        )
+    )
+
+    _, hints = linter.main(tmp_path, return_hints=True)
+    print(hints)
+    assert all("has some malformed specs" not in hint for hint in hints) is ok
 
 
 if __name__ == "__main__":

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4222,7 +4222,7 @@ def test_version_zero(filename: str):
         ("python =3.9=*cpython*", False),
         ("python=3.9=*cpython*", False),
         ("python malformed=*cpython*", False),
-    ]
+    ],
 )
 def test_bad_specs(spec, result):
     assert hints._ensure_spec_space_separated(spec) is result
@@ -4238,7 +4238,7 @@ def test_bad_specs(spec, result):
         ("python =3.9=*cpython*", False),
         ("python=3.9=*cpython*", False),
         ("python malformed=*cpython*", False),
-    ]
+    ],
 )
 def test_bad_specs_report(tmp_path, spec, ok):
     (tmp_path / "meta.yaml").write_text(


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

@h-vetinari raised this issue in conda-build (https://github.com/conda/conda-build/issues/5571), which led us to realizing that conda-build assumes all specs in a `meta.yaml` are space separated. However, this is not checked and `=`-separated specs are happily accepted. The problem is that they bypass some checks like [this one about incompatible hashes](https://github.com/conda/conda-build/issues/5571#issuecomment-2604505922) because they are not a "three field matchspec".

I don't think we can forbid this and error out in conda-build, but at least we should hint against it to inform folks about this possible footgun. The repodata.json entries should only contain three-field matchspecs anyway (for backwards compat).
