### PR TITLE
lower limit at which we start shortening filenames for variant configs

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -791,12 +791,13 @@ def dump_subspace_config_files(
             package_key(config, top_level_loop_vars, metas[0].config.subdir),
         )
         short_config_name = config_name
+        salt = hashlib.sha256(config_name.encode("utf-8")).hexdigest()[:8]
+        # drone has a limit of 50, see https://github.com/conda-forge/conda-smithy/issues/1188
         if len(short_config_name) >= 49:
-            h = hashlib.sha256(config_name.encode("utf-8")).hexdigest()[:10]
-            short_config_name = config_name[:35] + "_h" + h
-        if len("conda-forge-build-done-" + config_name) >= 250:
+            short_config_name = config_name[:40] + "_h" + salt
+        if len("conda-forge-build-done-" + config_name) >= 200:
             # Shorten file name length to avoid hitting maximum filename limits.
-            config_name = short_config_name
+            config_name = config_name[:190] + "_h" + salt
 
         out_folder = os.path.join(root_path, ".ci_support")
         out_path = os.path.join(out_folder, config_name) + ".yaml"


### PR DESCRIPTION
This was proposed by Isuru [here](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6910#issuecomment-2614206765). I don't know where the limit on the windows server from prefix is coming from, normally filenames until 260 characters should be fine, but it _still_ fails in https://github.com/conda-forge/pytorch-cpu-feedstock/pull/332 (which has been rerendered with the changes this PR) with
```
Checking out the ref
  "C:\Program Files\Git\bin\git.exe" checkout --progress --force refs/remotes/pull/332/merge
  Error: error: unable to create file .ci_support/linux_64_blas_implgenericc_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13github_actions_labelscirun-openstack-cpu-2xlargeis_h2ab6b548.yaml: Filename too long
  Error: error: unable to create file .ci_support/linux_64_blas_implgenericc_compiler_version13channel_targetsconda-forge_maincuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13github_actions_labelscirun-openstack-gpu-2xlargeis_h6173e25b.yaml: Filename too long
```

On the other hand, I don't want to shorten the config names too much, because then we lose a lot of information which is relevant for the pytorch/tensorflow feedstocks, like is this a CPU or GPU job (doubly so if we'd take the doubled CI as in https://github.com/conda-forge/pytorch-cpu-feedstock/pull/332), and it's not desirable to just too-short filenames that are only distinguishable by hashes, where one has no idea which exact config is behind when looking at the actions UI.