### PR TITLE
consistently set `encoding=utf-8` for opening files

### DIFF
--- a/conda_smithy/ci_skeleton.py
+++ b/conda_smithy/ci_skeleton.py
@@ -21,7 +21,7 @@ def _render_template(template_file, env, forge_dir, config):
     print("Generating " + target_fname, file=sys.stderr)
     new_file_contents = template.render(**config)
     os.makedirs(os.path.dirname(target_fname), exist_ok=True)
-    with open(target_fname, "w") as fh:
+    with open(target_fname, "w", encoding="utf-8") as fh:
         fh.write(new_file_contents)
 
 
@@ -40,7 +40,7 @@ def _insert_into_gitignore(
     fname = os.path.join(feedstock_directory, ".gitignore")
     print("Updating " + fname)
     if os.path.isfile(fname):
-        with open(fname) as f:
+        with open(fname, encoding="utf-8") as f:
             s = f.read()
         before, _, s = s.partition(prefix)
         _, _, after = s.partition(suffix)
@@ -51,7 +51,7 @@ def _insert_into_gitignore(
             os.makedirs(dname, exist_ok=True)
     new = prefix + GITIGNORE_ADDITIONAL + suffix
     # write out the file
-    with open(fname, "w") as f:
+    with open(fname, "w", encoding="utf-8") as f:
         f.write(before + new + after)
     return fname
 

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -70,12 +70,12 @@ def generate_feedstock_content(
             os.path.join(target_recipe_dir, "conda-forge.yml")
         )
         try:
-            with open(forge_yml_recipe) as fp:
+            with open(forge_yml_recipe, encoding="utf-8") as fp:
                 _cfg = yaml.load(fp.read())
         except Exception:
             _cfg = {}
 
-        with open(forge_yml) as fp:
+        with open(forge_yml, encoding="utf-8") as fp:
             _cfg_feedstock = yaml.load(fp.read())
             merge_dict(_cfg, _cfg_feedstock)
         with feedstock_io.write_file(forge_yml) as fp:

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1036,7 +1036,8 @@ def _render_ci_provider(
         # detect if `compiler('cuda')` is used in meta.yaml,
         # and set appropriate environment variable
         with open(
-            os.path.join(forge_dir, forge_config["recipe_dir"], recipe_file)
+            os.path.join(forge_dir, forge_config["recipe_dir"], recipe_file),
+            encoding="utf-8",
         ) as f:
             meta_lines = f.readlines()
         # looking for `compiler('cuda')` with both quote variants;
@@ -2108,7 +2109,9 @@ def render_readme(jinja_env, forge_config, forge_dir, render_info=None):
             if filename.endswith(".yaml"):
                 variant_name, _ = os.path.splitext(filename)
                 variants.append(variant_name)
-                with open(os.path.join(ci_support_path, filename)) as fh:
+                with open(
+                    os.path.join(ci_support_path, filename), encoding="utf-8"
+                ) as fh:
                     data = yaml.safe_load(fh)
                     channel_targets.append(
                         data.get("channel_targets", ["conda-forge main"])[0]
@@ -2617,7 +2620,7 @@ def get_cfp_file_path(temporary_directory):
 
     response = requests.get(pkg.url)
     response.raise_for_status()
-    with open(dest, "wb") as f:
+    with open(dest, "wb", encoding="utf-8") as f:
         f.write(response.content)
 
     logger.info("Extracting conda-forge-pinning to %s", temporary_directory)

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -547,7 +547,7 @@ def _collapse_subpackage_variants(
     cbc_path = os.path.join(recipe_dir, "conda_build_config.yaml")
     has_macdt = False
     if os.path.exists(cbc_path):
-        with open(cbc_path) as f:
+        with open(cbc_path, encoding="utf-8") as f:
             cbc_text = f.read()
         if re.match(r"^\s*MACOSX_DEPLOYMENT_TARGET:", cbc_text):
             has_macdt = True
@@ -558,7 +558,7 @@ def _collapse_subpackage_variants(
     if not os.path.exists(recipe_path):
         recipe_path = os.path.join(recipe_dir, "recipe.yaml")
     # either v0 or v1 recipe must exist; no fall-back if missing
-    with open(recipe_path) as f:
+    with open(recipe_path, encoding="utf-8") as f:
         meta_text = f.read()
     pm_pat = re.compile(r".*\{\{ python_min \}\}")
     if any(pm_pat.match(x) for x in meta_text.splitlines()):
@@ -896,7 +896,7 @@ def migrate_combined_spec(combined_spec, forge_dir, config, forge_config):
     from conda_smithy.variant_algebra import parse_variant, variant_add
 
     migration_variants = [
-        (fn, parse_variant(open(fn).read(), config=config))
+        (fn, parse_variant(open(fn, encoding="utf-8").read(), config=config))
         for fn in migrations
     ]
 
@@ -1398,7 +1398,7 @@ def generate_yum_requirements(forge_config, forge_dir):
     )
     yum_build_setup = ""
     if os.path.exists(yum_requirements_fpath):
-        with open(yum_requirements_fpath) as fh:
+        with open(yum_requirements_fpath, encoding="utf-8") as fh:
             requirements = [
                 line.strip()
                 for line in fh
@@ -1548,7 +1548,7 @@ def _render_template_exe_files(
         if target_fname in get_common_scripts(forge_dir) and os.path.exists(
             target_fname
         ):
-            with open(target_fname) as fh:
+            with open(target_fname, encoding="utf-8") as fh:
                 old_file_contents = fh.read()
                 if old_file_contents != new_file_contents:
                     import difflib
@@ -2288,7 +2288,7 @@ def _update_dict_within_dict(items, config):
 
 def _read_forge_config(forge_dir, forge_yml=None):
     # Load default values from the conda-forge.yml file
-    with open(CONDA_FORGE_YAML_DEFAULTS_FILE) as fh:
+    with open(CONDA_FORGE_YAML_DEFAULTS_FILE, encoding="utf-8") as fh:
         default_config = yaml.safe_load(fh.read())
 
     if forge_yml is None:
@@ -2303,7 +2303,7 @@ def _read_forge_config(forge_dir, forge_yml=None):
             " feedstock root if it's the latter."
         )
 
-    with open(forge_yml) as fh:
+    with open(forge_yml, encoding="utf-8") as fh:
         documents = list(yaml.safe_load_all(fh))
         file_config = (documents or [None])[0] or {}
 
@@ -2745,7 +2745,7 @@ def get_migrations_in_dir(migrations_root):
     """
     res = {}
     for fn in glob.glob(os.path.join(migrations_root, "*.yaml")):
-        with open(fn) as f:
+        with open(fn, encoding="utf-8") as f:
             contents = f.read()
             migration_yaml = (
                 yaml.load(contents, Loader=yaml.loader.BaseLoader) or {}

--- a/conda_smithy/feedstocks.py
+++ b/conda_smithy/feedstocks.py
@@ -257,6 +257,7 @@ def feedstocks_yaml(
                         os.path.join(
                             feedstock.directory, "recipe", "meta.yaml"
                         ),
+                        encoding="utf-8",
                     ) as fh:
                         content = "".join(fh.readlines())
                 else:

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -96,7 +96,7 @@ def _get_forge_yaml(recipe_dir: Optional[str] = None) -> dict:
             )
         )
         if forge_yaml_filename:
-            with open(forge_yaml_filename[0]) as fh:
+            with open(forge_yaml_filename[0], encoding="utf-8") as fh:
                 forge_yaml = get_yaml().load(fh)
         else:
             forge_yaml = {}
@@ -274,7 +274,7 @@ def lintify_meta_yaml(
         )
 
         if conda_build_config_filename:
-            with open(conda_build_config_filename) as fh:
+            with open(conda_build_config_filename, encoding="utf-8") as fh:
                 conda_build_config_keys = set(get_yaml().load(fh).keys())
         else:
             conda_build_config_keys = set()
@@ -284,7 +284,7 @@ def lintify_meta_yaml(
         )
 
         if forge_yaml_filename:
-            with open(forge_yaml_filename) as fh:
+            with open(forge_yaml_filename, encoding="utf-8") as fh:
                 forge_yaml = get_yaml().load(fh)
         else:
             forge_yaml = {}
@@ -649,7 +649,7 @@ def run_conda_forge_specific(
         )
     ):
         try:
-            with open(cfyml_pth) as fh:
+            with open(cfyml_pth, encoding="utf-8") as fh:
                 get_yaml(allow_duplicate_keys=False).load(fh)
         except DuplicateKeyError:
             lints.append(
@@ -675,7 +675,7 @@ def run_conda_forge_specific(
         recipe_fname = os.path.join(recipe_dir or "", "meta.yaml")
 
     if os.path.exists(recipe_fname):
-        with open(recipe_fname) as fh:
+        with open(recipe_fname, encoding="utf-8") as fh:
             recipe_text = fh.read()
         lint_recipe_is_parsable(
             recipe_text,
@@ -747,7 +747,7 @@ def main(
         )
 
     if build_tool == CONDA_BUILD_TOOL:
-        with open(recipe_file) as fh:
+        with open(recipe_file, encoding="utf-8") as fh:
             content = render_meta_yaml("".join(fh))
             meta = get_yaml().load(content)
     else:

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -73,7 +73,7 @@ def hint_suggest_noarch(
                 build_reqs, raw_requirements_section, hints
             )
         else:
-            with open(recipe_fname) as fh:
+            with open(recipe_fname, encoding="utf-8") as fh:
                 in_runreqs = False
                 no_arch_possible = True
                 for line in fh:
@@ -103,7 +103,7 @@ def hint_shellcheck_usage(recipe_dir, hints):
         shell_scripts = glob(os.path.join(recipe_dir, "*.sh"))
         forge_yaml = find_local_config_file(recipe_dir, "conda-forge.yml")
         if shell_scripts and forge_yaml:
-            with open(forge_yaml) as fh:
+            with open(forge_yaml, encoding="utf-8") as fh:
                 code = get_yaml().load(fh)
                 shellcheck_enabled = code.get("shellcheck", {}).get(
                     "enabled", shellcheck_enabled
@@ -181,11 +181,15 @@ def hint_check_spdx(about_section, hints):
         if not licenseref_regex.match(license):
             filtered_licenses.append(license)
 
-    with open(os.path.join(os.path.dirname(__file__), "licenses.txt")) as f:
+    with open(
+        os.path.join(os.path.dirname(__file__), "licenses.txt"),
+        encoding="utf-8",
+    ) as f:
         expected_licenses = f.readlines()
         expected_licenses = {li.strip() for li in expected_licenses}
     with open(
-        os.path.join(os.path.dirname(__file__), "license_exceptions.txt")
+        os.path.join(os.path.dirname(__file__), "license_exceptions.txt"),
+        encoding="utf-8",
     ) as f:
         expected_exceptions = f.readlines()
         expected_exceptions = {li.strip() for li in expected_exceptions}

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -143,7 +143,7 @@ def lint_selectors_should_be_in_tidy_form(recipe_fname, lints, hints):
     # Look out for py27, py35 selectors; we prefer py==35
     python_selectors_pat = re.compile(r".+#\s*\[.*?(py\d{2,3}).*\]")
     if os.path.exists(recipe_fname):
-        with open(recipe_fname) as fh:
+        with open(recipe_fname, encoding="utf-8") as fh:
             for selector_line, line_number in selector_lines(fh):
                 if not good_selectors_pat.match(selector_line):
                     bad_selectors.append(selector_line)
@@ -182,7 +182,7 @@ def lint_selectors_should_be_in_tidy_form(recipe_fname, lints, hints):
 def lint_no_comment_selectors(recipe_fname, lints, hints):
     bad_lines = []
     if os.path.exists(recipe_fname):
-        with open(recipe_fname) as fh:
+        with open(recipe_fname, encoding="utf-8") as fh:
             for selector_line, line_number in selector_lines(
                 fh, only_in_comment=True
             ):
@@ -245,7 +245,7 @@ def lint_license_should_not_have_license(about_section, lints):
 
 def lint_should_be_empty_line(meta_fname, lints):
     if os.path.exists(meta_fname):
-        with open(meta_fname) as f:
+        with open(meta_fname, encoding="utf-8") as f:
             lines = f.read().split("\n")
         # Count the number of empty lines from the end of the file
         empty_lines = itertools.takewhile(lambda x: x == "", reversed(lines))
@@ -361,7 +361,7 @@ def lint_noarch_and_runtime_dependencies(
 ):
     if noarch_value is not None and os.path.exists(meta_fname):
         noarch_platforms = len(forge_yaml.get("noarch_platforms", [])) > 1
-        with open(meta_fname) as fh:
+        with open(meta_fname, encoding="utf-8") as fh:
             in_runreqs = False
             for line in fh:
                 line_s = line.strip()
@@ -408,7 +408,7 @@ def lint_jinja_variables_definitions(meta_fname, lints):
     # Good Jinja2 variable definitions look like "{% set .+ = .+ %}"
     good_jinja_pat = re.compile(r"\s*\{%\s(set)\s[^\s]+\s=\s[^\s]+\s%\}")
     if os.path.exists(meta_fname):
-        with open(meta_fname) as fh:
+        with open(meta_fname, encoding="utf-8") as fh:
             for jinja_line, line_number in jinja_lines(fh):
                 if not good_jinja_pat.match(jinja_line):
                     bad_jinja.append(jinja_line)
@@ -552,7 +552,7 @@ def lint_jinja_var_references(meta_fname, hints, recipe_version: int = 0):
         else conda_recipe_v1_linter.JINJA_VAR_PAT
     )
     if os.path.exists(meta_fname):
-        with open(meta_fname) as fh:
+        with open(meta_fname, encoding="utf-8") as fh:
             for i, line in enumerate(fh.readlines()):
                 for m in jinja_pattern.finditer(line):
                     if m.group(1) is not None:
@@ -679,7 +679,7 @@ def lint_check_usage_of_whls(meta_fname, noarch_value, lints, hints):
     pure_python_wheel_re = re.compile(r".*[:-]\s+(http.*-none-any\.whl)\s+.*")
     wheel_re = re.compile(r".*[:-]\s+(http.*\.whl)\s+.*")
     if os.path.exists(meta_fname):
-        with open(meta_fname) as f:
+        with open(meta_fname, encoding="utf-8") as f:
             for line in f:
                 if match := pure_python_wheel_re.search(line):
                     pure_python_wheel_urls.append(match.group(1))
@@ -888,7 +888,7 @@ def lint_stdlib(
     else:
         cbc_lines = []
         if conda_build_config_filename:
-            with open(conda_build_config_filename) as fh:
+            with open(conda_build_config_filename, encoding="utf-8") as fh:
                 cbc_lines = fh.readlines()
 
         # filter on osx-relevant lines
@@ -1055,7 +1055,7 @@ def lint_recipe_is_parsable(
         else:
             with tempfile.TemporaryDirectory() as tmpdir:
                 recipe_file = os.path.join(tmpdir, "meta.yaml")
-                with open(recipe_file, "w") as f:
+                with open(recipe_file, "w", encoding="utf-8") as f:
                     f.write(recipe_text)
 
                 try:

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -1381,10 +1381,10 @@ if __name__ == "__main__":
 
     model = ConfigModel()
 
-    with CONDA_FORGE_YAML_SCHEMA_FILE.open(mode="w+") as f:
+    with CONDA_FORGE_YAML_SCHEMA_FILE.open(mode="w+", encoding="utf-8") as f:
         obj = model.model_json_schema()
         f.write(json.dumps(obj, indent=2))
         f.write("\n")
 
-    with CONDA_FORGE_YAML_DEFAULTS_FILE.open(mode="w+") as f:
+    with CONDA_FORGE_YAML_DEFAULTS_FILE.open(mode="w+", encoding="utf-8") as f:
         f.write(yaml.dump(model.model_dump(by_alias=True), indent=2))

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -77,7 +77,7 @@ def get_feedstock_about_from_meta(meta) -> dict:
         recipe_meta = os.path.join(
             meta.meta["extra"]["parent_recipe"]["path"], "meta.yaml"
         )
-        with open(recipe_meta) as fh:
+        with open(recipe_meta, encoding="utf-8") as fh:
             content = render_meta_yaml("".join(fh))
             meta = get_yaml().load(content)
         return dict(meta["about"])
@@ -179,7 +179,7 @@ def update_conda_forge_config(forge_yaml):
     ...     cfg['foo'] = 'bar'
     """
     if os.path.exists(forge_yaml):
-        with open(forge_yaml) as fh:
+        with open(forge_yaml, encoding="utf-8") as fh:
             code = get_yaml().load(fh)
     else:
         code = {}

--- a/conda_smithy/validate_schema.py
+++ b/conda_smithy/validate_schema.py
@@ -44,7 +44,7 @@ def validate_json_schema(
     if not schema_file:
         schema_file = CONDA_FORGE_YAML_SCHEMA_FILE
 
-    with open(schema_file) as fh:
+    with open(schema_file, encoding="utf-8") as fh:
         _json_schema = json.loads(fh.read())
 
     validator = _VALIDATOR_CLASS(_json_schema)


### PR DESCRIPTION
I haven't had issues with running the linter on windows, but today I ran into encoding errors while linting a multi-output rattler recipe (no idea what triggered it exactly). Since python won't default to utf-8 until 3.15(!), it's better to be explicit about the encoding where we're interacting with files. I only needed the changes in `lints.py`, but while I was at it, I also looked for other uses of bare `open()` (with the exception of some obviously unix-only files, e.g. those using paths like `~/...`)