### PR TITLE
fix superfluous encoding kwarg for reading in binary mode

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2620,7 +2620,7 @@ def get_cfp_file_path(temporary_directory):
 
     response = requests.get(pkg.url)
     response.raise_for_status()
-    with open(dest, "wb", encoding="utf-8") as f:
+    with open(dest, "wb") as f:
         f.write(response.content)
 
     logger.info("Extracting conda-forge-pinning to %s", temporary_directory)


### PR DESCRIPTION
Fix an oversight from applying changes mechanically in #2244; files opened in binary mode don't take an encoding, and this causes
```
    with open(dest, "wb", encoding="utf-8") as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: binary mode doesn't take an encoding argument
```

Surprising that this wasn't caught by our tests... 🤔 