### PR TITLE
Fix false positive when v1 recipe name is non-context variable

### DIFF
--- a/conda_smithy/linter/conda_recipe_v1_linter.py
+++ b/conda_smithy/linter/conda_recipe_v1_linter.py
@@ -134,6 +134,11 @@ def lint_recipe_name(
     lints: list[str],
 ) -> None:
     name = get_recipe_name(recipe_content)
+    # Avoid false positives if the recipe is using variables
+    # from conda_build_config.yaml.
+    # https://github.com/conda-forge/conda-smithy/issues/2224
+    if "${{" in name:
+        return
 
     lint_msg = _lint_recipe_name(name)
     if lint_msg:

--- a/news/2248-v1-recipe-name-var.rst
+++ b/news/2248-v1-recipe-name-var.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed a false positive when a v1 recipe name refers to a variable from ``conda_build_config.yaml`` (#2248).
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1793,21 +1793,19 @@ linter:
         lints, _ = linter.lintify_meta_yaml(
             meta_with_context, recipe_version=1
         )
-        expected_message = (
-            "Recipe name has invalid characters. only lowercase alpha, "
-            "numeric, underscores, hyphens and dots allowed"
-        )
         self.assertIn(expected_message, lints)
 
         meta_with_context = {"recipe": {"name": "mp++"}, "outputs": []}  # noqa
         lints, _ = linter.lintify_meta_yaml(
             meta_with_context, recipe_version=1
         )
-        expected_message = (
-            "Recipe name has invalid characters. only lowercase alpha, "
-            "numeric, underscores, hyphens and dots allowed"
-        )
         self.assertIn(expected_message, lints)
+
+        # variable may be defined e.g. in conda_build_config.yaml
+        # https://github.com/conda-forge/conda-smithy/issues/2224
+        meta = {"package": {"name": "${{ variant_name }}"}}
+        lints, _ = linter.lintify_meta_yaml(meta, recipe_version=1)
+        self.assertNotIn(expected_message, lints)
 
     def test_end_empty_line(self):
         bad_contents = [


### PR DESCRIPTION

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes #2224

<!--
Please add any other relevant info below:
-->
Skip checking v1 recipe name if it contains unresolved variables, in order to fix false positives when a variable
from `conda_build_config.yaml` is used.

Iterating over all possible variants and verifying the resulting package names is unlikely to be worth the extra complexity.  This also roughly matches the linter behavior for v0 recipes, where `{{ var_name }}` is converted into `var_name`, and therefore is never properly linted anyway.
