### PR TITLE
Use explicit path in "recipe not found" exception

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -743,7 +743,7 @@ def main(
 
     if not os.path.exists(recipe_file):
         raise OSError(
-            f"Feedstock has no recipe/{os.path.basename(recipe_file)}"
+            f'Recipe not found: {recipe_file}; did you pass the "recipe" subdirectory?'
         )
 
     if build_tool == CONDA_BUILD_TOOL:

--- a/news/2249-recipe-not-found-path.rst
+++ b/news/2249-recipe-not-found-path.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Improve the "reciep not found" exception to include the path used and a suggestion what path to pass. (#2249)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/2249-recipe-not-found-path.rst
+++ b/news/2249-recipe-not-found-path.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* Improve the "reciep not found" exception to include the path used and a suggestion what path to pass. (#2249)
+* Improve the "recipe not found" exception to include the path used and a suggestion what path to pass. (#2249)
 
 **Deprecated:**
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Replace the "Feedstock has no ..." error message with a more clear "recipe not found" with explicit path, and a suggestion to pass the `recipe` subdirectory.  This should help people like me, who keep forgetting that in top feedstock directory you need to run:

    conda smithy lint recipe/

instead of just:

    conda smithy lint

and get the message:

    OSError: Feedstock has no recipe/meta.yaml

which is confusing since clearly there is a `recipe/meta.yaml` in the current directory.  Unless you're using v1 recipes, then you get even more confused why it tries to use a v0 recipe file.

