### PR TITLE
Ensure a newline at the end of pixi.toml and use double quotes for platforms

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2268,7 +2268,7 @@ def render_pixi(jinja_env, forge_config, forge_dir):
         **forge_config,
     )
     with write_file(target_fname) as fh:
-        fh.write(new_file_contents)
+        fh.write(new_file_contents.rstrip() + "\n")
 
 
 def copy_feedstock_content(forge_config, forge_dir):

--- a/conda_smithy/templates/pixi.toml.tmpl
+++ b/conda_smithy/templates/pixi.toml.tmpl
@@ -8,7 +8,7 @@ version = "{{ smithy_version }}"
 description = "Pixi configuration for conda-forge/{{ feedstock_name }}"
 authors = ["@conda-forge/{{ feedstock_name[:-10] }}"]
 channels = ["conda-forge"]
-platforms = {{ platforms }}
+platforms = {{ platforms|tojson }}
 
 [dependencies]
 {%- for spec_name, spec_constraints in build_tool_deps_dict|dictsort %}

--- a/news/2256-double-quotes-and-newline.rst
+++ b/news/2256-double-quotes-and-newline.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Ensure newline at the end of `pixi.toml`.
+* Use double quotes in `platforms` list in `pixi.toml` (like in the rest of the file.)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/2256-double-quotes-and-newline.rst
+++ b/news/2256-double-quotes-and-newline.rst
@@ -4,8 +4,8 @@
 
 **Changed:**
 
-* Ensure newline at the end of `pixi.toml`.
-* Use double quotes in `platforms` list in `pixi.toml` (like in the rest of the file.)
+* Ensure newline at the end of ``pixi.toml``. (#2256)
+* Use double quotes in ``platforms`` list in ``pixi.toml`` (like in the rest of the file). (#2256)
 
 **Deprecated:**
 


### PR DESCRIPTION
I just converted a couple of recipes to v1 :tada: and noticed a couple of things with the generated `pixi.toml`.
In this PR I fix:
- Ensure newline at the end of `pixi.toml`
- Use double quotes in `platforms` list, like in the rest of the file.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
