### PR TITLE
fix lint_single_space_in_pinned_requirements on run_exports for v1 recipes

### DIFF
--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -444,6 +444,10 @@ def lint_single_space_in_pinned_requirements(
             and requirements
         ):
             requirements = requirements[0].get("from_package", [])
+        if recipe_version == 1 and section == "run_exports":
+            # v1 recipes have more sections under 'requirements' than v0
+            # and rattler_build_conda_compat doesn't return the right structure for run_exports
+            continue
 
         # we can have `if` statements in the v1 requirements and we need to
         # flatten them

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -443,11 +443,32 @@ def lint_single_space_in_pinned_requirements(
             and section == "ignore_run_exports"
             and requirements
         ):
-            requirements = requirements[0].get("from_package", [])
-        if recipe_version == 1 and section == "run_exports":
-            # v1 recipes have more sections under 'requirements' than v0
-            # and rattler_build_conda_compat doesn't return the right structure for run_exports
-            continue
+            # v1 ignore_run_exports is a dict, but
+            # rattler-build-conda-compat returns it inside a list
+            # instead of the dict itself
+            # check for this case to protect against rattler-build-conda-compat fixing the bug
+            if isinstance(requirements, list):
+                requirements = requirements[0]
+            requirements = requirements.get("from_package", [])
+        if recipe_version == 1 and section == "run_exports" and requirements:
+            # v1 run_exports may be a list of requirements
+            # or a dict of `weak:, strong:` etc. lists.
+            # The dict case may arrive as a length-1 list containing the dict
+            # this is a bug in rattler-build-conda-compat
+            # handle this case, but make sure it's not
+            # run_exports:
+            #   - if: something
+            #     then: ...
+            # which is _correctly_ a length-1 list containing a dict
+            if (
+                isinstance(requirements, list)
+                and len(requirements) == 1
+                and isinstance(requirements[0], dict)
+                and "if" not in requirements[0]
+            ):
+                requirements = requirements[0]
+            if isinstance(requirements, dict):
+                requirements = list(itertools.chain(*requirements.values()))
 
         # we can have `if` statements in the v1 requirements and we need to
         # flatten them

--- a/news/2268-lint-error.rst
+++ b/news/2268-lint-error.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Lint error in v1 recipes when `run_exports` is a dict

--- a/tests/recipes/v1_recipes/recipe-fenics-dolfinx.yaml
+++ b/tests/recipes/v1_recipes/recipe-fenics-dolfinx.yaml
@@ -80,11 +80,12 @@ outputs:
             - zlib
             - liblzma-devel
       run_exports:
-        - ${{ pin_subpackage("fenics-libdolfinx", upper_bound="x.x.x") }}
-        - if: not win
-          then:
-            - petsc * ${{ scalar }}_*
-        - ${{ mpi | replace("impi", "impi_rt") }}
+        weak:
+          - ${{ pin_subpackage("fenics-libdolfinx", upper_bound="x.x.x") }}
+          - if: not win
+            then:
+              - petsc * ${{ scalar }}_*
+          - ${{ mpi | replace("impi", "impi_rt") }}
     tests:
       - script: test-libdolfinx
         files:


### PR DESCRIPTION
closes #2267 by skipping the failing lint for run_exports, which is consistent with v0 recipes, since they don't include run_exports in the `requirements` section.