### PR TITLE
feat: add line number to lint for noarch and runtime dependencies

### DIFF
--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -361,7 +361,7 @@ def lint_noarch_and_runtime_dependencies(
 ):
     """Lints `noarch` recipes where the meta file exists.
 
-    `noarch` recipes may not have runtime dependencies.  They are checked 
+    `noarch` recipes may not have runtime dependencies.  They are checked
     for skips with selectors, and for packages with selectors.
     """
     if noarch_value is None or not os.path.exists(meta_fname):

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -359,38 +359,46 @@ def lint_recipe_v1_noarch_and_runtime_dependencies(
 def lint_noarch_and_runtime_dependencies(
     noarch_value, meta_fname, forge_yaml, conda_build_config_keys, lints
 ):
-    if noarch_value is not None and os.path.exists(meta_fname):
-        noarch_platforms = len(forge_yaml.get("noarch_platforms", [])) > 1
-        with open(meta_fname, encoding="utf-8") as fh:
-            in_runreqs = False
-            for line in fh:
-                line_s = line.strip()
-                if line_s == "host:" or line_s == "run:":
-                    in_runreqs = True
-                    runreqs_spacing = line[: -len(line.lstrip())]
+    """Lints `noarch` recipes where the meta file exists.
+
+    `noarch` recipes may not have runtime dependencies.  They are checked 
+    for skips with selectors, and for packages with selectors.
+    """
+    if noarch_value is None or not os.path.exists(meta_fname):
+        return
+    noarch_platforms = len(forge_yaml.get("noarch_platforms", [])) > 1
+    with open(meta_fname, encoding="utf-8") as fh:
+        in_runreqs = False
+        for line_number, line in enumerate(fh, 1):
+            line_s = line.strip()
+            if line_s == "host:" or line_s == "run:":
+                in_runreqs = True
+                runreqs_spacing = line[: -len(line.lstrip())]
+                continue
+            if line_s.startswith("skip:") and is_selector_line(line):
+                lints.append(
+                    "`noarch` packages can't have skips with selectors. If "
+                    "the selectors are necessary, please remove "
+                    f"`noarch: {noarch_value}`, or selector on line {line_number}:"
+                    f"\n{line}"
+                )
+                break
+            if in_runreqs:
+                if runreqs_spacing == line[: -len(line.lstrip())]:
+                    in_runreqs = False
                     continue
-                if line_s.startswith("skip:") and is_selector_line(line):
+                if is_selector_line(
+                    line,
+                    allow_platforms=noarch_platforms,
+                    allow_keys=conda_build_config_keys,
+                ):
                     lints.append(
-                        "`noarch` packages can't have skips with selectors. If "
+                        "`noarch` packages can't have selectors. If "
                         "the selectors are necessary, please remove "
-                        f"`noarch: {noarch_value}`."
+                        f"`noarch: {noarch_value}`, or selector on line {line_number}:"
+                        f"\n{line}"
                     )
                     break
-                if in_runreqs:
-                    if runreqs_spacing == line[: -len(line.lstrip())]:
-                        in_runreqs = False
-                        continue
-                    if is_selector_line(
-                        line,
-                        allow_platforms=noarch_platforms,
-                        allow_keys=conda_build_config_keys,
-                    ):
-                        lints.append(
-                            "`noarch` packages can't have selectors. If "
-                            "the selectors are necessary, please remove "
-                            f"`noarch: {noarch_value}`."
-                        )
-                        break
 
 
 def lint_package_version(package_section, lints):

--- a/news/2269-line-no-for-noarch-and-runtime-dependencies.rst
+++ b/news/2269-line-no-for-noarch-and-runtime-dependencies.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* print line number of selector for noarch recipes that contain runtime dependencies. (#2269)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/2269-line-no-for-noarch-and-runtime-dependencies.rst
+++ b/news/2269-line-no-for-noarch-and-runtime-dependencies.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* print line number of selector for noarch recipes that contain runtime dependencies. (#2269)
+* Print line number of selector for noarch recipes that contain runtime dependencies. (#2269)
 
 **Changed:**
 

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1059,7 +1059,7 @@ linter:
                 )
                 self.assertEqual(
                     not is_good,
-                    any(f"or selector on line {line_number}" in lint  for lint in lints),
+                    any(lint.startswith(expected_start) and f"or selector on line {line_number}" in lint for lint in lints),
                 )
 
             assert_noarch_selector(

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1024,7 +1024,9 @@ class TestLinter(unittest.TestCase):
 
         with tmp_directory() as recipe_dir:
 
-            def assert_noarch_selector(meta_string, line_number=None, is_good=False, skip=False):
+            def assert_noarch_selector(
+                meta_string, line_number=None, is_good=False, skip=False
+            ):
                 with open(os.path.join(recipe_dir, "meta.yaml"), "w") as fh:
                     fh.write(meta_string)
                 if skip:
@@ -1059,7 +1061,11 @@ linter:
                 )
                 self.assertEqual(
                     not is_good,
-                    any(lint.startswith(expected_start) and f"or selector on line {line_number}" in lint for lint in lints),
+                    any(
+                        lint.startswith(expected_start)
+                        and f"or selector on line {line_number}" in lint
+                        for lint in lints
+                    ),
                 )
 
             assert_noarch_selector(
@@ -1068,7 +1074,7 @@ linter:
                               noarch: python
                               skip: true  # [py2k]
                             """,
-                line_number=4
+                line_number=4,
             )
             assert_noarch_selector(
                 """
@@ -1076,7 +1082,7 @@ linter:
                               noarch: generic
                               skip: true  # [win]
                             """,
-                line_number=4
+                line_number=4,
             )
             assert_noarch_selector(
                 """
@@ -1174,7 +1180,7 @@ linter:
                                   - python
                                   - enum34     # [py2k]
                             """,
-                line_number=7
+                line_number=7,
             )
             assert_noarch_selector(
                 """
@@ -1186,7 +1192,7 @@ linter:
                                 run:
                                   - python
                             """,
-                line_number=6
+                line_number=6,
             )
             assert_noarch_selector(
                 """
@@ -1198,7 +1204,7 @@ linter:
                                 run:
                                   - enum34     # [py2k]
                             """,
-                line_number=8
+                line_number=8,
             )
 
     def test_recipe_v1_noarch_selectors(self):

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -1024,7 +1024,7 @@ class TestLinter(unittest.TestCase):
 
         with tmp_directory() as recipe_dir:
 
-            def assert_noarch_selector(meta_string, is_good=False, skip=False):
+            def assert_noarch_selector(meta_string, line_number=None, is_good=False, skip=False):
                 with open(os.path.join(recipe_dir, "meta.yaml"), "w") as fh:
                     fh.write(meta_string)
                 if skip:
@@ -1057,20 +1057,26 @@ linter:
                     any(lint.startswith(expected_start) for lint in lints),
                     message,
                 )
+                self.assertEqual(
+                    not is_good,
+                    any(f"or selector on line {line_number}" in lint  for lint in lints),
+                )
 
             assert_noarch_selector(
                 """
                             build:
                               noarch: python
                               skip: true  # [py2k]
-                            """
+                            """,
+                line_number=4
             )
             assert_noarch_selector(
                 """
                             build:
                               noarch: generic
                               skip: true  # [win]
-                            """
+                            """,
+                line_number=4
             )
             assert_noarch_selector(
                 """
@@ -1156,7 +1162,8 @@ linter:
                                 run:
                                   - python
                                   - enum34     # [py2k]
-                            """
+                            """,
+                line_number=8,
             )
             assert_noarch_selector(
                 """
@@ -1166,7 +1173,8 @@ linter:
                                 host:
                                   - python
                                   - enum34     # [py2k]
-                            """
+                            """,
+                line_number=7
             )
             assert_noarch_selector(
                 """
@@ -1177,7 +1185,8 @@ linter:
                                   - enum34     # [py2k]
                                 run:
                                   - python
-                            """
+                            """,
+                line_number=6
             )
             assert_noarch_selector(
                 """
@@ -1188,7 +1197,8 @@ linter:
                                   - python
                                 run:
                                   - enum34     # [py2k]
-                            """
+                            """,
+                line_number=8
             )
 
     def test_recipe_v1_noarch_selectors(self):


### PR DESCRIPTION
I wanted to get feedback on this PR, in particularly I would find it useful if the linter would tell you which line the linting issue occurs on. While this PR only address a single lint I'm interested in (since I had trouble locating where the selector was in the recipe), I want feedback if a larger PR would be welcome that would describe the line number various lint issues occur on?
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
