### PR TITLE
feat: Add a lint on obsolete `os_version`

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -50,6 +50,7 @@ from conda_smithy.linter.lints import (
     lint_noarch,
     lint_noarch_and_runtime_dependencies,
     lint_non_noarch_builds,
+    lint_os_version,
     lint_package_version,
     lint_pin_subpackages,
     lint_recipe_have_tests,
@@ -372,6 +373,9 @@ def lintify_meta_yaml(
     lint_go_licenses_are_bundled(
         build_requirements, lints, recipe_version=recipe_version
     )
+
+    # 30. Check for obsolete os_version
+    lint_os_version(forge_yaml, lints)
 
     # hints
     # 1: suggest pip

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -1158,3 +1158,19 @@ def lint_recipe_is_parsable(
                     hints.append(
                         f"The recipe is not parsable by parser `{parser_name}`. {msg}"
                     )
+
+
+def lint_os_version(
+    forge_yaml: dict[str, Any],
+    lints: list[str],
+) -> None:
+    default_os_version = "alma9"
+    obsolete_os_versions = ("cos7", "alma8")
+    matches = {k: v for k, v in forge_yaml.get("os_version", {}).items()
+               if v in obsolete_os_versions}
+    if matches:
+        lints.append(
+            f"The feedstock is lowering the image versions for one or more platforms: {matches} "
+            f"(the default is {default_os_version}). Unless you are in the very rare case of repackaging binary"
+            "artifacts, consider removing these overrides from conda-forge.yml in the top feedstock directory."
+        )

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4514,5 +4514,36 @@ def test_find_recipe_directory_with_feedstock_dir(
     )
 
 
+def test_cfyml_obsolete_os_version():
+    expected_message = (
+        "The feedstock is lowering the image versions for one or more platforms: {'linux_64': 'cos7'}"
+    )
+
+    with tmp_directory() as feedstock_dir:
+        cfyml = os.path.join(feedstock_dir, "conda-forge.yml")
+        recipe_dir = os.path.join(feedstock_dir, "recipe")
+        os.makedirs(recipe_dir, exist_ok=True)
+        with open(os.path.join(recipe_dir, "meta.yaml"), "w") as fh:
+            fh.write(
+                """
+                package:
+                  name: foo
+                """
+            )
+
+        with open(cfyml, "w") as fh:
+            fh.write(
+                textwrap.dedent(
+                    """
+                    os_version:
+                      linux_64: cos7
+                    """
+                )
+            )
+
+        lints = linter.main(recipe_dir, conda_forge=True)
+        assert any(expected_message in lint for lint in lints)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Checklist
* [ ] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #2251

<!--
Please add any other relevant info below:
-->
Originally, I wanted to add this to `lintify_forge_yaml()` but that function uses `jsonschema.ValidationError`s as output.