### PR TITLE
fix: properly quote variable in POSIX

### DIFF
--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/{{ recipe_dir }}"

--- a/news/2276-fix-quotes.rst
+++ b/news/2276-fix-quotes.rst
@@ -1,3 +1,3 @@
 **Fixed:**
 
-* Allow current directory to have whitespace in its path.
+* Allow current directory to have whitespace in its path. (#2276)

--- a/news/2276-fix-quotes.rst
+++ b/news/2276-fix-quotes.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Allow current directory to have whitespace in its path.


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

POSIX shell scripts are horrible and humanity should have moved past them 30 years ago