### PR TITLE
Customize Github highlighting in `*.tmpl` files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,6 @@
 *.md.tmpl linguist-language=jinja
 *.sh.tmpl linguist-language=sh
 *.toml.tmpl linguist-language=jinja
-*.yml.ci-skel.tmpl linguist-language=jinja
+*.yaml.ci-skel.tmpl linguist-language=jinja
 *.yml.tmpl linguist-language=jinja
+*.yaml.tmpl linguist-language=jinja

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 .git_archival.txt  export-subst
 
 # Make GitHub syntax-highlight the templates correctly
+*.tmpl linguist-language=jinja
 *.sh.tmpl linguist-language=sh
 *.bat.tmpl linguist-language=bat
-*.tmpl linguist-language=jinja

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 .git_archival.txt  export-subst
+
+# Make GitHub syntax-highlight the templates correctly
+*.tmpl linguist-language=jinja

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,6 @@
 *.md.tmpl linguist-language=jinja
 *.sh.tmpl linguist-language=sh
 *.toml.tmpl linguist-language=jinja
-*.yaml.ci-skel.tmpl linguist-language=jinja
+*.yaml.ci-skel.tmpl linguist-language=yaml
 *.yml.tmpl linguist-language=jinja
 *.yaml.tmpl linguist-language=jinja

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,9 +2,10 @@
 
 # Make GitHub syntax-highlight the templates correctly
 *.bat.tmpl linguist-language=bat
-*.md.tmpl linguist-language=jinja
+*.md.tmpl linguist-language=markdown
 *.sh.tmpl linguist-language=sh
-*.toml.tmpl linguist-language=jinja
+*.toml.tmpl linguist-language=toml
+*.yml.ci-skel.tmpl linguist-language=yaml
 *.yaml.ci-skel.tmpl linguist-language=yaml
-*.yml.tmpl linguist-language=jinja
-*.yaml.tmpl linguist-language=jinja
+*.yml.tmpl linguist-language=yaml
+*.yaml.tmpl linguist-language=yaml

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
 .git_archival.txt  export-subst
 
 # Make GitHub syntax-highlight the templates correctly
-*.tmpl linguist-language=jinja
-*.sh.tmpl linguist-language=sh
 *.bat.tmpl linguist-language=bat
+*.md.tmpl linguist-language=jinja
+*.sh.tmpl linguist-language=sh
+*.toml.tmpl linguist-language=jinja
+*.yml.ci-skel.tmpl linguist-language=jinja
+*.yml.tmpl linguist-language=jinja

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 
 # Make GitHub syntax-highlight the templates correctly
 *.bat.tmpl linguist-language=bat
-*.md.tmpl linguist-language=markdown
+*.md.tmpl linguist-language=jinja
 *.sh.tmpl linguist-language=sh
 *.toml.tmpl linguist-language=toml
 *.yml.ci-skel.tmpl linguist-language=yaml

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
 .git_archival.txt  export-subst
 
 # Make GitHub syntax-highlight the templates correctly
+*.sh.tmpl linguist-language=sh
+*.bat.tmpl linguist-language=bat
 *.tmpl linguist-language=jinja

--- a/news/2278-linguist.rst
+++ b/news/2278-linguist.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added linguist hooks for template files. (#2278)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Define some linguist entries to enable better syntax highlighting in our templates. Browse in [branch](https://github.com/jaimergp/conda-smithy/tree/linguist/conda_smithy/templates) to see effects before merge. Compare to [current main](https://github.com/conda-forge/conda-smithy/tree/main/conda_smithy/templates) if needed.

Examples:

* Batch: [main](https://github.com/conda-forge/conda-smithy/blob/main/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl) vs [PR](https://github.com/jaimergp/conda-smithy/blob/linguist/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl)
* Shell: [main](https://github.com/conda-forge/conda-smithy/blob/main/conda_smithy/templates/build_steps.sh.tmpl) vs [PR](https://github.com/jaimergp/conda-smithy/blob/linguist/conda_smithy/templates/build_steps.sh.tmpl)

Note there's some client side caching going on, so I recommend browsing each version from a different browser to actually compare versions. 