### PR TITLE
Use a platform-specific env if Pixi is used to provision the environment on Docker builds

### DIFF
--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -49,12 +49,15 @@ arch=$(uname -m)
 if [[ "$arch" == "x86_64" ]]; then
   arch="64"
 fi
-sed -i.bak "s/platforms = .*/platforms = [\"linux-${arch}\"]/" pixi.toml
+{#- We patch the pixi.toml file to only solve for one platform, and to create a platform-specific
+environment identical to 'default'. Otherwise local usage might result in 'default' being clobbered
+by the OS-specific builds (e.g. running Docker Linux on macOS). #}
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/build_linux-$arch =/" pixi.toml
 echo "Creating environment"
-PIXI_CACHE_DIR=/opt/conda pixi install
+PIXI_CACHE_DIR=/opt/conda pixi install --environment build_linux-$arch
 pixi list
 echo "Activating environment"
-eval "$(pixi shell-hook)"
+eval "$(pixi shell-hook --environment build_linux-$arch)"
 mv pixi.toml.bak pixi.toml
 popd
 {%- endif %}

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -54,10 +54,10 @@ environment identical to 'default'. Otherwise local usage might result in 'defau
 by the OS-specific builds (e.g. running Docker Linux on macOS). #}
 sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/build-linux-$arch =/" pixi.toml
 echo "Creating environment"
-PIXI_CACHE_DIR=/opt/conda pixi install --environment build_linux-$arch
+PIXI_CACHE_DIR=/opt/conda pixi install --environment build-linux-$arch
 pixi list
 echo "Activating environment"
-eval "$(pixi shell-hook --environment build_linux-$arch)"
+eval "$(pixi shell-hook --environment build-linux-$arch)"
 mv pixi.toml.bak pixi.toml
 popd
 {%- endif %}

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -52,7 +52,7 @@ fi
 {#- We patch the pixi.toml file to only solve for one platform, and to create a platform-specific
 environment identical to 'default'. Otherwise local usage might result in 'default' being clobbered
 by the OS-specific builds (e.g. running Docker Linux on macOS). #}
-sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/build_linux-$arch =/" pixi.toml
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/build-linux-$arch =/" pixi.toml
 echo "Creating environment"
 PIXI_CACHE_DIR=/opt/conda pixi install --environment build_linux-$arch
 pixi list

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -52,12 +52,12 @@ fi
 {#- We patch the pixi.toml file to only solve for one platform, and to create a platform-specific
 environment identical to 'default'. Otherwise local usage might result in 'default' being clobbered
 by the OS-specific builds (e.g. running Docker Linux on macOS). #}
-sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/build-linux-$arch =/" pixi.toml
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
 echo "Creating environment"
-PIXI_CACHE_DIR=/opt/conda pixi install --environment build-linux-$arch
+PIXI_CACHE_DIR=/opt/conda pixi install --environment docker-build-linux-$arch
 pixi list
 echo "Activating environment"
-eval "$(pixi shell-hook --environment build-linux-$arch)"
+eval "$(pixi shell-hook --environment docker-build-linux-$arch)"
 mv pixi.toml.bak pixi.toml
 popd
 {%- endif %}

--- a/conda_smithy/templates/pixi.toml.tmpl
+++ b/conda_smithy/templates/pixi.toml.tmpl
@@ -44,3 +44,5 @@ lint = "conda-smithy lint {{ recipe_dir }}"
 
 [environments]
 smithy = ["smithy"]
+# This is a copy of default, to be enabled by build_steps.sh during Docker builds
+# __PLATFORM_SPECIFIC_ENV__ = []

--- a/news/2279-pixi-docker-env.rst
+++ b/news/2279-pixi-docker-env.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Use a platform-specific name for Pixi-provisioned environments when run in a Docker container
+  to avoid cross-operating-system ``default`` environment clobbering. (#2279)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Comes from report at [#general > &#96;pixi r build-locally&#96; fails, &#96;pixi r build&#96; succeeds](https://conda-forge.zulipchat.com/#narrow/channel/457337-general/topic/.60pixi.20r.20build-locally.60.20fails.2C.20.60pixi.20r.20build.60.20succeeds)