### PR TITLE
add ubi8 to image versions being linted on

### DIFF
--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -466,7 +466,7 @@ def hint_os_version(
     hints: list[str],
 ) -> None:
     default_os_version = "alma9"
-    obsolete_os_versions = ("cos7", "alma8")
+    obsolete_os_versions = ("cos7", "alma8", "ubi8")
     matches = {
         k: v
         for k, v in forge_yaml.get("os_version", {}).items()

--- a/news/2283-ubi8.rst
+++ b/news/2283-ubi8.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added ``ubi8`` to list of ``os_version``s linted on. (#2283)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
This is a minor fix-up of #2270. Since #2155, we're limiting the possible values of `os_version` through schema validation to 
https://github.com/conda-forge/conda-smithy/blob/22169a89bc72614918bdba42a6fbe7c7feec0e52/conda_smithy/schema.py#L49

but #2270 did not add a hint for that. The ubi8 images are still in use for CUDA 11.8, which is also the only place that needs them. They can continue to be used for that purpose (and any feedstock building for CUDA 11.8 will pull them in automatically), but users shouldn't set `os_version: [linux_64: ubi8]` in `conda-forge.yml` anymore.

CC @mgorny