### PR TITLE
regen schema with pydantic 2.11.1

### DIFF
--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -2061,6 +2061,7 @@
     "travis": {
       "anyOf": [
         {
+          "additionalProperties": true,
           "type": "object"
         },
         {
@@ -2073,6 +2074,7 @@
     "circle": {
       "anyOf": [
         {
+          "additionalProperties": true,
           "type": "object"
         },
         {
@@ -2085,6 +2087,7 @@
     "appveyor": {
       "anyOf": [
         {
+          "additionalProperties": true,
           "type": "object"
         },
         {
@@ -2163,6 +2166,7 @@
     "matrix": {
       "anyOf": [
         {
+          "additionalProperties": true,
           "type": "object"
         },
         {

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - license-expression
   - libarchive
   - cirun >=0.30
-  - pydantic >=2,<3
+  - pydantic >=2.11,<3
   - jsonschema
   - backports.strenum
   - exceptiongroup

--- a/news/2289-schema.rst
+++ b/news/2289-schema.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* updated schema with pydantic 2.11

--- a/news/2289-schema.rst
+++ b/news/2289-schema.rst
@@ -1,3 +1,3 @@
 **Fixed:**
 
-* updated schema with pydantic 2.11
+* Updated schema with pydantic 2.11 (#2289)


### PR DESCRIPTION
pydantic 2.11 adds `additionalProperties: true` to empty `type: object` fields
