### PR TITLE
Revert "build(deps): bump actions/upload-artifact from 4.6.1 to 4.6.2 in /.github/workflows in the github-actions group"

### DIFF
--- a/.github/workflows/_proxy-file-for-dependabot-tests.yml
+++ b/.github/workflows/_proxy-file-for-dependabot-tests.yml
@@ -11,4 +11,4 @@ jobs:
     if: false
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1


### PR DESCRIPTION
Reverts conda-forge/conda-smithy#2290

I forgot we need to update the template files too. 