### PR TITLE
Windows: Fix virus scanners blocking downloads

### DIFF
--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -37,7 +37,7 @@ set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
 
 echo Downloading micromamba %MICROMAMBA_VERSION%
 if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
-certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
+powershell -ExecutionPolicy Bypass -Command "(New-Object Net.WebClient).DownloadFile('%MICROMAMBA_URL%', '%MICROMAMBA_EXE%')"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 echo Creating environment
@@ -87,7 +87,7 @@ call :start_group "Installing a fresh version of Miniforge"
 set "MINIFORGE_URL=https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe"
 set "MINIFORGE_EXE=Miniforge3-Windows-x86_64.exe"
 echo Downloading Miniforge
-certutil -urlcache -split -f "%MINIFORGE_URL%" "%MINIFORGE_EXE%"
+powershell -ExecutionPolicy Bypass -Command "(New-Object Net.WebClient).DownloadFile('%MINIFORGE_URL%', '%MINIFORGE_EXE%')"
 if !errorlevel! neq 0 exit /b !errorlevel!
 echo Installing Miniforge
 start /wait "" %MINIFORGE_EXE% /InstallationType=JustMe /RegisterPython=0 /S /D=%MINIFORGE_HOME%

--- a/news/news_win_fix_blocked_downloads.rst
+++ b/news/news_win_fix_blocked_downloads.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Use ``powershell`` instead of ``certutil``to avoid virus scanners blocking downloads (#2299)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Added a ``news`` entry
* [X] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

Closes https://github.com/conda-forge/staged-recipes/issues/28990.

certutil (which is a Certificate Authority admin tool) is being blocked by Windows Defender and other virus scanners. This PR uses powershell to directly download the files instead of certutil.
