### PR TITLE
fix: resolve non-stable rerenders by producing CI jobs for the intersection of loop vars over all outputs

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -567,7 +567,8 @@ def _collapse_subpackage_variants(
     # on osx, merge MACOSX_DEPLOYMENT_TARGET & c_stdlib_version to max of either; see #1884
     all_variants = _merge_deployment_target(all_variants, has_macdt)
 
-    # we use the intersection of all of the loop vars in the outputs.
+    # we use the intersection of all of the loop vars in the outputs
+    # to distribute CI jobs.
     # this eliminates cases where a fully expanded build matrix would produce
     # duplicate outputs if an output used some variables but not others.
     # For outputs that do not use some variables, conda-build will properly

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1205,6 +1205,11 @@ def _render_ci_provider(
         for meta in metas:
             if not meta.skip():
                 enable_platform[i] = True
+
+        # sort the list of metas by the distribution string to ensure stable
+        # rendering later
+        metas = sorted(metas, key=lambda x: x.dist())
+
         metas_list_of_lists.append(metas)
 
     if not any(enable_platform):

--- a/news/2300-min-ci-support-job.rst
+++ b/news/2300-min-ci-support-job.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Fixed unstable rerenders in an edge case by producing the smallest number of CI support jobs. (#2300)
+* Fixed unstable rerenders in an edge case by using the intersection of top-leve loop vars over all outputs. (#2300)
 * Removed extraneous print statement in rendering, turning it into a debug-level log statement. (#2300)
 
 **Security:**

--- a/news/2300-min-ci-support-job.rst
+++ b/news/2300-min-ci-support-job.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed unstable rerenders in an edge case by producing the smallest number of CI support jobs. (#2300)
+
+**Security:**
+
+* <news item>

--- a/news/2300-min-ci-support-job.rst
+++ b/news/2300-min-ci-support-job.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* <news item>
+* Added info-level logging statement printing which variables are used to distribute CI jobs. (#2300)
 
 **Changed:**
 
@@ -17,6 +17,7 @@
 **Fixed:**
 
 * Fixed unstable rerenders in an edge case by producing the smallest number of CI support jobs. (#2300)
+* Removed extraneous print statement in rendering, turning it into a debug-level log statement. (#2300)
 
 **Security:**
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR fixes an issue where rerenders got different numbers of CI jobs depending on which output appeared first in the list of metadata objects for each output (but only when there is not an output corresponding to the top-level package name.) The first element depends on the python hash seed, hence things not being stable.

Per the code comment, we resolve this ambiguity by producing CI jobs for all combinations of the intersection of top-level loop vars over all outputs.

Another possibility would be to let people add or exclude variables to be expanded over in the CI support jobs by hand. I'd rather not do that yet, so let's try this first.

I tested this version of smithy against the ctng-compiler-activation-feedstock locally and it rendered the expected set of CI jobs.

This PR also resolves something that I have wondered about for a long time, which is why we always used index 0 to get the loop vars.

closes #2100