### PR TITLE
fix: ensure bad specs hint is formatted properly and exclude some jinja2 as evaled

### DIFF
--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -418,7 +418,7 @@ def hint_space_separated_specs(
     for output, requirements in report.items():
         lines.append(f"{output} output has some malformed specs:")
         for req_type, specs in requirements.items():
-            specs = [f"`{spec}" for spec in specs]
+            specs = [f"`{spec}`" for spec in specs]
             lines.append(f"- In section {req_type}: {', '.join(specs)}")
     if lines:
         lines.append(
@@ -439,8 +439,14 @@ def _ensure_spec_space_separated(spec: str) -> bool:
         spec = spec.split("#")[0]
     spec = spec.strip()
 
-    if "{{" in spec:
-        # Do not flag Jinja expressions
+    # exclude jinja2 stubs or expressions
+    if "{{" in spec or any(
+        spec.startswith(stub)
+        for stub in [
+            "compatible_pin ",
+            "subpackage_pin ",
+        ]
+    ):
         return True
 
     fields = spec.split()

--- a/news/2301-linter-spec-fixes.rst
+++ b/news/2301-linter-spec-fixes.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed linter false-positive for malformed specs on jinja2 ``pin_compatible`` and ``pin_subpackage`` statements. (#2301)

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4363,6 +4363,8 @@ def test_version_zero(filename: str):
         ('{{ pin_subpackage("pkg-" ~ var, max_pin="x.x.x") }}', True),
         ("conda-verify  >=3.1.0", True),
         ("conda-verify  >=3.1.0   *_0", True),
+        ("subpackage_pin blah 4.5", True),
+        ("compatible_pin blah 345", True),
     ],
 )
 def test_bad_specs(spec, result):


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

This PR fixes the linter error formatting and ensures that evaled jinja2 stuff is excluded.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

closes #2272 
