### PR TITLE
fix: use better hints for v1 noarch python tests section

### DIFF
--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -293,8 +293,19 @@ def _hint_noarch_python_use_python_min_inner(
                         "{{ python_min }}", "${{ python_min }}"
                     )
                 test_syntax = syntax
+
+                if section_name == "test.requires":
+                    report_section_name = "`tests[].python.python_version` or `tests[].requirements.run`"
+                    report_entry = "`python_version` or `python`"
+                    report_syntax = "`python_version: ${{ python_min }}.*` or `python ${{ python_min }}.*`"
+                else:
+                    report_section_name = f"`{section_name}`"
+                    report_entry = "`python`"
             else:
                 test_syntax = syntax.replace("{{ python_min }}", "9999")
+                report_section_name = f"`{section_name}`"
+                report_entry = "`python`"
+                report_syntax = f"`{report_syntax}`"
 
             for req in reqs:
                 if (
@@ -305,11 +316,11 @@ def _hint_noarch_python_use_python_min_inner(
                     break
             else:
                 section_desc = (
-                    f"`{output_name}` output" if output_name else "recipe"
+                    f"`{output_name}` output" if output_name else "the recipe"
                 )
                 hint.append(
-                    f"\n   - For the `{section_name}` section of {section_desc}, you should usually use `{report_syntax}` "
-                    f"for the `python` entry."
+                    f"\n   - For the {report_section_name} section of {section_desc}, you "
+                    f"should usually use the pin {report_syntax} for the {report_entry} entry."
                 )
     return hint
 

--- a/news/2302-noarch-python-min-hint-tests.rst
+++ b/news/2302-noarch-python-min-hint-tests.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed hint for ``noarch: python`` min version pins for the ``tests`` section for v1 recipes. (#2302)

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -3646,6 +3646,59 @@ linter:
                 package:
                   name: python
 
+                build:
+                  noarch: python
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python >=${{ python_min }}
+
+                tests:
+                  - requirements:
+                      run:
+                        - python
+                """
+            ),
+            [
+                "tests[].python.python_version",
+                "tests[].requirements.run",
+                "python ${{ python_min }}.*",
+            ],
+        ),
+        (
+            textwrap.dedent(
+                """
+                package:
+                  name: python
+
+                build:
+                  noarch: python
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python >=${{ python_min }}
+
+                tests:
+                  - python:
+                      pip_check: false
+                """
+            ),
+            [
+                "tests[].python.python_version",
+                "tests[].requirements.run",
+                "python ${{ python_min }}.*",
+            ],
+        ),
+        (
+            textwrap.dedent(
+                """
+                package:
+                  name: python
+
                 requirements:
                   run:
                     - if: blah


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

This PR adds a better description of the `noarch: python` min version hints/lints for the `tests` section for v1 recipes.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

closes #2286 