### PR TITLE
Only show stdlib lint for go-cgo compilers, not go-nocgo

### DIFF
--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -813,10 +813,12 @@ def lint_stdlib(
     )
     if recipe_version == 0:
         pat_compiler_stub = re.compile(
-            "(m2w64_)?(c|cxx|fortran|rust)_compiler_stub"
+            "(m2w64_)?(c|cxx|fortran|rust|go-cgo)_compiler_stub"
         )
     else:
-        pat_compiler_stub = re.compile(r"^\${{ compiler\(")
+        pat_compiler_stub = re.compile(
+            r"^\${{ compiler\('(m2w64_)?(c|cxx|fortran|rust|go-cgo)"
+        )
 
     outputs = get_section(meta, "outputs", lints, recipe_version)
     output_reqs = [x.get("requirements", {}) for x in outputs]

--- a/news/go-no-cgo.rst
+++ b/news/go-no-cgo.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Only show stdlib lint for go-cgo compilers, not go-nocgo
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -51,7 +51,17 @@ def tmp_directory():
 
 @pytest.mark.parametrize(
     "comp_lang",
-    ["c", "cxx", "fortran", "rust", "m2w64_c", "m2w64_cxx", "m2w64_fortran"],
+    [
+        "c",
+        "cxx",
+        "fortran",
+        "rust",
+        "m2w64_c",
+        "m2w64_cxx",
+        "m2w64_fortran",
+        "go-cgo",
+        "go-nocgo",
+    ],
 )
 def test_stdlib_lint(comp_lang):
     expected_message = "This recipe is using a compiler"
@@ -70,7 +80,11 @@ def test_stdlib_lint(comp_lang):
             )
 
         lints, _ = linter.main(recipe_dir, return_hints=True)
-        assert any(lint.startswith(expected_message) for lint in lints)
+        if comp_lang == "go-nocgo":
+            # This doesn't need a stdlib
+            assert not any(lint.startswith(expected_message) for lint in lints)
+        else:
+            assert any(lint.startswith(expected_message) for lint in lints)
 
 
 def test_m2w64_stdlib_legal():
@@ -96,7 +110,17 @@ def test_m2w64_stdlib_legal():
 
 @pytest.mark.parametrize(
     "comp_lang",
-    ["c", "cxx", "fortran", "rust", "m2w64_c", "m2w64_cxx", "m2w64_fortran"],
+    [
+        "c",
+        "cxx",
+        "fortran",
+        "rust",
+        "m2w64_c",
+        "m2w64_cxx",
+        "m2w64_fortran",
+        "go-cgo",
+        "go-nocgo",
+    ],
 )
 def test_v1_stdlib_hint(comp_lang):
     expected_message = "This recipe is using a compiler"
@@ -119,7 +143,10 @@ def test_v1_stdlib_hint(comp_lang):
         lints, _ = linter.main(
             recipe_dir, feedstock_dir=recipe_dir, return_hints=True
         )
-        assert any(lint.startswith(expected_message) for lint in lints)
+        if comp_lang == "go-nocgo":
+            assert not any(lint.startswith(expected_message) for lint in lints)
+        else:
+            assert any(lint.startswith(expected_message) for lint in lints)
 
 
 def test_sysroot_lint():


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
