### PR TITLE
fix: run post-link scripts on Windows

### DIFF
--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -70,6 +70,9 @@ move /y pixi.toml pixi.toml.bak
 set "arch=64"
 if "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "arch=arm64"
 powershell -NoProfile -ExecutionPolicy unrestricted -Command "(Get-Content pixi.toml.bak -Encoding UTF8) -replace 'platforms = .*', 'platforms = [''win-%arch%'']' | Out-File pixi.toml -Encoding UTF8"
+:: Git on Windows needs to run post link scripts to properly set up SSL certificates
+pixi config set --global run-post-link-scripts insecure
+if !errorlevel! neq 0 exit /b !errorlevel!
 pixi install
 if !errorlevel! neq 0 exit /b !errorlevel!
 pixi list

--- a/news/pixi-git-ssl.rst
+++ b/news/pixi-git-ssl.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Run post-link scripts on Windows in order to fix a m2-git SSL issue.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
We ran into issues because `m2-git` requires post-link scripts to be run.

This should fix: https://github.com/conda-forge/conda-smithy/issues/2239

