### PR TITLE
don't hint on v1 python_version list with python_min

### DIFF
--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -269,10 +269,13 @@ def get_all_test_requirements(
             ) or []
 
             if "python" in test_element:
-                if test_element["python"].get("python_version") is not None:
-                    test_reqs.append(
-                        f"python {test_element['python']['python_version']}"
-                    )
+                py_version = test_element["python"].get("python_version")
+
+                if isinstance(py_version, str):
+                    py_version = [py_version]
+
+                if isinstance(py_version, list):
+                    test_reqs += [f"python {pv}" for pv in py_version]
                 else:
                     test_reqs.append("python")
     else:

--- a/news/v1-python-version-matrix.rst
+++ b/news/v1-python-version-matrix.rst
@@ -1,0 +1,27 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* A v1 recipe ``tests`` item with a matrix-style ``python_version`` will not be
+  flagged for CFEP-25 syntax as long it contains `at least` a
+  ``${{ python_min }}.*`` item. Feedstocks may use this syntax to verify the
+  package will at least solve, install, import, and ``pip_check`` on both the
+  current CFEP-25 minimum and a later python.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4334,32 +4334,51 @@ def test_lint_recipe_v1_invalid_schema_version():
         assert lints == ["Unsupported recipe.yaml schema version 2"]
 
 
-def test_lint_recipe_v1_python_min_in_python_version():
+@pytest.mark.parametrize("text", [
+    """
+package:
+    name: python
+
+build:
+    noarch: python
+
+requirements:
+    host:
+      - python ${{ python_min }}
+    run:
+      - python >=${{ python_min }}
+
+tests:
+  - python:
+      imports:
+        - mypackage
+      python_version: ${{ python_min }}.*
+    """, """
+package:
+  name: python
+
+build:
+  noarch: python
+
+requirements:
+  host:
+    - python ${{ python_min }}
+  run:
+    - python >=${{ python_min }}
+
+tests:
+  - python:
+      imports:
+        - mypackage
+      python_version:
+        - ${{ python_min }}.*
+        - 3.13.*
+    """,
+])
+def test_lint_recipe_v1_python_min_in_python_version(text):
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:
-            f.write(
-                textwrap.dedent(
-                    """
-                package:
-                  name: python
-
-                build:
-                  noarch: python
-
-                requirements:
-                  host:
-                    - python ${{ python_min }}
-                  run:
-                    - python >=${{ python_min }}
-
-                tests:
-                - python:
-                    imports:
-                        - mypackage
-                    python_version: ${{ python_min }}.*
-                """
-                )
-            )
+            f.write(text)
         _, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
         assert hints == []
 

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4384,7 +4384,10 @@ def test_lint_recipe_v1_python_min_in_python_version(text):
         with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:
             f.write(text)
         _, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
-        assert hints == []
+        assert not any(
+            "`noarch: python` recipes should usually follow the syntax" in h
+            for h in hints
+        )
 
 
 def test_lint_recipe_v1_comment_selectors():

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4334,8 +4334,10 @@ def test_lint_recipe_v1_invalid_schema_version():
         assert lints == ["Unsupported recipe.yaml schema version 2"]
 
 
-@pytest.mark.parametrize("text", [
-    """
+@pytest.mark.parametrize(
+    "text",
+    [
+        """
 package:
     name: python
 
@@ -4353,7 +4355,8 @@ tests:
       imports:
         - mypackage
       python_version: ${{ python_min }}.*
-    """, """
+    """,
+        """
 package:
   name: python
 
@@ -4374,7 +4377,8 @@ tests:
         - ${{ python_min }}.*
         - 3.13.*
     """,
-])
+    ],
+)
 def test_lint_recipe_v1_python_min_in_python_version(text):
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:


### PR DESCRIPTION
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

Thanks for the tireless effort on maintaining `conda-smithy`!

While CFEP-25 specifies packages SHOULD be validated against the ecosystem (or feedstock) `python_min`, validating against _some other python_ can find _interesting_ upstream issues.

This PR updates `hint_noarch_python_use_python_min` to allow [v1 recipes](https://github.com/prefix-dev/recipe-format/blob/fa2df/schema.json#L3320-L3337) to specify testing against `python_min` **and** some other python, at the maintainer cost of a single line, and a single, generally very fast, solve.