### PR TITLE
Use native runner to build for linux-aarch64 on github actions

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1710,7 +1710,7 @@ def _github_actions_specific_setup(
         },
         "linux-aarch64": {
             "os": "ubuntu",
-            "hosted_labels": ("ubuntu-latest",),
+            "hosted_labels": ("ubuntu-24.04-arm",),
             "self_hosted_labels": ("linux", "ARM64"),
         },
         "win-64": {

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -116,8 +116,10 @@ jobs:
 {%- endfor %}
       shell: bash
       run: |
-        echo "::group::Configure binfmt_misc"
-        docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
+        if [[ "$(uname -m)" == "x86_64" ]]; then
+          echo "::group::Configure binfmt_misc"
+          docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
+        fi
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"

--- a/news/linux-aarch64-native-gha.rst
+++ b/news/linux-aarch64-native-gha.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* When using GitHub Actions as a CI provider to build linux-aarch64; and using
+  the GitHub hosted runners, CI will now use the native ARM64 runners
+  (`ubuntu-24.04-arm`) instead of emulation.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fix #2243

<!--
Please add any other relevant info below:
-->

-------

We are using conda-smithy outside of conda-forge to maintain some feedstocks that are not yet in conda-forge (either because there is an open PR to staged-recipe, or because the code we want to build is not merged in the upstream project). This is working very well for us, allowing us to create our own conda channel that is 100% compatible with the rest of conda-forge.

We are using github action as a CI provider, and we would like to take advantage of the native linux-arm runners there to build for linux-aarch64, hence the change in this PR. Let me know if such a change is OK for you!