### PR TITLE
fix case where non-primary, non-zipped key has an ordering

### DIFF
--- a/conda_smithy/variant_algebra.py
+++ b/conda_smithy/variant_algebra.py
@@ -237,6 +237,13 @@ def op_variant_key_add(v1: dict, v2: dict):
 
                     result[key] = new_value
 
+    # case where there's a non-primary, non-zipped key with an ordering
+    extra_ordering = set(ordering.keys()).difference(
+        set(newly_added_zip_keys) | {primary_key}
+    )
+    for key in extra_ordering:
+        result[key] = variant_key_add(key, v1[key], v2[key], ordering[key])
+
     return result
 
 

--- a/tests/test_variant_algebra.py
+++ b/tests/test_variant_algebra.py
@@ -136,8 +136,8 @@ def test_ordering_with_tail_and_readd():
     cuda_compiler_version:
         - "None"
         - "12.6"
-    docker_image:
-        - linux-anvil-x86_64:alma9
+    cuda_compiler_version_min:
+        - "12.6"
     """
         )
     )
@@ -176,7 +176,13 @@ def test_ordering_with_tail_and_readd():
                 - "None"
                 - "12.9"
                 - "11.8"
+            cuda_compiler_version_min:
+                - "12.6"
+                - "12.9"
+                - "11.8"
     cuda_compiler_version:
+        - "11.8"
+    cuda_compiler_version_min:
         - "11.8"
     cuda_compiler:
         - nvcc
@@ -188,6 +194,7 @@ def test_ordering_with_tail_and_readd():
     res2 = variant_add(res, cuda129_migrator)
     assert res2["cuda_compiler_version"] == ["None", "12.9", "11.8"]
     assert res2["cuda_compiler"] == ["cuda-nvcc", "cuda-nvcc", "nvcc"]
+    assert res2["cuda_compiler_version_min"] == ["11.8"]
 
 
 def test_no_ordering():


### PR DESCRIPTION
Another fix-up that's necessary for correctly handling the CUDA 11.8 migrator.

News still falls under
https://github.com/conda-forge/conda-smithy/blob/ed2dc248c5cbe7e23c56cb051b9b9ad36c6471df/news/tail-ordering.rst?plain=1#L19