### PR TITLE
remove redundant setting of ARCHIVE_UNIQUE_ID in win artefact script

### DIFF
--- a/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
@@ -36,9 +36,6 @@ if not "%ARTIFACT_UNIQUE_ID%" == "%ARTIFACT_UNIQUE_ID:~0,80%" (
     set ARTIFACT_UNIQUE_ID=%CI_RUN_ID%_%SHORT_CONFIG%
 )
 
-rem Set a descriptive ID for the archive(s), specialized for this particular job run
-set ARCHIVE_UNIQUE_ID=%CI_RUN_ID%_%CONFIG%
-
 rem Make the build artifact zip
 if defined BLD_ARTIFACT_PREFIX (
     set BLD_ARTIFACT_NAME=%BLD_ARTIFACT_PREFIX%_%ARTIFACT_UNIQUE_ID%


### PR DESCRIPTION
Noticed that the following is fully redundant, and actually undoes the `%SHORT_CONFIG%` logic, see

https://github.com/conda-forge/conda-smithy/blob/c9a3fbb05d892329327c64d8e52bcecf408d10a5/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl#L33-L40