### PR TITLE
Fix artefact generation regression on azure

### DIFF
--- a/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
@@ -19,8 +19,6 @@ rem BLD_ARTIFACT_PATH
 rem ENV_ARTIFACT_NAME
 rem ENV_ARTIFACT_PATH
 
-@echo on
-
 rem Check that the conda-build directory exists
 if not exist %CONDA_BLD_DIR% (
     echo conda-build directory does not exist

--- a/news/fix_artefact_generation.rst
+++ b/news/fix_artefact_generation.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix artefact generation on windows failing spuriously due to enabling logging (#2351).
+
+**Security:**
+
+* <news item>

--- a/tests/test_variant_algebra.py
+++ b/tests/test_variant_algebra.py
@@ -482,19 +482,19 @@ def test_py39_migration():
       - 3.6.* *_cpython   # [not (osx and arm64)]
       - 3.7.* *_cpython   # [not (osx and arm64)]
       - 3.8.* *_cpython
-      - 3.6.* *_73_pypy   # [not (win64 or (osx and arm64))]
+      - 3.6.* *_73_pypy   # [not (osx and arm64)]
 
     numpy:
       - 1.16       # [not (osx and arm64)]
       - 1.16       # [not (osx and arm64)]
       - 1.16
-      - 1.18       # [not (win64 or (osx and arm64))]
+      - 1.18       # [not (osx and arm64)]
 
     python_impl:
       - cpython    # [not (osx and arm64)]
       - cpython    # [not (osx and arm64)]
       - cpython
-      - pypy       # [not (win64 or (osx and arm64))]
+      - pypy       # [not (osx and arm64)]
 
 
     zip_keys:
@@ -583,19 +583,19 @@ def test_multiple_key_add_migration():
       - 3.6.* *_cpython   # [not (osx and arm64)]
       - 3.7.* *_cpython   # [not (osx and arm64)]
       - 3.8.* *_cpython
-      - 3.6.* *_73_pypy   # [not (win64 or (osx and arm64))]
+      - 3.6.* *_73_pypy   # [not (osx and arm64)]
 
     numpy:
       - 1.16       # [not (osx and arm64)]
       - 1.16       # [not (osx and arm64)]
       - 1.16
-      - 1.18       # [not (win64 or (osx and arm64))]
+      - 1.18       # [not (osx and arm64)]
 
     python_impl:
       - cpython    # [not (osx and arm64)]
       - cpython    # [not (osx and arm64)]
       - cpython
-      - pypy       # [not (win64 or (osx and arm64))]
+      - pypy       # [not (osx and arm64)]
 
 
     zip_keys:


### PR DESCRIPTION
This is not a comprehensive fix, but "solves" #2351 by going back to what worked before. 

While at it, I'm fixing a minor annoyance that was never important enough for its own PR: some tests in `test_variant_algebra.py` have incorrect expectations when run on windows. Rather than change the logic, just simplify the selectors to match the expectations.