### PR TITLE
add osx-arm64 as default platform in Pixi.toml

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2215,6 +2215,16 @@ def render_pixi(jinja_env, forge_config, forge_dir):
         for platform, service in forge_config["provider"].items()
         if service
     }
+    if (
+        len(variants) == 1
+        and variants[0].startswith("linux_64")
+        and platforms == {"linux-64", "osx-64", "win-64"}
+    ):
+        # very likely noarch, add also osx-arm64 for local debugging
+        # this workaround can be removed when forge_config["providers"]
+        # gains 'osx-arm64' as default; see 'Provider' in schema.py
+        platforms.add("osx-arm64")
+
     new_file_contents = template.render(
         smithy_version=__version__,
         platforms=sorted(platforms),

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -437,6 +437,8 @@ OSVersion = create_model(
 
 ProviderType = Union[list[CIservices], CIservices, bool, Nullable]
 
+# When updating the list of default providers, check
+# 'platforms' in configure_feedstock.render_pixi() and update accordingly
 Provider = create_model(
     "provider",
     **dict(


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Closes https://github.com/conda-forge/conda-smithy/issues/2357