### PR TITLE
Reformat commit message to show more info about rattler-* versions

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2513,7 +2513,9 @@ def check_version_uptodate(name, installed_version, error_on_warn):
         logger.info(msg)
 
 
-def commit_changes(forge_file_directory, commit, cs_ver, cfp_ver, cb_ver, rb_ver=None, rbc_ver=None):
+def commit_changes(
+    forge_file_directory, commit, cs_ver, cfp_ver, cb_ver, rb_ver=None, rbc_ver=None
+):
     tools_and_versions = {
         "conda-build": cb_ver,
         "rattler-build": rb_ver,
@@ -2523,7 +2525,13 @@ def commit_changes(forge_file_directory, commit, cs_ver, cfp_ver, cb_ver, rb_ver
     if cfp_ver:
         msg += f" and conda-forge-pinning {cfp_ver}"
     msg += "\n\nOther tools:\n"
-    msg += "\n".join([f"- {tool} {version}" for tool, version in tools_and_versions.items() if version])
+    msg += "\n".join(
+        [
+            f"- {tool} {version}"
+            for tool, version in tools_and_versions.items()
+            if version
+        ]
+    )
     logger.info(msg)
 
     is_git_repo = os.path.exists(os.path.join(forge_file_directory, ".git"))

--- a/news/2359-commit-msg.rst
+++ b/news/2359-commit-msg.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Reformat commit messages in rerenders to show rattler-build and rattler-build-conda-compat versions. (#2359)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

In feedstocks with `recipe.yaml`, the commit message still shows `conda-build` versions for rerenders. Extend this to also show rattler-build and rattler-build-conda-compat if present.

I also reformatted it so the extra info is under the fold. This is how they look now:

```
MNT: Re-rendered with conda-smithy 3.51.1 and conda-forge-pinning 2025.07.15.13.41.12

Other tools:
- conda-build 25.5.0
- rattler-build 0.44.0
- rattler-build-conda-compat 1.4.3
```