### PR TITLE
Remove slashes and commas from variant names

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -801,6 +801,9 @@ def dump_subspace_config_files(metas, root_path, platform, arch, upload, forge_c
             f"{platform}_{arch}",
             package_key(config, top_level_loop_vars, metas[0].config.subdir),
         )
+        # remove slashes that may occur in variant values and thus the filename
+        config_name = config_name.replace("/", "").replace(",", "")
+
         short_config_name = config_name
         conf_hash = hashlib.sha256(config_name.encode("utf-8")).hexdigest()[:8]
         # drone has a limit of 50, see https://github.com/conda-forge/conda-smithy/issues/1188

--- a/news/2366-remove-slashes-from-variant-names.rst
+++ b/news/2366-remove-slashes-from-variant-names.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Remove slashes from variant file names which caused problems due to being mis-handled as folders. Also remove commas, which can be similarly misinterpreted (#2366).
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4030,7 +4030,6 @@ def test_lint_recipe_parses_ok():
 
 def test_lint_recipe_parses_forblock():
     with tempfile.TemporaryDirectory() as tmpdir:
-        # CRM cannot parse this one
         with open(os.path.join(tmpdir, "meta.yaml"), "w") as f:
             f.write(
                 textwrap.dedent(
@@ -4065,12 +4064,6 @@ def test_lint_recipe_parses_forblock():
         ), lints
         assert not any(
             hint.startswith("The recipe is not parsable by parser `conda-forge-tick")
-            for hint in hints
-        ), hints
-        assert any(
-            hint.startswith(
-                "The recipe is not parsable by parser `conda-recipe-manager"
-            )
             for hint in hints
         ), hints
         assert not any(
@@ -4159,12 +4152,6 @@ def test_lint_recipe_parses_v1_spacing():
             )
             for lint in lints
         ), lints
-        assert any(
-            hint.startswith(
-                "The recipe is not parsable by parser `conda-recipe-manager"
-            )
-            for hint in hints
-        ), hints
         assert not any(
             hint.startswith("The recipe is not parsable by parser `ruamel.yaml")
             for hint in hints


### PR DESCRIPTION
Fix issues discovered by py3.14 migration. Currently, the fact that we have values like
```yaml
channel_sources:
- conda-forge,conda-forge/label/python_rc
```
in a zip-key, which ends up in the variant file names as
```
.ci_support/linux_aarch64_channel_sourcesconda-forge,conda-forge/label/python_rcpython3.14.____cp314.yaml
                                                                ^     ^
                                                                !!!!!!!
```
This causes obvious issues because these slashes cause folders where there shouldn't be any (c.f. #2366). Just removing slashes from the filenames fixes this.

Fixes #2366