### PR TITLE
switch osx runners to macOS-15; macOS-13 will be removed soon

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1653,13 +1653,13 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
     runs_on = {
         "osx-64": {
             "os": "macos",
-            "hosted_labels": ("macos-13",),
+            "hosted_labels": ("macos-15",),
             "self_hosted_labels": ("macOS", "x64"),
         },
         "osx-arm64": {
             "os": "macos",
             # FUTURE: Use -latest once GHA fully migrates
-            "hosted_labels": ("macos-14",),
+            "hosted_labels": ("macos-15",),
             "self_hosted_labels": ("macOS", "arm64"),
         },
         "linux-64": {

--- a/conda_smithy/data/conda-forge.yml
+++ b/conda_smithy/data/conda-forge.yml
@@ -17,7 +17,7 @@ azure:
   settings_osx:
     install_atl: false
     pool:
-      vmImage: macOS-13
+      vmImage: macOS-15
     swapfile_size: null
     timeoutInMinutes: 360
     variables: {}

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -182,7 +182,7 @@ class AzureConfig(BaseModel):
     )
 
     settings_osx: AzureRunnerSettings = Field(
-        default_factory=lambda: AzureRunnerSettings(pool={"vmImage": "macOS-13"}),
+        default_factory=lambda: AzureRunnerSettings(pool={"vmImage": "macOS-15"}),
         description="OSX-specific settings for runners",
     )
 

--- a/news/macos_image.rst
+++ b/news/macos_image.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Switched to `macOS-15` images for osx jobs by default, due to impending removal of `macOS-13`.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
This is a bit confusing, given that GHA will [drop](https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down) `macOS-13`, and the [overview page](https://github.com/actions/runner-images/#available-images) for the images makes it seem like `macOS-{14,15}` only exist for `osx-arm64` or in the paid `-large` variant.

However, @jaimergp [pointed out](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=macos-images%2Cyaml) that things are different on Azure Pipelines. I've tested this in https://github.com/conda-forge/scipy-feedstock/pull/250, and indeed, `macOS-14` & `-15` work fine for our `osx-64` workflows.

So I'm not 100% sure if the given deprecation dates also apply to AZP
> mac-OS 13 Ventura
>  * Deprecation Start Date: 1st September 2025
>  * Full Retiral Date: 14th November 2025

but in any case we should switch away from this ASAP, and there doesn't seem to be a downside to using `macOS-15`.