### PR TITLE
try harder to create swap file; fail early if does not succeed

### DIFF
--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -42,10 +42,17 @@ jobs:
 {%- endif %}
 {%- if not (azure.settings_linux.swapfile_size|string).startswith("0") %}
   - script: |
-         sudo fallocate -l {{ azure.settings_linux.swapfile_size }} /swapfile || true
-         sudo chmod 600 /swapfile || true
-         sudo mkswap /swapfile || true
-         sudo swapon /swapfile || true
+        SWAPFILE=/swapfile
+        # If there is already a swapfile, disable it and remove it
+        if swapon --show | grep -q $SWAPFILE; then
+            echo "Disabling existing swapfile..."
+            sudo swapoff $SWAPFILE || true
+        fi
+        [ -f "$SWAPFILE" ] && sudo rm -f $SWAPFILE
+        sudo fallocate -l {{ azure.settings_linux.swapfile_size }} $SWAPFILE
+        sudo chmod 600 $SWAPFILE
+        sudo mkswap $SWAPFILE
+        sudo swapon $SWAPFILE
     displayName: Create swap file
 {%- endif %}
   # configure qemu binfmt-misc running.  This allows us to run docker containers

--- a/news/2384-swap-handling.rst
+++ b/news/2384-swap-handling.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Try harder to set up swap file, and fail early if this does not succeed. (#2384)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Fixes #2384; tested in https://github.com/conda-forge/mlir-feedstock/pull/107, which went from ~1-in-4 success rate to create the swap file with the template from smithy 3.52.0, to 100% success rate with the changes from this PR.

