### PR TITLE
fix rattler-build invocation

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -102,10 +102,9 @@ def warn_once(msg: str):
 
 @cache
 def rattler_build_version() -> str | None:
-    if sys.platform == "win32":
-        path = os.path.join(sys.prefix, "Library", "bin")
-    else:
-        path = os.path.join(sys.prefix, "bin")
+    # rattler-build is not packaged in %CONDA_PREFIX%\Library\bin on windows,
+    # but in the same location (relative to prefix) as on unix
+    path = os.path.join(sys.prefix, "bin")
     p = subprocess.run(
         [f"{path}/rattler-build", "--version"], text=True, capture_output=True
     )


### PR DESCRIPTION
Fixup for #2381, because rattler-build [packages](https://conda-metadata-app.streamlit.app/?q=conda-forge%2Fwin-64%2Frattler-build-0.46.0-h18a1a76_0.conda) the exe in a non-standard location (but matching the relative unix path).

CC @isuruf