### PR TITLE
fix: work around global yaml parsing changes from rattler-build-conda-compat

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -771,13 +771,19 @@ def main(recipe_dir, conda_forge=False, return_hints=False, feedstock_dir=None):
 
     recipe_version = 1 if build_tool == RATTLER_BUILD_TOOL else 0
 
+    # this call to lint the confa-forge.yml has to come before the
+    # actual recipe linter is called
+    # rattler-build-conda-compat
+    # is setting a global option to force yaml to be parsed as a string
+    # see https://github.com/prefix-dev/rattler-build-conda-compat/issues/88
+    validation_errors, validation_hints = lintify_forge_yaml(recipe_dir=recipe_dir)
+
     results, hints = lintify_meta_yaml(
         meta,
         recipe_dir,
         conda_forge,
         recipe_version=recipe_version,
     )
-    validation_errors, validation_hints = lintify_forge_yaml(recipe_dir=recipe_dir)
 
     results.extend([_format_validation_msg(err) for err in validation_errors])
     hints.extend([_format_validation_msg(hint) for hint in validation_hints])

--- a/news/cfyaml_lint.rst
+++ b/news/cfyaml_lint.rst
@@ -17,7 +17,7 @@
 **Fixed:**
 
 * Fixed issue where ``rattler-build-conda-compat`` makes global modifications to YAML
-  parsing causing the linter for ``conda-forge.yml`` files to fail. (#)
+  parsing causing the linter for ``conda-forge.yml`` files to fail. (#2387)
 
 **Security:**
 

--- a/news/cfyaml_lint.rst
+++ b/news/cfyaml_lint.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed issue where ``rattler-build-conda-compat`` makes global modifications to YAML
+  parsing causing the linter for ``conda-forge.yml`` files to fail. (#)
+
+**Security:**
+
+* <news item>

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -307,7 +307,6 @@ def test_schema_validate_json_schema_with_bot_uri_override(tmp_path):
     ),
 )
 def test_schema_with_rattler_build_conda_compat():
-    # this test assures
     from rattler_build_conda_compat.yaml import _yaml_object
 
     _yaml_object()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -319,7 +319,7 @@ def test_schema_with_rattler_build_conda_compat():
                     """\
                 bot:
                 version_updates:
-                    random_fracvtion_to_keep: 0.02
+                    random_fraction_to_keep: 0.02
                 """
                 )
             )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -301,7 +301,10 @@ def test_schema_validate_json_schema_with_bot_uri_override(tmp_path):
 
 
 @pytest.mark.xfail(
-    reason="rattler-build-conda-compat makes global modifications to ruamel.yaml - see https://github.com/prefix-dev/rattler-build-conda-compat/issues/88"
+    reason=(
+        "rattler-build-conda-compat makes global modifications to ruamel.yaml"
+        " - see https://github.com/prefix-dev/rattler-build-conda-compat/issues/88"
+    ),
 )
 def test_schema_with_rattler_build_conda_compat():
     # this test assures

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -292,6 +292,7 @@ def test_schema_validate_json_schema_with_bot_uri_override(tmp_path):
         lints, hints = validate_json_schema(cfyaml)
         assert lints == []
         assert hints == []
+
     finally:
         if old_val:
             os.environ["CONDA_SMITHY_BOT_SCHEMA_URI"] = old_val


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

closes #2284

<!--
Please add any other relevant info below:
-->

See https://github.com/prefix-dev/rattler-build-conda-compat/issues/88 for details on bug in `rattler-build-conda-compat`.
