### PR TITLE
fix: ensure we always use python standard strings when processing variants

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -55,6 +55,7 @@ from conda_smithy.feedstock_io import (
 from conda_smithy.utils import (
     RATTLER_BUILD,
     HashableDict,
+    ensure_standard_strings,
     get_feedstock_about_from_meta,
     get_feedstock_name_from_meta,
 )
@@ -1079,6 +1080,7 @@ def _render_ci_provider(
             )
             if os.path.exists(variants_path):
                 new_spec = parse_recipe_config_file(variants_path, namespace)
+                new_spec = ensure_standard_strings(new_spec)
                 specs = {
                     "combined_spec": combined_variant_spec,
                     "variants.yaml": new_spec,

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -21,14 +21,13 @@ from conda_smithy.linter.utils import (
     TEST_KEYS,
     _lint_package_version,
     _lint_recipe_name,
-    ensure_standard_strings,
     flatten_v1_if_else,
     get_section,
     is_selector_line,
     jinja_lines,
     selector_lines,
 )
-from conda_smithy.utils import get_yaml
+from conda_smithy.utils import ensure_standard_strings, get_yaml
 
 logger = logging.getLogger(__name__)
 

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -21,6 +21,7 @@ from conda_smithy.linter.utils import (
     TEST_KEYS,
     _lint_package_version,
     _lint_recipe_name,
+    ensure_standard_strings,
     flatten_v1_if_else,
     get_section,
     is_selector_line,
@@ -879,6 +880,7 @@ def lint_stdlib(
                 platform_namespace,
                 allow_missing_selector=True,
             )
+            cbc_osx = ensure_standard_strings(cbc_osx)
     else:
         cbc_lines = []
         if conda_build_config_filename:

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -6,6 +6,7 @@ import shutil
 import tempfile
 import time
 from collections import defaultdict
+from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Union
@@ -223,3 +224,22 @@ class HashableDict(dict):
 
     def __hash__(self):
         return hash(json.dumps(self, sort_keys=True, default=_json_default))
+
+
+def ensure_standard_strings(cfg: Any) -> Any:
+    """Ensure an object composed of sequences, dicts, and values only has
+    Python `str` strings in it."""
+
+    if isinstance(cfg, str):
+        return str(cfg)
+    elif isinstance(cfg, Mapping):
+        for k in list(cfg.keys()):
+            v = cfg.pop(k)
+            k = ensure_standard_strings(k)
+            v = ensure_standard_strings(v)
+            cfg[k] = v
+        return cfg
+    elif isinstance(cfg, Sequence):
+        return type(cfg)([ensure_standard_strings(v) for v in cfg])
+    else:
+        return cfg

--- a/news/pyt_str_var.rst
+++ b/news/pyt_str_var.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed bug where variants loaded via ``parse_recipe_config_file`` had non-standard Python strings
+  that did not serialize correctly when passed through ``yaml.dump``. (#)
+
+**Security:**
+
+* <news item>

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -1,4 +1,5 @@
 import copy
+import io
 import logging
 import os
 import re
@@ -10,9 +11,11 @@ from pathlib import Path
 import pytest
 import yaml
 from conftest import ConfigYAML
+from rattler_build_conda_compat.loader import parse_recipe_config_file
 
 from conda_smithy import configure_feedstock
 from conda_smithy.configure_feedstock import _read_forge_config
+from conda_smithy.utils import ensure_standard_strings
 
 
 def test_noarch_skips_appveyor(noarch_recipe, jinja_env):
@@ -2070,3 +2073,30 @@ def test_read_forge_config_default_values_aliases():
         assert isinstance(config["azure"]["settings_linux"]["timeoutInMinutes"], int)
         assert isinstance(config["azure"]["settings_osx"]["timeoutInMinutes"], int)
         assert isinstance(config["azure"]["settings_win"]["timeoutInMinutes"], int)
+
+
+def test_configure_feedstock_rattler_build_conda_compat_round_trip():
+    def _dumps(cfg):
+        val = io.StringIO()
+        yaml.dump(cfg, val, default_flow_style=False)
+        return val.getvalue()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fname = os.path.join(tmpdir, "variants.yaml")
+        with open(fname, "w") as fp:
+            fp.write(
+                textwrap.dedent(
+                    """
+                varkey:
+                - "val1"
+                - 'val2'
+                - val
+                """
+                )
+            )
+
+        cfg = parse_recipe_config_file(fname, {})
+        assert "ruamel.yaml" in _dumps(cfg)
+
+        cfg = ensure_standard_strings(cfg)
+        assert "ruamel.yaml" not in _dumps(cfg)


### PR DESCRIPTION
This PR ensures we only use standard python strings when processing variants loaded via `rattler_build_conda_compat`. 

See this [ci job](https://github.com/conda-forge/admin-requests/actions/runs/18045130153/job/51353901331) for the traceback where we got


```
yaml.constructor.ConstructorError: could not determine a constructor for the tag 'tag:yaml.org,2002:python/object/new:ruamel.yaml.scalarstring.DoubleQuotedScalarString'
  in "/tmp/tmp22yiw7br__feedstocks/mg5amcnlo-pythia8-interface-feedstock/.ci_support/linux_64_pythia88.312.yaml", line 18, column 3
```

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
