### PR TITLE
linter: ignore package version when it is templated for v1

### DIFF
--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -211,6 +211,11 @@ def _lint_package_version(version: Optional[str]) -> Optional[str]:
         return no_package_version
 
     ver = str(version)
+
+    if ver.startswith("$"):
+        # version is templatised. skip the lint
+        return
+
     try:
         VersionOrder(ver)
     except InvalidVersionSpec as e:

--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -212,7 +212,7 @@ def _lint_package_version(version: Optional[str]) -> Optional[str]:
 
     ver = str(version)
 
-    if ver.startswith("$"):
+    if ver.startswith("${{"):
         # version is templatised. skip the lint
         return
 

--- a/news/version_template.rst
+++ b/news/version_template.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* linter will ignore package versions that are jinja templated for v1.
+
+**Security:**
+
+* <news item>

--- a/news/version_template.rst
+++ b/news/version_template.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* linter will ignore package versions that are jinja templated for v1.
+* linter will ignore package versions that are jinja templated for v1 (#2402).
 
 **Security:**
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
