### PR TITLE
free_disk_space on github actions: only remove installed packages

### DIFF
--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -77,9 +77,10 @@ jobs:
         done
 {%- endif %}
 {%- if (github_actions.free_disk_space == true) or ('apt' in github_actions.free_disk_space) %}
-        sudo apt-get purge -y -f firefox \
-                                 google-chrome-stable \
-                                 microsoft-edge-stable
+        BROWSERS="firefox google-chrome-stable microsoft-edge-stable"
+        BROWSERS_TO_REMOVE=$(dpkg --get-selections $BROWSERS 2>/dev/null | awk '{print $1}')
+        sudo apt-get remove --purge -y $BROWSERS_TO_REMOVE
+
         sudo apt-get autoremove -y >& /dev/null
         sudo apt-get autoclean -y >& /dev/null
 {%- endif %}

--- a/news/gha-free-space-linux-aarch64.rst
+++ b/news/gha-free-space-linux-aarch64.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* `free_disk_space = [apt]` now properly works on native linux-aarch64 runner
+  with GitHub Actions.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
`google-chrome-stable` and `microsoft-edge-stable` are not installed on the linux aarch64 runners on github actions, so running `sudo apt-get remove --purge` for them fails CI.

Tested in https://github.com/metatensor/lammps-metatomic-feedstock/pull/8