### PR TITLE
remove link to stdlib meta issue in lint message

### DIFF
--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -775,8 +775,7 @@ def lint_stdlib(
     stdlib_lint = (
         "This recipe is using a compiler, which now requires adding a build "
         f"dependence on {jinja_stdlib_c} as well. Note that this rule applies to "
-        "each output of the recipe using a compiler. For further details, please "
-        "see https://github.com/conda-forge/conda-forge.github.io/issues/2102."
+        "each output of the recipe using a compiler."
     )
     if recipe_version == 0:
         pat_compiler_stub = re.compile(


### PR DESCRIPTION
I cannot open https://github.com/conda-forge/conda-forge.github.io/issues/2102 anymore, presumably because we've created too many links to that issue. Tried reloading ~10 times, never managed to get the timeline.

<img width="1176" height="447" alt="image" src="https://github.com/user-attachments/assets/a33a6ef5-00aa-44c1-8946-8d6288169109" />

Remove the link from the linter message, to avoid overloading that issue even more.

I think we can also close this issue now, as suggested by @jakirkham (who it appears was able to load the timeline; I only got it through an email notification)
> Do we think this is ok to close at this point? Or are there some remaining tasks we still need to track?

To answer that point briefly, I had been keeping track every now and then about the "velocity" of new links to that issue, but yes, I think we're good to close this.

Closes https://github.com/conda-forge/conda-forge.github.io/issues/2102