### PR TITLE
Change `{{ stdlib("c") }}` issue links in lints to doc links

### DIFF
--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -841,7 +841,7 @@ def lint_stdlib(
         f"now be done by adding a build dependence on {jinja_stdlib_c}, and "
         "overriding `c_stdlib_version` in `recipe/conda_build_config.yaml` for the "
         "respective platform as necessary. For further details, please see "
-        "https://github.com/conda-forge/conda-forge.github.io/issues/2102."
+        "https://conda-forge.org/docs/maintainer/infrastructure/#using-compilers-in-feedstocks"
     )
     pat_sysroot = re.compile(r"sysroot_linux.*")
     if any(pat_sysroot.match(req) for req in all_build_reqs_flat):
@@ -853,7 +853,7 @@ def lint_stdlib(
         f"should now be done by adding a build dependence on {jinja_stdlib_c}, "
         "and overriding `c_stdlib_version` in `recipe/conda_build_config.yaml` for "
         "the respective platform as necessary. For further details, please see "
-        "https://github.com/conda-forge/conda-forge.github.io/issues/2102."
+        "https://conda-forge.org/docs/maintainer/knowledge_base/#requiring-newer-macos-sdks"
     )
 
     to_check = all_run_reqs_flat + all_contraints_flat

--- a/news/use_stdlib_c_doc_links.rst
+++ b/news/use_stdlib_c_doc_links.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Replace old ``{{ stdlib("c") }}`` meta issue links with doc links. ( #2429 )
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Replace links to the old `{{ stdlib("c") }}` meta issue with doc links. This should be more informative for maintainers and cutdown on extra GitHub cross-links.

<!--
Please add any other relevant info below:
-->
