### PR TITLE
macOS GHA: use dedicated `OSX_SDK_DIR`

### DIFF
--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -125,7 +125,8 @@ fi
 {% if build_setup -%}
 if [[ "${OSX_SDK_DIR:-}" == "" ]]; then
   if [[ "${CI:-}" == "" ]]; then
-    OSX_SDK_DIR=$(mktemp -d)
+    echo "Please set OSX_SDK_DIR to a directory where SDKs can be downloaded to. Aborting"
+    exit 1
   else
     # here we're definitely in the CI case
     export OSX_SDK_DIR=/opt/conda-sdks

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -123,9 +123,24 @@ if [[ "${sha:-}" == "" ]]; then
 fi
 
 {% if build_setup -%}
-export OSX_SDK_DIR=/opt/conda-sdks
-/usr/bin/sudo mkdir -p "${OSX_SDK_DIR}"
-/usr/bin/sudo chown "${USER}" "${OSX_SDK_DIR}"
+if [[ "${OSX_SDK_DIR:-}" == "" ]]; then
+  if [[ "${CI:-}" == "" ]]; then
+    OSX_SDK_DIR=$(mktemp -d)
+  else
+    # here we're definitely in the CI case
+    export OSX_SDK_DIR=/opt/conda-sdks
+    /usr/bin/sudo mkdir -p "${OSX_SDK_DIR}"
+    /usr/bin/sudo chown "${USER}" "${OSX_SDK_DIR}"
+  fi
+else
+  if tmpf=$(mktemp -p "$OSX_SDK_DIR" tmp.XXXXXXXX 2>/dev/null); then
+      rm -f "$tmpf"
+      echo "OSX_SDK_DIR is writeable without sudo, continuing"
+  else
+      echo "User-provided OSX_SDK_DIR is not writeable for current user! Aborting"
+      exit 1
+  fi
+fi
 
 echo -e "\n\nRunning the build setup script."
 {{ build_setup }}

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -128,7 +128,6 @@ if [[ "${OSX_SDK_DIR:-}" == "" ]]; then
     echo "Please set OSX_SDK_DIR to a directory where SDKs can be downloaded to. Aborting"
     exit 1
   else
-    # here we're definitely in the CI case
     export OSX_SDK_DIR=/opt/conda-sdks
     /usr/bin/sudo mkdir -p "${OSX_SDK_DIR}"
     /usr/bin/sudo chown "${USER}" "${OSX_SDK_DIR}"

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -123,6 +123,10 @@ if [[ "${sha:-}" == "" ]]; then
 fi
 
 {% if build_setup -%}
+export OSX_SDK_DIR=/opt/conda-sdks
+/usr/bin/sudo mkdir -p "${OSX_SDK_DIR}"
+/usr/bin/sudo chown "${USER}" "${OSX_SDK_DIR}"
+
 echo -e "\n\nRunning the build setup script."
 {{ build_setup }}
 {%- endif %}

--- a/news/macos-gha-sdk-dir.rst
+++ b/news/macos-gha-sdk-dir.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* macOS GitHub Actions setup now sets ``OSX_SDK_DIR`` to a dedicated directory where SDKs can be downloaded without altering the system (see https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/409).
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/macos-gha-sdk-dir.rst
+++ b/news/macos-gha-sdk-dir.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* macOS GitHub Actions setup now sets ``OSX_SDK_DIR`` to a dedicated directory where SDKs can be downloaded without altering the system (see https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/409).
+* macOS CI setup now sets ``OSX_SDK_DIR`` to a dedicated directory where SDKs can be downloaded without altering the system (see https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/409).
 
 **Deprecated:**
 


### PR DESCRIPTION
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Set a dedicated `OSX_SDK_DIR` for macOS GitHub Actions runners, so that SDKs can be downloaded without altering the main system install, as requested on https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/409.

