### PR TITLE
fix quotes in "git commit ..." log message

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2591,10 +2591,11 @@ def commit_changes(
                 subprocess.check_call(git_args, cwd=forge_file_directory)
                 logger.info("")
             else:
+                # Use only the first line of msg for the suggested command
+                msg_first_line = msg.split("\n")[0]
                 logger.info(
-                    "You can commit the changes with:\n\n"
-                    '    git commit -m "MNT: %s"\n',
-                    msg,
+                    'You can commit the changes with:\n\n    git commit -m "MNT: %s"\n',
+                    msg_first_line,
                 )
             logger.info("These changes need to be pushed to github!\n")
         else:

--- a/news/changelog_quotes.rst
+++ b/news/changelog_quotes.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed quotes in "git commit ..." log message (#2437)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Closes #2436 

This now looks like this:

```
INFO:conda_smithy.configure_feedstock:Re-rendered with conda-smithy 3.53.4.dev3+g5b2575d3c.d20251216 and conda-forge-pinning 2025.12.16.12.55.14

Other tools:
- conda-build 25.11.1
- rattler-build 0.54.0
- rattler-build-conda-compat 1.4.10
INFO:conda_smithy.configure_feedstock:You can commit the changes with:

    git commit -m "MNT: Re-rendered with conda-smithy 3.53.4.dev3+g5b2575d3c.d20251216 and conda-forge-pinning 2025.12.16.12.55.14"

INFO:conda_smithy.configure_feedstock:These changes need to be pushed to github!
```

Not sure whether this is preferrable to the way it was before:

```
INFO:conda_smithy.configure_feedstock:Re-rendered with conda-smithy 3.53.4.dev3+g5b2575d3c.d20251216 and conda-forge-pinning 2025.12.16.12.55.14

Other tools:
- conda-build 25.11.1
- rattler-build 0.54.0
- rattler-build-conda-compat 1.4.10
INFO:conda_smithy.configure_feedstock:You can commit the changes with:

    git commit -m "MNT: Re-rendered with conda-smithy 3.53.4.dev3+g5b2575d3c.d20251216 and conda-forge-pinning 2025.12.16.12.55.14

Other tools:
- conda-build 25.11.1
- rattler-build 0.54.0
- rattler-build-conda-compat 1.4.10"

INFO:conda_smithy.configure_feedstock:These changes need to be pushed to github!
```

WDYT?