### PR TITLE
add some missing `encoding=utf-8` for opening files

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2620,7 +2620,7 @@ def get_cfp_file_path(temporary_directory):
 
     response = requests.get(pkg.url)
     response.raise_for_status()
-    with open(dest, "wb") as f:
+    with open(dest, "wb", encoding="utf-8") as f:
         f.write(response.content)
 
     logger.info("Extracting conda-forge-pinning to %s", temporary_directory)

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -681,7 +681,7 @@ def run_conda_forge_specific(
     # 13: no empty conda_forge_config.yaml files
     cbc_pth = os.path.join(recipe_dir or "", "conda_build_config.yaml")
     if os.path.exists(cbc_pth):
-        with open(cbc_pth) as fh:
+        with open(cbc_pth, encoding="utf-8") as fh:
             data = fh.read()
         if not data:
             lints.append(
@@ -784,7 +784,7 @@ def main(recipe_dir, conda_forge=False, return_hints=False, feedstock_dir=None):
         # we have to preserve the string quoting information for properly
         # rendering the context section of the recipe
         yl = get_yaml(preserve_quotes=True)
-        with open(recipe_file) as fp:
+        with open(recipe_file, encoding="utf-8") as fp:
             meta = yl.load(fp.read())
 
     recipe_version = 1 if build_tool == RATTLER_BUILD_TOOL else 0


### PR DESCRIPTION
Some more places have crept in where `open()` is specified without `encoding="utf-8"`, which can break on windows. I'm soooooo looking forward to python 3.15 _finally_ defaulting to utf-8.