### PR TITLE
Require `conda-recipe-manager>=0.9` and expect duplicate key errors

### DIFF
--- a/conda_smithy/templates/azure-pipelines.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines.yml.tmpl
@@ -15,7 +15,7 @@ stages:
   jobs:
     - job: Skip
       pool:
-        vmImage: 'ubuntu-22.04'
+        vmImage: 'ubuntu-latest'
       variables:
         DECODE_PERCENTS: 'false'
         RET: 'true'

--- a/environment.yml
+++ b/environment.yml
@@ -42,4 +42,5 @@ dependencies:
   - jsonschema
   - backports.strenum
   - exceptiongroup
+  - py-rattler >=0.21
   - rattler-build-conda-compat >=1.4.5,<2.0.0a0

--- a/news/2449-ubuntu-skip.rst
+++ b/news/2449-ubuntu-skip.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Use ``ubuntu-latest`` in Azure Pipelines skip-control job. (#2449)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/faster-get_most_recent_version.rst
+++ b/news/faster-get_most_recent_version.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Optimized ``get_most_recent_version`` for faster rerenders by using sharded repodata instead of Anaconda.org API. (#2451)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python conda_smithy/schema.py`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

https://github.com/conda/conda-recipe-manager/pull/460 introduced a new behavior where conda-recipe-manager raises on duplicate keys, which breaks the tests. Adjust the tests accordingly for the new version requirement.