### PR TITLE
update license year

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2022, conda-forge
+Copyright (c) 2015-2026, conda-forge
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/conda_smithy/feedstock_content/LICENSE.txt
+++ b/conda_smithy/feedstock_content/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD-3-Clause license
-Copyright (c) 2015-2022, conda-forge contributors
+Copyright (c) 2015-2026, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
I don't really ever look at the feedstock licenses, but I noticed through https://github.com/python/cpython/pull/143468 that we haven't updated the license year for a long time.