### PR TITLE
help users debug mismatched zip-keys more easily

### DIFF
--- a/news/debug-hint.rst
+++ b/news/debug-hint.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* Provide a hint and additional logging in case of failures within conda-build, such that
+  analysing intermediate variant configurations (e.g. after applying migrations) becomes
+  more discoverable and accessible without hacking on smithy's source code.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Every couple of months I relearn that `CONDA_SMITHY_LOGLEVEL` exists, and then forget again how it's spelled. I've also failed many times to grep for it, because I had somehow misremembered the name. So I propose to display this more prominently, and make use of this existing infrastructure for better logging.

Inspired by an edge-case (borderline bug) I just ran into, I want to display the variants before a failure during conda-build; it can be notoriously difficult to debug that, due to the way that the variant algebra often modify the contents of various keys in a zip.