### PR TITLE
reflect upcoming macos 11.0 baseline

### DIFF
--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -924,7 +924,7 @@ def lint_stdlib(
                 versions = versions[::-1]
         return versions
 
-    baseline_version = ["10.13", "11.0"]
+    baseline_version = ["11.0", "11.0"]
     v_stdlib = sort_osx(cbc_osx.get("c_stdlib_version", baseline_version))
     macdt = sort_osx(cbc_osx.get("MACOSX_DEPLOYMENT_TARGET", baseline_version))
     sdk = sort_osx(cbc_osx.get("MACOSX_SDK_VERSION", baseline_version))
@@ -968,7 +968,7 @@ def lint_stdlib(
         # only warn if version is below baseline
         outdated_lint = (
             "You are setting `c_stdlib_version` below the current global baseline "
-            "in conda-forge (10.13). If this is your intention, you also need to "
+            "in conda-forge (11.0). If this is your intention, you also need to "
             "override `MACOSX_DEPLOYMENT_TARGET` (with the same value) locally."
         )
         if len(v_stdlib) == len(macdt):
@@ -996,7 +996,7 @@ def lint_stdlib(
         "(you can leave it out if it is equal).\n"
         "If you are not setting `c_stdlib_version` yourself, this means "
         "you are requesting a version below the current global baseline in "
-        "conda-forge (10.13). If this is the intention, you also need to "
+        "conda-forge (11.0). If this is the intention, you also need to "
         "override `c_stdlib_version` and `MACOSX_DEPLOYMENT_TARGET` locally."
     )
     if len(sdk) == len(merged_dt):

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -285,10 +285,10 @@ def test_recipe_v1_osx_noarch_hint():
         (["10.9", "11.0"], ["10.13", "11.0"], None, "Conflicting spec"),
         (["10.13", "11.0"], ["10.13", "12.3"], None, "Conflicting spec"),
         # only deployment target -> warn
-        (["10.13", "11.0"], None, None, "In your conda_build_config.yaml"),
+        (["11.0", "12.0"], None, None, "In your conda_build_config.yaml"),
         # only stdlib -> no warning
-        (None, ["10.13", "11.0"], None, None),
-        (None, ["10.15"], None, None),
+        (None, ["11.0", "11.0"], None, None),
+        (None, ["11.1"], None, None),
         # only stdlib, but outdated -> warn
         (None, ["10.9", "11.0"], None, "You are"),
         (None, ["10.9"], None, "You are"),
@@ -306,8 +306,8 @@ def test_recipe_v1_osx_noarch_hint():
         (["10.9", "11.0"], ["10.13", "11.0"], ["10.12"], "Conflicting spec"),
         (["10.9", "11.0"], ["10.13", "11.0"], ["10.12"], "You are"),
         # only sdk -> no warning
-        (None, None, ["10.13"], None),
-        (None, None, ["10.14", "12.0"], None),
+        (None, None, ["11.0"], None),
+        (None, None, ["11.1", "12.0"], None),
         # only sdk, but below global baseline -> warning
         (None, None, ["10.12"], "You are"),
         (None, None, ["10.12", "11.0"], "You are"),
@@ -422,10 +422,10 @@ def test_license_file_empty(recipe_version: int):
         (["10.9", "11.0"], ["10.13", "11.0"], None, "Conflicting spec"),
         (["10.13", "11.0"], ["10.13", "12.3"], None, "Conflicting spec"),
         # only deployment target -> warn
-        (["10.13", "11.0"], None, None, "In your conda_build_config.yaml"),
+        (["11.0", "12.0"], None, None, "In your conda_build_config.yaml"),
         # only stdlib -> no warning
-        (None, ["10.13", "11.0"], None, None),
-        (None, ["10.15"], None, None),
+        (None, ["11.0", "11.0"], None, None),
+        (None, ["11.1"], None, None),
         # only stdlib, but outdated -> warn
         (None, ["10.9", "11.0"], None, "You are"),
         (None, ["10.9"], None, "You are"),
@@ -443,8 +443,8 @@ def test_license_file_empty(recipe_version: int):
         (["10.9", "11.0"], ["10.13", "11.0"], ["10.12"], "Conflicting spec"),
         (["10.9", "11.0"], ["10.13", "11.0"], ["10.12"], "You are"),
         # only sdk -> no warning
-        (None, None, ["10.13"], None),
-        (None, None, ["10.14", "12.0"], None),
+        (None, None, ["11.0"], None),
+        (None, None, ["11.1", "12.0"], None),
         # only sdk, but below global baseline -> warning
         (None, None, ["10.12"], "You are"),
         (None, None, ["10.12", "11.0"], "You are"),


### PR DESCRIPTION
For https://github.com/conda-forge/conda-forge.github.io/issues/2467; we should try to sync the next smithy release with when we actually flip the switch to 11.0 (xref https://github.com/conda-forge/conda-forge.github.io/pull/2721)

