### PR TITLE
improve visibility of CONDA_SMITHY_LOGLEVEL msg

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1044,10 +1044,12 @@ def _conda_build_api_render_for_smithy(
     except ValueError as e:
         # if conda-build fails to render the recipe, e.g. due to some zip_keys that have
         # become mismatched by applying migrations, tell users how to debug this more easily
-        raise ValueError(
-            "To see the variant configuration that was handed to conda-build, which failed "
-            "to render the recipe, set the environment variable CONDA_SMITHY_LOGLEVEL=debug"
-        ) from e
+        if os.environ.get("CONDA_SMITHY_LOGLEVEL", None) is None:
+            raise ValueError(
+                "To see the variant configuration that was handed to conda-build, which failed "
+                "to render the recipe, set the environment variable CONDA_SMITHY_LOGLEVEL=debug"
+            ) from e
+        raise
 
     output_metas = []
     for meta, download, render_in_env in metadata_tuples:


### PR DESCRIPTION
Follow-up to #2459; the print gets a bit lost in the noise, because it's shown before the traceback, not at the bottom, where the content of the ValueError is shown.