### PR TITLE
Lint on recipes that do not quote YAML floats

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -42,6 +42,7 @@ from conda_smithy.linter.lints import (
     lint_build_section_should_have_a_number,
     lint_check_usage_of_whls,
     lint_feedstock_name_not_end_with_feedstock,
+    lint_floats_quoted,
     lint_go_licenses_are_bundled,
     lint_jinja_var_references,
     lint_jinja_variables_definitions,
@@ -388,6 +389,9 @@ def lintify_meta_yaml(
                 # the version of the config file does not change the version of the recipe
                 recipe_version=recipe_version,
             )
+
+    # 32: floats should be quoted
+    lint_floats_quoted(meta, lints, recipe_version=recipe_version)
 
     # hints
     # 1: suggest pip

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -1128,3 +1128,27 @@ def lint_recipe_is_abi3_bool(
             "string (i.e., 'true' or 'false'). Please change syntax like "
             "`is_abi3 == 'true' to `is_abi3`."
         )
+
+
+def lint_floats_quoted(
+    meta: dict,
+    lints: list[str],
+    recipe_version: int,
+) -> None:
+    def process_recursively(key: str, value: Any) -> None:
+        if isinstance(value, dict):
+            for subkey, subvalue in value.items():
+                process_recursively(f"{key}.{subkey}", subvalue)
+        elif isinstance(value, list):
+            for i, subvalue in enumerate(value):
+                process_recursively(f"{key}[{i}]", subvalue)
+        elif isinstance(value, float):
+            v0_hint = ' or "{{ var }}"' if recipe_version == 0 else ""
+            lints.append(
+                f"{key} has a value that is interpreted as a floating-point "
+                f'number. Please quote it (like "{value}"{v0_hint}) to '
+                "ensure that it is interpreted as string and preserved exactly."
+            )
+
+    for key, value in meta.items():
+        process_recursively(key, value)

--- a/news/float-lint.rst
+++ b/news/float-lint.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* New linter that checks that no unquoted floating-point number is found in a recipe. (#2453)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/recipes/cb3_jinja2_functions/recipe/meta.yaml
+++ b/tests/recipes/cb3_jinja2_functions/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: test_cb3_jinja2_functions
-  version: 1.0
+  version: "1.0"
 
 build:
   number: 0

--- a/tests/recipes/multiple_sources/meta.yaml
+++ b/tests/recipes/multiple_sources/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: test_cb3_multiple_sources
-  version: 1.0
+  version: "1.0"
 
 source:
   - url: https://storage.googleapis.com/golang/go{{ version }}.src.tar.gz

--- a/tests/recipes/v1_recipes/torchvision.yaml
+++ b/tests/recipes/v1_recipes/torchvision.yaml
@@ -9,7 +9,7 @@ context:
   torch_proc_type: ${{ "cuda" ~ cuda_compiler_version | version_to_buildstring if cuda_compiler_version != "None" else "cpu" }}
   # Upstream has specific compatability ranges for pytorch and python which are
   # updated every 0.x release. https://github.com/pytorch/vision#installation
-  compatible_pytorch: 2.5
+  compatible_pytorch: "2.5"
 
   tests_to_skip: >
     ${{ 'skip test_url_is_accessible instead of hitting 20+ servers per run, since' if 0 }}

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4544,5 +4544,127 @@ def test_no_custom_github_actions_workflows(tmp_path):
     assert not any("Github Actions workflows" in lint for lint in lints)
 
 
+@pytest.mark.parametrize(
+    "var_value,value,expect_lint",
+    [
+        ("1.0", "{{ version }}", True),
+        ("1.0", '"{{ version }}"', False),
+        ('\\"1.0\\"', "{{ version }}", False),  # ugly but valid
+        ("1", "{{ version }}", False),
+        ("1.0.0", "{{ version }}", False),
+        ("", "1.0", True),
+        ("", '"1.0"', False),
+        ("", "1", False),
+        ("", "1.0.0", False),
+    ],
+)
+def test_lint_v0_unquoted_floats(var_value: str, value: str, expect_lint: bool) -> None:
+    recipe = f"""\
+{{% set version = "{var_value}" %}}
+
+package:
+  name: foo
+  version: {value}
+
+build:
+  number: 1
+
+test:
+  commands:
+    - true
+
+about:
+  home: https://example.com
+  license: GPL-3.0-or-later
+  license_file:
+    - COPYING
+  summary: test
+
+extra:
+  recipe-maintainers:
+    - mgorny
+"""
+
+    with tmp_directory() as recipe_dir:
+        # Create minimal recipe content - the linter determines version from filename
+        with open(os.path.join(recipe_dir, "meta.yaml"), "w") as fh:
+            fh.write(recipe)
+
+        lints, hints = linter.main(recipe_dir, return_hints=True, conda_forge=True)
+
+    assert lints == (
+        [
+            "package.version has a value that is interpreted as a floating-point "
+            'number. Please quote it (like "1.0" or "{{ var }}") to ensure that it is '
+            "interpreted as string and preserved exactly."
+        ]
+        if expect_lint
+        else []
+    )
+    assert hints == []
+
+
+@pytest.mark.parametrize(
+    "var_value,value,expect_lint",
+    [
+        ("1.0", "${{ version }}", "context.version"),
+        ('"1.0"', "${{ version }}", None),
+        ("1", "${{ version }}", None),
+        ("1.0.0", "${{ version }}", None),
+        ("", "1.0", "package.version"),
+        ("", '"1.0"', None),
+        ("", "1", None),
+        ("", "1.0.0", None),
+    ],
+)
+def test_lint_v1_unquoted_floats(
+    var_value: str, value: str, expect_lint: str | None
+) -> None:
+    recipe = f"""\
+context:
+  version: {var_value}
+
+package:
+  name: foo
+  version: {value}
+
+build:
+  number: 1
+
+tests:
+  - script:
+    - true
+
+about:
+  homepage: https://example.com
+  license: GPL-3.0-or-later
+  license_file:
+    - COPYING
+  summary: test
+
+extra:
+  recipe-maintainers:
+    - mgorny
+"""
+
+    with tmp_directory() as recipe_dir:
+        # Create minimal recipe content - the linter determines version from filename
+        with open(os.path.join(recipe_dir, "recipe.yaml"), "w") as fh:
+            fh.write(recipe)
+
+        lints, hints = linter.main(recipe_dir, return_hints=True, conda_forge=True)
+
+    assert lints == (
+        [
+            f"{expect_lint} has a value that is interpreted as a floating-point "
+            'number. Please quote it (like "1.0") to ensure that it is '
+            "interpreted as string and preserved exactly."
+        ]
+        if expect_lint is not None
+        else []
+    )
+    assert hints == []
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes #2453

<!--
Please add any other relevant info below:
-->
