### PR TITLE
Unified configuration format, `store_build_artifacts` part

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1822,9 +1822,19 @@ def render_appveyor(jinja_env, forge_config, forge_dir, return_metadata=False):
 
 
 def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform):
-    forge_config.setdefault("workflow_settings_processed", {})[
-        "store_build_artifacts"
-    ] = set()
+    platform_templates = {
+        "linux": [
+            ".scripts/run_docker_build.sh",
+            ".scripts/build_steps.sh",
+        ],
+        "osx": [
+            ".scripts/run_osx_build.sh",
+        ],
+        "win": [
+            ".scripts/run_win_build.bat",
+        ],
+    }
+    template_files = platform_templates.get(platform, [])
 
     # Handle GH-hosted and self-hosted runners runs-on config
     # Do it before the deepcopy below so these changes can be used by the
@@ -1882,8 +1892,9 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
             )
         )
         if data["store_build_artifacts"]:
-            forge_config["workflow_settings_processed"]["store_build_artifacts"].add(
-                data["platform"].split("-", 1)[0]
+            script_suffix = ".bat" if platform == "win" else ".sh"
+            template_files.append(
+                f".scripts/create_conda_build_artifacts{script_suffix}"
             )
 
     build_setup = _get_build_setup_line(forge_dir, platform, forge_config)
@@ -1895,24 +1906,6 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
 
     forge_config = deepcopy(forge_config)
     forge_config["build_setup"] = build_setup
-
-    platform_templates = {
-        "linux": [
-            ".scripts/run_docker_build.sh",
-            ".scripts/build_steps.sh",
-        ],
-        "osx": [
-            ".scripts/run_osx_build.sh",
-        ],
-        "win": [
-            ".scripts/run_win_build.bat",
-        ],
-    }
-
-    template_files = platform_templates.get(platform, [])
-    if platform in forge_config["workflow_settings_processed"]["store_build_artifacts"]:
-        suffix = ".bat" if platform == "win" else ".sh"
-        template_files.append(f".scripts/create_conda_build_artifacts{suffix}")
 
     _render_template_exe_files(
         forge_config=forge_config,
@@ -1965,6 +1958,23 @@ def render_github_actions(jinja_env, forge_config, forge_dir, return_metadata=Fa
 def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
     build_setup = _get_build_setup_line(forge_dir, platform, forge_config)
 
+    platform_templates = {
+        "linux": [
+            ".scripts/run_docker_build.sh",
+            ".scripts/build_steps.sh",
+            ".azure-pipelines/azure-pipelines-linux.yml",
+        ],
+        "osx": [
+            ".azure-pipelines/azure-pipelines-osx.yml",
+            ".scripts/run_osx_build.sh",
+        ],
+        "win": [
+            ".azure-pipelines/azure-pipelines-win.yml",
+            ".scripts/run_win_build.bat",
+        ],
+    }
+    template_files = platform_templates.get(platform, [])
+
     if platform == "linux":
         yum_build_setup = generate_yum_requirements(forge_config, forge_dir)
         if yum_build_setup:
@@ -1990,10 +2000,6 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
         ratio = platform_counts[platform.split("-")[0]] / n_configs
         azure_settings["strategy"]["maxParallel"] = max(1, round(max_parallel * ratio))
 
-    forge_config.setdefault("workflow_settings_processed", {})[
-        "store_build_artifacts"
-    ] = set()
-
     for data in forge_config["configs"]:
         if not data["build_platform"].startswith(platform):
             continue
@@ -2014,32 +2020,15 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
             else:
                 raise ValueError(f"Unknown build platform: '{data['build_platform']}'")
 
-        config_rendered.update(get_workflow_settings(forge_config["workflow_settings"], "azure", data["platform"]))
+        workflow_settings = get_workflow_settings(forge_config["workflow_settings"], "azure", data["platform"])
+        data.update(workflow_settings)
+        config_rendered.update(workflow_settings)
         if config_rendered["store_build_artifacts"]:
-            forge_config["workflow_settings_processed"]["store_build_artifacts"].add(data["platform"].split("-", 1)[0])
             config_rendered["SHORT_CONFIG"] = data["short_config_name"]
+            script_suffix = ".bat" if platform == "win" else ".sh"
+            template_files.append(f".scripts/create_conda_build_artifacts{script_suffix}")
         azure_settings["strategy"]["matrix"][data["config_name"]] = config_rendered
         # fmt: on
-
-    platform_templates = {
-        "linux": [
-            ".scripts/run_docker_build.sh",
-            ".scripts/build_steps.sh",
-            ".azure-pipelines/azure-pipelines-linux.yml",
-        ],
-        "osx": [
-            ".azure-pipelines/azure-pipelines-osx.yml",
-            ".scripts/run_osx_build.sh",
-        ],
-        "win": [
-            ".azure-pipelines/azure-pipelines-win.yml",
-            ".scripts/run_win_build.bat",
-        ],
-    }
-    template_files = platform_templates.get(platform, [])
-    if platform in forge_config["workflow_settings_processed"]["store_build_artifacts"]:
-        suffix = ".bat" if platform == "win" else ".sh"
-        template_files.append(f".scripts/create_conda_build_artifacts{suffix}")
 
     forge_config["azure_yaml"] = yaml.dump(azure_settings)
     _render_template_exe_files(

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1872,15 +1872,14 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
                 data["gha_with_gpu"] = True
             data["gha_runs_on"].append(label)
 
-        store_build_artifacts = filter_conditional_values(
-            forge_config["workflow_settings"]["store_build_artifacts"],
-            provider="github_actions",
-            platform=data["platform"],
-            os=data["platform"].split("-", 1)[0],
-        )
-        data["store_build_artifacts"] = (
-            store_build_artifacts[-1].value if store_build_artifacts else None
-        )
+        for setting_key, setting_value in forge_config["workflow_settings"].items():
+            filtered = filter_conditional_values(
+                setting_value,
+                provider="github_actions",
+                platform=data["platform"],
+                os=data["platform"].split("-", 1)[0],
+            )
+            data[setting_key] = filtered[-1].value if filtered else None
 
     build_setup = _get_build_setup_line(forge_dir, platform, forge_config)
 
@@ -2035,16 +2034,17 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
                 config_rendered["VMIMAGE"] = "macOS-15-arm64"
             else:
                 raise ValueError(f"Unknown build platform: '{data['build_platform']}'")
-        store_build_artifacts = filter_conditional_values(
-            forge_config["workflow_settings"]["store_build_artifacts"],
-            provider="azure",
-            platform=data["platform"],
-            os=data["platform"].split("-", 1)[0],
-        )
-        config_rendered["STORE_BUILD_ARTIFACTS"] = (
-            store_build_artifacts[-1].value if store_build_artifacts else None
-        )
-        if config_rendered["STORE_BUILD_ARTIFACTS"]:
+        for setting_key, setting_value in forge_config["workflow_settings"].items():
+            filtered = filter_conditional_values(
+                setting_value,
+                provider="azure",
+                platform=data["platform"],
+                os=data["platform"].split("-", 1)[0],
+            )
+            config_rendered[setting_key] = (
+                filtered[-1].value if filtered else None
+            )
+        if config_rendered["store_build_artifacts"]:
             config_rendered["SHORT_CONFIG"] = data["short_config_name"]
         azure_settings["strategy"]["matrix"][data["config_name"]] = config_rendered
         # fmt: on

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2460,6 +2460,19 @@ def _read_forge_config(forge_dir, forge_yml=None):
         )
         logger.debug("Relevant schema:\n%s", json.dumps(err.schema, indent=2))
 
+    # Check for conflicting values.
+    if "store_build_artifacts" in file_config.get("workflow_settings", {}):
+        if "store_build_artifacts" in file_config.get("azure", {}):
+            raise ValueError(
+                "store_build_artifacts both in workflow_settings and azure. "
+                "Please remove the latter."
+            )
+        if "store_build_artifacts" in file_config.get("github_actions", {}):
+            raise ValueError(
+                "store_build_artifacts both in workflow_settings and "
+                "github_actions. Please remove the latter."
+            )
+
     # The config is just the union of the defaults, and the overridden
     # values.
     config = _update_dict_within_dict(file_config.items(), default_config)

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1872,14 +1872,15 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
                 data["gha_with_gpu"] = True
             data["gha_runs_on"].append(label)
 
-        # TODO: filter per specific job
+        store_build_artifacts = filter_conditional_values(
+            forge_config["workflow_settings"]["store_build_artifacts"],
+            provider="github_actions",
+            platform=data["platform"],
+            os=data["platform"].split("-", 1)[0],
+        )
         data["store_build_artifacts"] = (
-            filter_conditional_values(
-                forge_config["workflow_settings"]["store_build_artifacts"],
-                provider="github_actions",
-            )
-            or []
-        )[-1].value
+            store_build_artifacts[-1].value if store_build_artifacts else False
+        )
 
     build_setup = _get_build_setup_line(forge_dir, platform, forge_config)
 

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1980,30 +1980,6 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
     forge_config = deepcopy(forge_config)
     forge_config["build_setup"] = build_setup
 
-    platform_templates = {
-        "linux": [
-            ".scripts/run_docker_build.sh",
-            ".scripts/build_steps.sh",
-            ".azure-pipelines/azure-pipelines-linux.yml",
-        ],
-        "osx": [
-            ".azure-pipelines/azure-pipelines-osx.yml",
-            ".scripts/run_osx_build.sh",
-        ],
-        "win": [
-            ".azure-pipelines/azure-pipelines-win.yml",
-            ".scripts/run_win_build.bat",
-        ],
-    }
-    azure_store = filter_conditional_values(
-        forge_config["workflow_settings"]["store_build_artifacts"], provider="azure"
-    )
-    if any(x.value for x in azure_store):
-        platform_templates["linux"].append(".scripts/create_conda_build_artifacts.sh")
-        platform_templates["osx"].append(".scripts/create_conda_build_artifacts.sh")
-        platform_templates["win"].append(".scripts/create_conda_build_artifacts.bat")
-    template_files = platform_templates.get(platform, [])
-
     azure_settings = deepcopy(forge_config["azure"][f"settings_{platform}"])
     azure_settings.pop("swapfile_size", None)
     azure_settings.pop("install_atl", None)
@@ -2020,6 +1996,8 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
         )
         ratio = platform_counts[platform.split("-")[0]] / n_configs
         azure_settings["strategy"]["maxParallel"] = max(1, round(max_parallel * ratio))
+
+    store_build_artifacts = {x: False for x in ("linux", "osx", "win")}
 
     for data in forge_config["configs"]:
         if not data["build_platform"].startswith(platform):
@@ -2040,20 +2018,46 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
                 config_rendered["VMIMAGE"] = "macOS-15-arm64"
             else:
                 raise ValueError(f"Unknown build platform: '{data['build_platform']}'")
+        os = data["platform"].split("-", 1)[0]
         for setting_key, setting_value in forge_config["workflow_settings"].items():
             filtered = filter_conditional_values(
                 setting_value,
                 provider="azure",
                 platform=data["platform"],
-                os=data["platform"].split("-", 1)[0],
+                os=os,
             )
             config_rendered[setting_key] = (
                 filtered[-1].value if filtered else None
             )
         if config_rendered["store_build_artifacts"]:
+            store_build_artifacts[os] = True
+            forge_config[f"store_{os}_build_artifacts"] = True
             config_rendered["SHORT_CONFIG"] = data["short_config_name"]
         azure_settings["strategy"]["matrix"][data["config_name"]] = config_rendered
         # fmt: on
+
+    platform_templates = {
+        "linux": [
+            ".scripts/run_docker_build.sh",
+            ".scripts/build_steps.sh",
+            ".azure-pipelines/azure-pipelines-linux.yml",
+        ],
+        "osx": [
+            ".azure-pipelines/azure-pipelines-osx.yml",
+            ".scripts/run_osx_build.sh",
+        ],
+        "win": [
+            ".azure-pipelines/azure-pipelines-win.yml",
+            ".scripts/run_win_build.bat",
+        ],
+    }
+    for key, enabled in store_build_artifacts.items():
+        if enabled:
+            suffix = ".bat" if key == "win" else ".sh"
+            platform_templates[key].append(
+                f".scripts/create_conda_build_artifacts{suffix}"
+            )
+    template_files = platform_templates.get(platform, [])
 
     forge_config["azure_yaml"] = yaml.dump(azure_settings)
     _render_template_exe_files(

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1872,6 +1872,15 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
                 data["gha_with_gpu"] = True
             data["gha_runs_on"].append(label)
 
+        # TODO: filter per specific job
+        data["store_build_artifacts"] = (
+            filter_conditional_values(
+                forge_config["workflow_settings"]["store_build_artifacts"],
+                provider="github_actions",
+            )
+            or []
+        )[-1].value
+
     build_setup = _get_build_setup_line(forge_dir, platform, forge_config)
 
     if platform == "linux":

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -59,9 +59,9 @@ from conda_smithy.utils import (
     RATTLER_BUILD,
     HashableDict,
     ensure_standard_strings,
-    filter_conditional_values,
     get_feedstock_about_from_meta,
     get_feedstock_name_from_meta,
+    get_workflow_settings,
 )
 from conda_smithy.validate_schema import (
     CONDA_FORGE_YAML_DEFAULTS_FILE,
@@ -1875,15 +1875,11 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
                 data["gha_with_gpu"] = True
             data["gha_runs_on"].append(label)
 
-        for setting_key, setting_value in forge_config["workflow_settings"].items():
-            filtered = filter_conditional_values(
-                setting_value,
-                provider="github_actions",
-                platform=data["platform"],
-                os=data["platform"].split("-", 1)[0],
+        data.update(
+            get_workflow_settings(
+                forge_config["workflow_settings"], "github_actions", data["platform"]
             )
-            data[setting_key] = filtered[-1].value if filtered else None
-
+        )
         if data["store_build_artifacts"]:
             forge_config["store_any_build_artifacts"] = True
             if platform.startswith("win-"):
@@ -2018,17 +2014,9 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
                 config_rendered["VMIMAGE"] = "macOS-15-arm64"
             else:
                 raise ValueError(f"Unknown build platform: '{data['build_platform']}'")
+
+        config_rendered.update(get_workflow_settings(forge_config["workflow_settings"], "azure", data["platform"]))
         os = data["platform"].split("-", 1)[0]
-        for setting_key, setting_value in forge_config["workflow_settings"].items():
-            filtered = filter_conditional_values(
-                setting_value,
-                provider="azure",
-                platform=data["platform"],
-                os=os,
-            )
-            config_rendered[setting_key] = (
-                filtered[-1].value if filtered else None
-            )
         if config_rendered["store_build_artifacts"]:
             store_build_artifacts[os] = True
             forge_config[f"store_{os}_build_artifacts"] = True

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2495,13 +2495,13 @@ def _read_forge_config(forge_dir, forge_yml=None):
         # Check for conflicting old keys.
         if "store_build_artifacts" in file_config.get("azure", {}):
             raise ValueError(
-                "store_build_artifacts both in workflow_settings and azure. "
-                "Please remove the latter."
+                "`store_build_artifacts` both in `workflow_settings` and `azure` "
+                "sections. Please remove the latter."
             )
         if "store_build_artifacts" in file_config.get("github_actions", {}):
             raise ValueError(
-                "store_build_artifacts both in workflow_settings and "
-                "github_actions. Please remove the latter."
+                "`store_build_artifacts` both in `workflow_settings` and "
+                "`github_actions` sections. Please remove the latter."
             )
     else:
         # Convert old keys to new settings.

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1822,6 +1822,9 @@ def render_appveyor(jinja_env, forge_config, forge_dir, return_metadata=False):
 
 
 def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform):
+    store_build_artifacts_unix = False
+    store_build_artifacts_win = False
+
     # Handle GH-hosted and self-hosted runners runs-on config
     # Do it before the deepcopy below so these changes can be used by the
     # .github/worfkflows/conda-build.yml template
@@ -1881,6 +1884,13 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
             )
             data[setting_key] = filtered[-1].value if filtered else None
 
+        if data["store_build_artifacts"]:
+            forge_config["store_any_build_artifacts"] = True
+            if platform.startswith("win-"):
+                store_build_artifacts_win = True
+            else:
+                store_build_artifacts_unix = True
+
     build_setup = _get_build_setup_line(forge_dir, platform, forge_config)
 
     if platform == "linux":
@@ -1906,13 +1916,9 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
 
     template_files = platform_templates.get(platform, [])
 
-    # Templates for all platforms
-    gha_store = filter_conditional_values(
-        forge_config["workflow_settings"]["store_build_artifacts"],
-        provider="github_actions",
-    )
-    if any(x.value for x in gha_store):
+    if store_build_artifacts_unix:
         template_files.append(".scripts/create_conda_build_artifacts.sh")
+    if store_build_artifacts_win:
         template_files.append(".scripts/create_conda_build_artifacts.bat")
 
     _render_template_exe_files(

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1822,8 +1822,9 @@ def render_appveyor(jinja_env, forge_config, forge_dir, return_metadata=False):
 
 
 def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform):
-    store_build_artifacts_unix = False
-    store_build_artifacts_win = False
+    forge_config.setdefault("workflow_settings_processed", {})[
+        "store_build_artifacts"
+    ] = set()
 
     # Handle GH-hosted and self-hosted runners runs-on config
     # Do it before the deepcopy below so these changes can be used by the
@@ -1881,11 +1882,9 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
             )
         )
         if data["store_build_artifacts"]:
-            forge_config["store_any_build_artifacts"] = True
-            if platform.startswith("win-"):
-                store_build_artifacts_win = True
-            else:
-                store_build_artifacts_unix = True
+            forge_config["workflow_settings_processed"]["store_build_artifacts"].add(
+                data["platform"].split("-", 1)[0]
+            )
 
     build_setup = _get_build_setup_line(forge_dir, platform, forge_config)
 
@@ -1911,11 +1910,9 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
     }
 
     template_files = platform_templates.get(platform, [])
-
-    if store_build_artifacts_unix:
-        template_files.append(".scripts/create_conda_build_artifacts.sh")
-    if store_build_artifacts_win:
-        template_files.append(".scripts/create_conda_build_artifacts.bat")
+    if platform in forge_config["workflow_settings_processed"]["store_build_artifacts"]:
+        suffix = ".bat" if platform == "win" else ".sh"
+        template_files.append(f".scripts/create_conda_build_artifacts{suffix}")
 
     _render_template_exe_files(
         forge_config=forge_config,
@@ -1993,7 +1990,9 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
         ratio = platform_counts[platform.split("-")[0]] / n_configs
         azure_settings["strategy"]["maxParallel"] = max(1, round(max_parallel * ratio))
 
-    store_build_artifacts = {x: False for x in ("linux", "osx", "win")}
+    forge_config.setdefault("workflow_settings_processed", {})[
+        "store_build_artifacts"
+    ] = set()
 
     for data in forge_config["configs"]:
         if not data["build_platform"].startswith(platform):
@@ -2016,10 +2015,8 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
                 raise ValueError(f"Unknown build platform: '{data['build_platform']}'")
 
         config_rendered.update(get_workflow_settings(forge_config["workflow_settings"], "azure", data["platform"]))
-        os = data["platform"].split("-", 1)[0]
         if config_rendered["store_build_artifacts"]:
-            store_build_artifacts[os] = True
-            forge_config[f"store_{os}_build_artifacts"] = True
+            forge_config["workflow_settings_processed"]["store_build_artifacts"].add(data["platform"].split("-", 1)[0])
             config_rendered["SHORT_CONFIG"] = data["short_config_name"]
         azure_settings["strategy"]["matrix"][data["config_name"]] = config_rendered
         # fmt: on
@@ -2039,13 +2036,10 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
             ".scripts/run_win_build.bat",
         ],
     }
-    for key, enabled in store_build_artifacts.items():
-        if enabled:
-            suffix = ".bat" if key == "win" else ".sh"
-            platform_templates[key].append(
-                f".scripts/create_conda_build_artifacts{suffix}"
-            )
     template_files = platform_templates.get(platform, [])
+    if platform in forge_config["workflow_settings_processed"]["store_build_artifacts"]:
+        suffix = ".bat" if platform == "win" else ".sh"
+        template_files.append(f".scripts/create_conda_build_artifacts{suffix}")
 
     forge_config["azure_yaml"] = yaml.dump(azure_settings)
     _render_template_exe_files(

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -59,6 +59,7 @@ from conda_smithy.utils import (
     RATTLER_BUILD,
     HashableDict,
     ensure_standard_strings,
+    filter_conditional_values,
     get_feedstock_about_from_meta,
     get_feedstock_name_from_meta,
 )
@@ -1897,7 +1898,11 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
     template_files = platform_templates.get(platform, [])
 
     # Templates for all platforms
-    if forge_config["github_actions"]["store_build_artifacts"]:
+    gha_store = filter_conditional_values(
+        forge_config["workflow_settings"]["store_build_artifacts"],
+        provider="github_actions",
+    )
+    if any(x.value for x in gha_store):
         template_files.append(".scripts/create_conda_build_artifacts.sh")
         template_files.append(".scripts/create_conda_build_artifacts.bat")
 
@@ -1975,7 +1980,10 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
             ".scripts/run_win_build.bat",
         ],
     }
-    if forge_config["azure"]["store_build_artifacts"]:
+    azure_store = filter_conditional_values(
+        forge_config["workflow_settings"]["store_build_artifacts"], provider="azure"
+    )
+    if any(x.value for x in azure_store):
         platform_templates["linux"].append(".scripts/create_conda_build_artifacts.sh")
         platform_templates["osx"].append(".scripts/create_conda_build_artifacts.sh")
         platform_templates["win"].append(".scripts/create_conda_build_artifacts.bat")
@@ -2010,7 +2018,8 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
         # fmt: off
         if "docker_image" in data["config"] and platform == "linux":
             config_rendered["DOCKER_IMAGE"] = data["config"]["docker_image"][-1]
-        if forge_config["azure"]["store_build_artifacts"]:
+        azure_store = filter_conditional_values(forge_config["workflow_settings"]["store_build_artifacts"], provider="azure")
+        if any(x.value for x in azure_store):
             config_rendered["SHORT_CONFIG"] = data["short_config_name"]
         if platform == "osx":
             if data["build_platform"] == "osx-64":

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1879,7 +1879,7 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
             os=data["platform"].split("-", 1)[0],
         )
         data["store_build_artifacts"] = (
-            store_build_artifacts[-1].value if store_build_artifacts else False
+            store_build_artifacts[-1].value if store_build_artifacts else None
         )
 
     build_setup = _get_build_setup_line(forge_dir, platform, forge_config)
@@ -2042,7 +2042,7 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
             os=data["platform"].split("-", 1)[0],
         )
         config_rendered["STORE_BUILD_ARTIFACTS"] = (
-            store_build_artifacts[-1].value if store_build_artifacts else False
+            store_build_artifacts[-1].value if store_build_artifacts else None
         )
         if config_rendered["STORE_BUILD_ARTIFACTS"]:
             config_rendered["SHORT_CONFIG"] = data["short_config_name"]

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2028,9 +2028,6 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
         # fmt: off
         if "docker_image" in data["config"] and platform == "linux":
             config_rendered["DOCKER_IMAGE"] = data["config"]["docker_image"][-1]
-        azure_store = filter_conditional_values(forge_config["workflow_settings"]["store_build_artifacts"], provider="azure")
-        if any(x.value for x in azure_store):
-            config_rendered["SHORT_CONFIG"] = data["short_config_name"]
         if platform == "osx":
             if data["build_platform"] == "osx-64":
                 config_rendered["VMIMAGE"] = "macOS-15"
@@ -2038,6 +2035,17 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
                 config_rendered["VMIMAGE"] = "macOS-15-arm64"
             else:
                 raise ValueError(f"Unknown build platform: '{data['build_platform']}'")
+        store_build_artifacts = filter_conditional_values(
+            forge_config["workflow_settings"]["store_build_artifacts"],
+            provider="azure",
+            platform=data["platform"],
+            os=data["platform"].split("-", 1)[0],
+        )
+        config_rendered["STORE_BUILD_ARTIFACTS"] = (
+            store_build_artifacts[-1].value if store_build_artifacts else False
+        )
+        if config_rendered["STORE_BUILD_ARTIFACTS"]:
+            config_rendered["SHORT_CONFIG"] = data["short_config_name"]
         azure_settings["strategy"]["matrix"][data["config_name"]] = config_rendered
         # fmt: on
 

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2460,8 +2460,12 @@ def _read_forge_config(forge_dir, forge_yml=None):
         )
         logger.debug("Relevant schema:\n%s", json.dumps(err.schema, indent=2))
 
-    # Check for conflicting values.
+    # The config is just the union of the defaults, and the overridden
+    # values.
+    config = _update_dict_within_dict(file_config.items(), default_config)
+
     if "store_build_artifacts" in file_config.get("workflow_settings", {}):
+        # Check for conflicting old keys.
         if "store_build_artifacts" in file_config.get("azure", {}):
             raise ValueError(
                 "store_build_artifacts both in workflow_settings and azure. "
@@ -2472,10 +2476,20 @@ def _read_forge_config(forge_dir, forge_yml=None):
                 "store_build_artifacts both in workflow_settings and "
                 "github_actions. Please remove the latter."
             )
-
-    # The config is just the union of the defaults, and the overridden
-    # values.
-    config = _update_dict_within_dict(file_config.items(), default_config)
+    else:
+        # Convert old keys to new settings.
+        config["workflow_settings"]["store_build_artifacts"].append(
+            {
+                "provider": "azure",
+                "value": config["azure"]["store_build_artifacts"],
+            }
+        )
+        config["workflow_settings"]["store_build_artifacts"].append(
+            {
+                "provider": "github_actions",
+                "value": config["github_actions"]["store_build_artifacts"],
+            }
+        )
 
     # check for conda-smithy 2.x matrix which we can't auto-migrate
     # to conda_build_config

--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -788,7 +788,10 @@
               "type": "boolean"
             },
             {
-              "$ref": "#/$defs/ConditionalValue__class__bool__"
+              "items": {
+                "$ref": "#/$defs/ConditionalValue__class__bool__"
+              },
+              "type": "array"
             },
             {
               "$ref": "#/$defs/Nullable"

--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -797,7 +797,7 @@
               "type": "null"
             }
           ],
-          "default": false,
+          "default": [],
           "description": "Store the conda build_artifacts directory as artifacts.",
           "title": "Store Build Artifacts"
         }

--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -2217,7 +2217,7 @@
           "type": "null"
         }
       ],
-      "description": "Per-workflow settings.\n\n```yaml\nworkflow_settings:\n  store_build_artifacts:\n    # the ultimate value matched is used\n    - provider: github_actions\n      value: true\n    - platform: [linux-64, win-64]  # OR\n      value: true\n```"
+      "description": "Per-workflow settings.\n\n```yaml\nworkflow_settings:\n  store_build_artifacts:\n    # there can be at most one value for each workflow\n    - provider: github_actions\n      platform: linux_aarch64\n      value: true\n    - platform: [linux_64, win_64]  # OR\n      value: true\n```"
     },
     "travis": {
       "anyOf": [

--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -391,6 +391,84 @@
       "title": "CondaForgeDocker",
       "type": "object"
     },
+    "ConditionalValue__class__bool__": {
+      "properties": {
+        "os": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/PlatformsAliases"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/PlatformsAliases"
+            },
+            {
+              "$ref": "#/$defs/Nullable"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Operating systems to set environment variable on (default: all)",
+          "title": "Os"
+        },
+        "platform": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Platforms"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/Platforms"
+            },
+            {
+              "$ref": "#/$defs/Nullable"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Platforms to set environment variable on (default: all)",
+          "title": "Platform"
+        },
+        "provider": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/CIservices"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/CIservices"
+            },
+            {
+              "$ref": "#/$defs/Nullable"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "CI providers to set environment variable on (default: all)",
+          "title": "Provider"
+        },
+        "value": {
+          "default": false,
+          "description": "Option value",
+          "title": "Value",
+          "type": "boolean"
+        }
+      },
+      "title": "ConditionalValue_<class 'bool'>",
+      "type": "object"
+    },
     "DefaultTestPlatforms": {
       "enum": [
         "all",
@@ -687,92 +765,6 @@
       "title": "PlatformsAliases",
       "type": "string"
     },
-    "SetEnvVar": {
-      "properties": {
-        "os": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/$defs/PlatformsAliases"
-              },
-              "type": "array"
-            },
-            {
-              "$ref": "#/$defs/PlatformsAliases"
-            },
-            {
-              "$ref": "#/$defs/Nullable"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Operating systems to set environment variable on (default: all)",
-          "title": "Os"
-        },
-        "platform": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/$defs/Platforms"
-              },
-              "type": "array"
-            },
-            {
-              "$ref": "#/$defs/Platforms"
-            },
-            {
-              "$ref": "#/$defs/Nullable"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Platforms to set environment variable on (default: all)",
-          "title": "Platform"
-        },
-        "provider": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/$defs/CIservices"
-              },
-              "type": "array"
-            },
-            {
-              "$ref": "#/$defs/CIservices"
-            },
-            {
-              "$ref": "#/$defs/Nullable"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "CI providers to set environment variable on (default: all)",
-          "title": "Provider"
-        },
-        "key": {
-          "description": "Environment variable name",
-          "title": "Key",
-          "type": "string"
-        },
-        "value": {
-          "description": "Environment variable value",
-          "title": "Value",
-          "type": "string"
-        }
-      },
-      "required": [
-        "key",
-        "value"
-      ],
-      "title": "SetEnvVar",
-      "type": "object"
-    },
     "ShellCheck": {
       "additionalProperties": false,
       "properties": {
@@ -784,6 +776,31 @@
         }
       },
       "title": "ShellCheck",
+      "type": "object"
+    },
+    "WorkflowSettings": {
+      "properties": {
+        "store_build_artifacts": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ConditionalValue__class__bool__"
+            },
+            {
+              "$ref": "#/$defs/Nullable"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "description": "Store the conda build_artifacts directory as artifacts.",
+          "title": "Store Build Artifacts"
+        }
+      },
+      "title": "WorkflowSettings",
       "type": "object"
     },
     "build_platform": {
@@ -2186,21 +2203,16 @@
       "description": "The depth of the git clone.",
       "title": "Clone Depth"
     },
-    "set_env_vars": {
+    "workflow_settings": {
       "anyOf": [
         {
-          "items": {
-            "$ref": "#/$defs/SetEnvVar"
-          },
-          "type": "array"
+          "$ref": "#/$defs/WorkflowSettings"
         },
         {
           "type": "null"
         }
       ],
-      "default": [],
-      "description": "Environment variables to set in the CI environment.",
-      "title": "Set Env Vars"
+      "description": "Per-workflow settings."
     },
     "travis": {
       "anyOf": [

--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -798,7 +798,7 @@
             }
           ],
           "default": [],
-          "description": "Store the conda build_artifacts directory as artifacts.",
+          "description": "Store the outputs of the build process as uploaded CI artifacts.",
           "title": "Store Build Artifacts"
         }
       },
@@ -2214,7 +2214,7 @@
           "type": "null"
         }
       ],
-      "description": "Per-workflow settings."
+      "description": "Per-workflow settings.\n\n```yaml\nworkflow_settings:\n  store_build_artifacts:\n    # the ultimate value matched is used\n    - provider: github_actions\n      value: true\n    - platform: [linux-64, win-64]  # OR\n      value: true\n```"
     },
     "travis": {
       "anyOf": [

--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -147,7 +147,8 @@
             }
           ],
           "default": false,
-          "description": "Store the conda build_artifacts directory as an         Azure pipeline artifact",
+          "deprecated": true,
+          "description": "Deprecated. Store the conda build_artifacts directory as an Azure pipeline artifact. Use `workflow_settings.store_build_artifacts` instead.",
           "title": "Store Build Artifacts"
         },
         "timeout_minutes": {
@@ -587,7 +588,8 @@
             }
           ],
           "default": false,
-          "description": "Whether to store build artifacts",
+          "deprecated": true,
+          "description": "Deprecated. Whether to store build artifacts. Use `workflow_settings.store_build_artifacts` instead.",
           "title": "Store Build Artifacts"
         },
         "timeout_minutes": {

--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -678,6 +678,101 @@
       "title": "Platforms",
       "type": "string"
     },
+    "PlatformsAliases": {
+      "enum": [
+        "linux",
+        "win",
+        "osx"
+      ],
+      "title": "PlatformsAliases",
+      "type": "string"
+    },
+    "SetEnvVar": {
+      "properties": {
+        "os": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/PlatformsAliases"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/PlatformsAliases"
+            },
+            {
+              "$ref": "#/$defs/Nullable"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Operating systems to set environment variable on (default: all)",
+          "title": "Os"
+        },
+        "platform": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Platforms"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/Platforms"
+            },
+            {
+              "$ref": "#/$defs/Nullable"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Platforms to set environment variable on (default: all)",
+          "title": "Platform"
+        },
+        "provider": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/CIservices"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/CIservices"
+            },
+            {
+              "$ref": "#/$defs/Nullable"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "CI providers to set environment variable on (default: all)",
+          "title": "Provider"
+        },
+        "key": {
+          "description": "Environment variable name",
+          "title": "Key",
+          "type": "string"
+        },
+        "value": {
+          "description": "Environment variable value",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ],
+      "title": "SetEnvVar",
+      "type": "object"
+    },
     "ShellCheck": {
       "additionalProperties": false,
       "properties": {
@@ -2090,6 +2185,22 @@
       "default": null,
       "description": "The depth of the git clone.",
       "title": "Clone Depth"
+    },
+    "set_env_vars": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/SetEnvVar"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": [],
+      "description": "Environment variables to set in the CI environment.",
+      "title": "Set Env Vars"
     },
     "travis": {
       "anyOf": [

--- a/conda_smithy/data/conda-forge.yml
+++ b/conda_smithy/data/conda-forge.yml
@@ -146,4 +146,4 @@ test_on_native_only: false
 travis: {}
 woodpecker: {}
 workflow_settings:
-  store_build_artifacts: false
+  store_build_artifacts: []

--- a/conda_smithy/data/conda-forge.yml
+++ b/conda_smithy/data/conda-forge.yml
@@ -137,6 +137,7 @@ remote_ci_setup:
 - conda-forge-ci-setup=4
 - conda-build>=24.1
 secrets: []
+set_env_vars: []
 shellcheck:
   enabled: false
 skip_render: []

--- a/conda_smithy/data/conda-forge.yml
+++ b/conda_smithy/data/conda-forge.yml
@@ -137,7 +137,6 @@ remote_ci_setup:
 - conda-forge-ci-setup=4
 - conda-build>=24.1
 secrets: []
-set_env_vars: []
 shellcheck:
   enabled: false
 skip_render: []
@@ -146,3 +145,5 @@ test: null
 test_on_native_only: false
 travis: {}
 woodpecker: {}
+workflow_settings:
+  store_build_artifacts: false

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -460,6 +460,39 @@ Provider = create_model(
 )
 
 
+class SetEnvVar(BaseModel):
+    os: Optional[Union[list[PlatformsAliases], PlatformsAliases, Nullable]] = Field(
+        default=None,
+        description=cleandoc("""
+        Operating systems to set environment variable on (default: all)
+        """),
+    )
+    platform: Optional[Union[list[Platforms], Platforms, Nullable]] = Field(
+        default=None,
+        description=cleandoc("""
+        Platforms to set environment variable on (default: all)
+        """),
+    )
+    provider: Optional[Union[list[CIservices], CIservices, Nullable]] = Field(
+        default=None,
+        description=cleandoc("""
+        CI providers to set environment variable on (default: all)
+        """),
+    )
+
+    key: str = Field(
+        description=cleandoc("""
+        Environment variable name
+        """),
+        # TODO: validation
+    )
+    value: str = Field(
+        description=cleandoc("""
+        Environment variable value
+        """),
+    )
+
+
 class ConfigModel(BaseModel):
     """
     This model describes in detail the top-level fields in  `conda-forge.yml`.
@@ -988,6 +1021,13 @@ class ConfigModel(BaseModel):
         default=None,
         description=cleandoc("""
         The depth of the git clone.
+        """),
+    )
+
+    set_env_vars: Optional[list[SetEnvVar]] = Field(
+        default=[],
+        description=cleandoc("""
+        Environment variables to set in the CI environment.
         """),
     )
 

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -505,7 +505,7 @@ def conditional_value(typ: type, default: Any = None) -> BaseModel:
 
 class WorkflowSettings(BaseModel):
     store_build_artifacts: Optional[
-        Union[bool, conditional_value(bool, False), Nullable]
+        Union[bool, list[conditional_value(bool, False)], Nullable]
     ] = Field(
         default=[],
         description=cleandoc("""

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -463,6 +463,7 @@ Provider = create_model(
 )
 
 
+@lru_cache
 def conditional_value(typ: type, default: Any = None) -> BaseModel:
     return create_model(
         f"ConditionalValue_{typ}",

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -230,8 +230,9 @@ class AzureConfig(BaseModel):
 
     store_build_artifacts: Optional[bool] = Field(
         default=False,
-        description="Store the conda build_artifacts directory as an \
-        Azure pipeline artifact",
+        deprecated=True,
+        description="Deprecated. Store the conda build_artifacts directory as an "
+        "Azure pipeline artifact. Use `workflow_settings.store_build_artifacts` instead.",
     )
 
     timeout_minutes: Optional[Union[int, Nullable]] = Field(
@@ -306,8 +307,10 @@ class GithubActionsConfig(BaseModel):
     )
 
     store_build_artifacts: Optional[bool] = Field(
-        description="Whether to store build artifacts",
+        description="Deprecated. Whether to store build artifacts. "
+        "Use `workflow_settings.store_build_artifacts` instead.",
         default=False,
+        deprecated=True,
     )
 
     timeout_minutes: Optional[int] = Field(

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -1051,6 +1051,16 @@ class ConfigModel(BaseModel):
         default_factory=WorkflowSettings,
         description=cleandoc("""
         Per-workflow settings.
+
+        ```yaml
+        workflow_settings:
+          store_build_artifacts:
+            # the ultimate value matched is used
+            - provider: github_actions
+              value: true
+            - platform: [linux-64, win-64]  # OR
+              value: true
+        ```
         """),
     )
     ###################################

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -460,35 +460,55 @@ Provider = create_model(
 )
 
 
-class SetEnvVar(BaseModel):
-    os: Optional[Union[list[PlatformsAliases], PlatformsAliases, Nullable]] = Field(
-        default=None,
-        description=cleandoc("""
-        Operating systems to set environment variable on (default: all)
-        """),
-    )
-    platform: Optional[Union[list[Platforms], Platforms, Nullable]] = Field(
-        default=None,
-        description=cleandoc("""
-        Platforms to set environment variable on (default: all)
-        """),
-    )
-    provider: Optional[Union[list[CIservices], CIservices, Nullable]] = Field(
-        default=None,
-        description=cleandoc("""
-        CI providers to set environment variable on (default: all)
-        """),
+def conditional_value(typ: type, default: Any = None) -> BaseModel:
+    return create_model(
+        f"ConditionalValue_{typ}",
+        os=(
+            Optional[Union[list[PlatformsAliases], PlatformsAliases, Nullable]],
+            Field(
+                default=None,
+                description=cleandoc("""
+                Operating systems to set environment variable on (default: all)
+                """),
+            ),
+        ),
+        platform=(
+            Optional[Union[list[Platforms], Platforms, Nullable]],
+            Field(
+                default=None,
+                description=cleandoc("""
+                Platforms to set environment variable on (default: all)
+                """),
+            ),
+        ),
+        provider=(
+            Optional[Union[list[CIservices], CIservices, Nullable]],
+            Field(
+                default=None,
+                description=cleandoc("""
+                CI providers to set environment variable on (default: all)
+                """),
+            ),
+        ),
+        value=(
+            typ,
+            Field(
+                description=cleandoc("""
+                Option value
+                """),
+                default=default,
+            ),
+        ),
     )
 
-    key: str = Field(
+
+class WorkflowSettings(BaseModel):
+    store_build_artifacts: Optional[
+        Union[bool, conditional_value(bool, False), Nullable]
+    ] = Field(
+        default=False,
         description=cleandoc("""
-        Environment variable name
-        """),
-        # TODO: validation
-    )
-    value: str = Field(
-        description=cleandoc("""
-        Environment variable value
+        Store the conda build_artifacts directory as artifacts.
         """),
     )
 
@@ -1024,13 +1044,12 @@ class ConfigModel(BaseModel):
         """),
     )
 
-    set_env_vars: Optional[list[SetEnvVar]] = Field(
-        default=[],
+    workflow_settings: Optional[WorkflowSettings] = Field(
+        default_factory=WorkflowSettings,
         description=cleandoc("""
-        Environment variables to set in the CI environment.
+        Per-workflow settings.
         """),
     )
-
     ###################################
     ####       CI Providers        ####
     ###################################

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -496,9 +496,7 @@ def conditional_value(typ: type, default: Any = None) -> BaseModel:
         value=(
             typ,
             Field(
-                description=cleandoc("""
-                Option value
-                """),
+                description="Option value",
                 default=default,
             ),
         ),

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -511,7 +511,7 @@ class WorkflowSettings(BaseModel):
     ] = Field(
         default=[],
         description=cleandoc("""
-        Store the conda build_artifacts directory as artifacts.
+        Store the outputs of the build process as uploaded CI artifacts.
         """),
     )
 

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -1055,10 +1055,11 @@ class ConfigModel(BaseModel):
         ```yaml
         workflow_settings:
           store_build_artifacts:
-            # the ultimate value matched is used
+            # there can be at most one value for each workflow
             - provider: github_actions
+              platform: linux_aarch64
               value: true
-            - platform: [linux-64, win-64]  # OR
+            - platform: [linux_64, win_64]  # OR
               value: true
         ```
         """),

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -509,7 +509,7 @@ class WorkflowSettings(BaseModel):
     store_build_artifacts: Optional[
         Union[bool, conditional_value(bool, False), Nullable]
     ] = Field(
-        default=False,
+        default=[],
         description=cleandoc("""
         Store the conda build_artifacts directory as artifacts.
         """),

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -5,6 +5,7 @@
 
 import json
 from enum import Enum
+from functools import lru_cache
 from inspect import cleandoc
 from typing import Annotated, Any, Literal, Optional, Union
 

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -4,8 +4,8 @@
 
 {%- set vars = namespace(store_build_artifacts=False) %}
 {%- for data in configs %}
-  {%- set pfarchless = data.build_platform.split('-')[0] %}
-  {%- if pfarchless == 'linux' and data.store_build_artifacts %}
+  {%- set os = data.build_platform.split('-')[0] %}
+  {%- if os == 'linux' and data.store_build_artifacts %}
     {%- set vars.store_build_artifacts = True %}
   {%- endif %}
 {%- endfor %}

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -87,7 +87,7 @@ jobs:
 {%- for secret in secrets %}
       {{ secret }}: $({{ secret }})
 {%- endfor %}
-{%- if store_linux_build_artifacts %}
+{%- if "linux" in workflow_settings_processed.store_build_artifacts %}
 
   - script: |
         export CI=azure

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -87,6 +87,7 @@ jobs:
 {%- for secret in secrets %}
       {{ secret }}: $({{ secret }})
 {%- endfor %}
+{%- if store_linux_build_artifacts %}
 
   - script: |
         export CI=azure
@@ -117,3 +118,4 @@ jobs:
     inputs:
       targetPath: $(ENV_ARTIFACT_PATH)
       artifactName: $(ENV_ARTIFACT_NAME)
+{%- endif %}

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -102,7 +102,7 @@ jobs:
         fi
         ./.scripts/create_conda_build_artifacts.sh
     displayName: Prepare conda build artifacts
-    condition: and(succeededOrFailed(), eq(variables.STORE_BUILD_ARTIFACTS, true))
+    condition: and(succeededOrFailed(), eq(variables.store_build_artifacts, true))
 
   - task: PublishPipelineArtifact@1
     displayName: Store conda build artifacts

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -2,6 +2,14 @@
 # update the conda-forge.yml and/or the recipe/meta.yaml.
 # -*- mode: yaml -*-
 
+{%- set vars = namespace(store_build_artifacts=False) %}
+{%- for data in configs %}
+  {%- set pfarchless = data.build_platform.split('-')[0] %}
+  {%- if pfarchless == 'linux' and data.store_build_artifacts %}
+    {%- set vars.store_build_artifacts = True %}
+  {%- endif %}
+{%- endfor %}
+
 jobs:
 - job: linux
   {{ azure_yaml|indent(2) }}
@@ -87,7 +95,7 @@ jobs:
 {%- for secret in secrets %}
       {{ secret }}: $({{ secret }})
 {%- endfor %}
-{%- if "linux" in workflow_settings_processed.store_build_artifacts %}
+{%- if vars.store_build_artifacts %}
 
   - script: |
         export CI=azure

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -88,7 +88,6 @@ jobs:
       {{ secret }}: $({{ secret }})
 {%- endfor %}
 
-{%- if azure.store_build_artifacts %}
   - script: |
         export CI=azure
         export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
@@ -103,7 +102,7 @@ jobs:
         fi
         ./.scripts/create_conda_build_artifacts.sh
     displayName: Prepare conda build artifacts
-    condition: succeededOrFailed()
+    condition: and(succeededOrFailed(), eq(variables.STORE_BUILD_ARTIFACTS, true))
 
   - task: PublishPipelineArtifact@1
     displayName: Store conda build artifacts
@@ -118,4 +117,3 @@ jobs:
     inputs:
       targetPath: $(ENV_ARTIFACT_PATH)
       artifactName: $(ENV_ARTIFACT_NAME)
-{%- endif %}

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -34,7 +34,6 @@ jobs:
       {{ secret }}: $({{ secret }})
 {%- endfor %}
 
-{%- if azure.store_build_artifacts %}
   - script: |
       export CI=azure
       export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
@@ -49,7 +48,7 @@ jobs:
       fi
       ./.scripts/create_conda_build_artifacts.sh
     displayName: Prepare conda build artifacts
-    condition: succeededOrFailed()
+    condition: and(succeededOrFailed(), eq(variables.STORE_BUILD_ARTIFACTS, true))
 
   - task: PublishPipelineArtifact@1
     displayName: Store conda build artifacts
@@ -64,4 +63,3 @@ jobs:
     inputs:
       targetPath: $(ENV_ARTIFACT_PATH)
       artifactName: $(ENV_ARTIFACT_NAME)
-{%- endif %}

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -48,7 +48,7 @@ jobs:
       fi
       ./.scripts/create_conda_build_artifacts.sh
     displayName: Prepare conda build artifacts
-    condition: and(succeededOrFailed(), eq(variables.STORE_BUILD_ARTIFACTS, true))
+    condition: and(succeededOrFailed(), eq(variables.store_build_artifacts, true))
 
   - task: PublishPipelineArtifact@1
     displayName: Store conda build artifacts

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -33,6 +33,7 @@ jobs:
 {%- for secret in secrets %}
       {{ secret }}: $({{ secret }})
 {%- endfor %}
+{%- if store_osx_build_artifacts %}
 
   - script: |
       export CI=azure
@@ -63,3 +64,4 @@ jobs:
     inputs:
       targetPath: $(ENV_ARTIFACT_PATH)
       artifactName: $(ENV_ARTIFACT_NAME)
+{%- endif %}

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -33,7 +33,7 @@ jobs:
 {%- for secret in secrets %}
       {{ secret }}: $({{ secret }})
 {%- endfor %}
-{%- if store_osx_build_artifacts %}
+{%- if "osx" in workflow_settings_processed.store_build_artifacts %}
 
   - script: |
       export CI=azure

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -4,8 +4,8 @@
 
 {%- set vars = namespace(store_build_artifacts=False) %}
 {%- for data in configs %}
-  {%- set pfarchless = data.build_platform.split('-')[0] %}
-  {%- if pfarchless == 'osx' and data.store_build_artifacts %}
+  {%- set os = data.build_platform.split('-')[0] %}
+  {%- if os == 'osx' and data.store_build_artifacts %}
     {%- set vars.store_build_artifacts = True %}
   {%- endif %}
 {%- endfor %}

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -2,6 +2,14 @@
 # update the conda-forge.yml and/or the recipe/meta.yaml.
 # -*- mode: yaml -*-
 
+{%- set vars = namespace(store_build_artifacts=False) %}
+{%- for data in configs %}
+  {%- set pfarchless = data.build_platform.split('-')[0] %}
+  {%- if pfarchless == 'osx' and data.store_build_artifacts %}
+    {%- set vars.store_build_artifacts = True %}
+  {%- endif %}
+{%- endfor %}
+
 jobs:
 - job: osx
   {{ azure_yaml|indent(2) }}
@@ -33,7 +41,7 @@ jobs:
 {%- for secret in secrets %}
       {{ secret }}: $({{ secret }})
 {%- endfor %}
-{%- if "osx" in workflow_settings_processed.store_build_artifacts %}
+{%- if vars.store_build_artifacts %}
 
   - script: |
       export CI=azure

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -68,6 +68,7 @@ jobs:
 {%- for secret in secrets %}
         {{ secret }}: $({{ secret }})
 {%- endfor %}
+{%- if store_win_build_artifacts %}
 
     - script: |
         set MINIFORGE_HOME=$(MINIFORGE_HOME)
@@ -97,3 +98,4 @@ jobs:
       inputs:
         targetPath: $(ENV_ARTIFACT_PATH)
         artifactName: $(ENV_ARTIFACT_NAME)
+{%- endif %}

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -2,6 +2,14 @@
 # update the conda-forge.yml and/or the recipe/meta.yaml.
 # -*- mode: yaml -*-
 
+{%- set vars = namespace(store_build_artifacts=False) %}
+{%- for data in configs %}
+  {%- set pfarchless = data.build_platform.split('-')[0] %}
+  {%- if pfarchless == 'win' and data.store_build_artifacts %}
+    {%- set vars.store_build_artifacts = True %}
+  {%- endif %}
+{%- endfor %}
+
 jobs:
 - job: win
   {{ azure_yaml|indent(2) }}
@@ -68,7 +76,7 @@ jobs:
 {%- for secret in secrets %}
         {{ secret }}: $({{ secret }})
 {%- endfor %}
-{%- if "win" in workflow_settings_processed.store_build_artifacts %}
+{%- if vars.store_build_artifacts %}
 
     - script: |
         set MINIFORGE_HOME=$(MINIFORGE_HOME)

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -82,7 +82,7 @@ jobs:
         )
         call ".scripts\create_conda_build_artifacts.bat"
       displayName: Prepare conda build artifacts
-      condition: and(succeededOrFailed(), eq(variables.STORE_BUILD_ARTIFACTS, true))
+      condition: and(succeededOrFailed(), eq(variables.store_build_artifacts, true))
 
     - task: PublishPipelineArtifact@1
       displayName: Store conda build artifacts

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -68,7 +68,7 @@ jobs:
 {%- for secret in secrets %}
         {{ secret }}: $({{ secret }})
 {%- endfor %}
-{%- if store_win_build_artifacts %}
+{%- if "win" in workflow_settings_processed.store_build_artifacts %}
 
     - script: |
         set MINIFORGE_HOME=$(MINIFORGE_HOME)

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -69,7 +69,6 @@ jobs:
         {{ secret }}: $({{ secret }})
 {%- endfor %}
 
-{%- if azure.store_build_artifacts %}
     - script: |
         set MINIFORGE_HOME=$(MINIFORGE_HOME)
         set CI=azure
@@ -83,7 +82,7 @@ jobs:
         )
         call ".scripts\create_conda_build_artifacts.bat"
       displayName: Prepare conda build artifacts
-      condition: succeededOrFailed()
+      condition: and(succeededOrFailed(), eq(variables.STORE_BUILD_ARTIFACTS, true))
 
     - task: PublishPipelineArtifact@1
       displayName: Store conda build artifacts
@@ -98,4 +97,3 @@ jobs:
       inputs:
         targetPath: $(ENV_ARTIFACT_PATH)
         artifactName: $(ENV_ARTIFACT_NAME)
-{%- endif %}

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -4,8 +4,8 @@
 
 {%- set vars = namespace(store_build_artifacts=False) %}
 {%- for data in configs %}
-  {%- set pfarchless = data.build_platform.split('-')[0] %}
-  {%- if pfarchless == 'win' and data.store_build_artifacts %}
+  {%- set os = data.build_platform.split('-')[0] %}
+  {%- if os == 'win' and data.store_build_artifacts %}
     {%- set vars.store_build_artifacts = True %}
   {%- endif %}
 {%- endfor %}

--- a/conda_smithy/templates/azure-pipelines.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines.yml.tmpl
@@ -4,9 +4,9 @@
 
 {%- set platformset = [] %}
 {%- for data in configs %}
-  {%- set pfarchless = data.build_platform.split('-')[0] %}
-  {%- if pfarchless not in platformset %}
-    {%- do platformset.append(pfarchless) %}
+  {%- set os = data.build_platform.split('-')[0] %}
+  {%- if os not in platformset %}
+    {%- do platformset.append(os) %}
   {%- endif %}
 {%- endfor %}
 

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -42,7 +42,7 @@ jobs:
         include:
         {%- for data in configs %}
           - CONFIG: {{ data.config_name }}
-            STORE_BUILD_ARTIFACTS: {{ data.store_build_artifacts }}
+            STORE_BUILD_ARTIFACTS: {{ data.store_build_artifacts is true }}
         {%- if data.store_build_artifacts %}
             SHORT_CONFIG: {{ data.short_config_name }}
         {%- endif %}

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -254,6 +254,7 @@ jobs:
       env:
         CI: github_actions
         CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
+        SHORT_CONFIG: {% raw %}${{ matrix.SHORT_CONFIG }}{% endraw %}
         JOB_STATUS: {% raw %}${{ steps.determine-status.outputs.status }}{% endraw %}
         OS: {% raw %}${{ matrix.os }}{% endraw %}
       run: |

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -4,9 +4,9 @@
 
 {%- set vars = namespace(platformset=[], store_build_artifacts=False) %}
 {%- for data in configs %}
-  {%- set pfarchless = data.build_platform.split('-')[0] %}
-  {%- if pfarchless not in vars.platformset %}
-    {%- do vars.platformset.append(pfarchless) %}
+  {%- set os = data.build_platform.split('-')[0] %}
+  {%- if os not in vars.platformset %}
+    {%- do vars.platformset.append(os) %}
   {%- endif %}
   {%- if data.store_build_artifacts %}
     {%- set vars.store_build_artifacts = True %}

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -249,7 +249,7 @@ jobs:
       id: prepare-artifacts
       shell: bash
       # we do not want to trigger artefact creation if the build was cancelled
-      if: {% raw %}${{ always() && steps.determine-status.outputs.status != 'cancelled' && matrix.STORE_BUILD_ARTIFACTS == True }}{% endraw %}
+      if: {% raw %}${{ always() && steps.determine-status.outputs.status != 'cancelled' && matrix.STORE_BUILD_ARTIFACTS == 'True' }}{% endraw %}
       env:
         CI: github_actions
         CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -221,7 +221,7 @@ jobs:
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}
-{%- if store_any_build_artifacts %}
+{%- if workflow_settings_processed.store_build_artifacts %}
 
     - name: Determine build outcome
       # this is to merge the status of the linux/osx/win builds into

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -42,7 +42,8 @@ jobs:
         include:
         {%- for data in configs %}
           - CONFIG: {{ data.config_name }}
-        {%- if github_actions.store_build_artifacts %}
+            STORE_BUILD_ARTIFACTS: {{ data.store_build_artifacts }}
+        {%- if data.store_build_artifacts %}
             SHORT_CONFIG: {{ data.short_config_name }}
         {%- endif %}
             UPLOAD_PACKAGES: {{ data.upload }}
@@ -220,7 +221,6 @@ jobs:
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}
-{%- if github_actions.store_build_artifacts %}
 
     - name: Determine build outcome
       # this is to merge the status of the linux/osx/win builds into
@@ -249,11 +249,10 @@ jobs:
       id: prepare-artifacts
       shell: bash
       # we do not want to trigger artefact creation if the build was cancelled
-      if: {% raw %}${{ always() && steps.determine-status.outputs.status != 'cancelled' }}{% endraw %}
+      if: {% raw %}${{ always() && steps.determine-status.outputs.status != 'cancelled' && matrix.STORE_BUILD_ARTIFACTS == True }}{% endraw %}
       env:
         CI: github_actions
         CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
-        SHORT_CONFIG: {% raw %}${{ matrix.SHORT_CONFIG }}{% endraw %}
         JOB_STATUS: {% raw %}${{ steps.determine-status.outputs.status }}{% endraw %}
         OS: {% raw %}${{ matrix.os }}{% endraw %}
       run: |
@@ -302,4 +301,3 @@ jobs:
         path: {% raw %}${{ steps.prepare-artifacts.outputs.ENV_ARTIFACT_PATH }}{% endraw %}
         retention-days: {{ github_actions.artifact_retention_days }}
       continue-on-error: true
-{%- endif %}

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -2,11 +2,14 @@
 # update the conda-forge.yml and/or the recipe/meta.yaml.
 # -*- mode: yaml -*-
 
-{%- set platformset = [] %}
+{%- set vars = namespace(platformset=[], store_build_artifacts=False) %}
 {%- for data in configs %}
   {%- set pfarchless = data.build_platform.split('-')[0] %}
-  {%- if pfarchless not in platformset %}
-    {%- do platformset.append(pfarchless) %}
+  {%- if pfarchless not in vars.platformset %}
+    {%- do vars.platformset.append(pfarchless) %}
+  {%- endif %}
+  {%- if data.store_build_artifacts %}
+    {%- set vars.store_build_artifacts = True %}
   {%- endif %}
 {%- endfor %}
 
@@ -221,7 +224,7 @@ jobs:
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}
-{%- if workflow_settings_processed.store_build_artifacts %}
+{%- if vars.store_build_artifacts %}
 
     - name: Determine build outcome
       # this is to merge the status of the linux/osx/win builds into

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -2,12 +2,8 @@
 # update the conda-forge.yml and/or the recipe/meta.yaml.
 # -*- mode: yaml -*-
 
-{%- set vars = namespace(platformset=[], store_build_artifacts=False) %}
+{%- set vars = namespace(store_build_artifacts=False) %}
 {%- for data in configs %}
-  {%- set os = data.build_platform.split('-')[0] %}
-  {%- if os not in vars.platformset %}
-    {%- do vars.platformset.append(os) %}
-  {%- endif %}
   {%- if data.store_build_artifacts %}
     {%- set vars.store_build_artifacts = True %}
   {%- endif %}

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -221,6 +221,7 @@ jobs:
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}
+{%- if store_any_build_artifacts %}
 
     - name: Determine build outcome
       # this is to merge the status of the linux/osx/win builds into
@@ -301,3 +302,4 @@ jobs:
         path: {% raw %}${{ steps.prepare-artifacts.outputs.ENV_ARTIFACT_PATH }}{% endraw %}
         retention-days: {{ github_actions.artifact_retention_days }}
       continue-on-error: true
+{%- endif %}

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -249,7 +249,7 @@ jobs:
       id: prepare-artifacts
       shell: bash
       # we do not want to trigger artefact creation if the build was cancelled
-      if: {% raw %}${{ always() && steps.determine-status.outputs.status != 'cancelled' && matrix.STORE_BUILD_ARTIFACTS == 'True' }}{% endraw %}
+      if: {% raw %}${{ always() && steps.determine-status.outputs.status != 'cancelled' && matrix.STORE_BUILD_ARTIFACTS }}{% endraw %}
       env:
         CI: github_actions
         CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}

--- a/conda_smithy/templates/travis.yml.tmpl
+++ b/conda_smithy/templates/travis.yml.tmpl
@@ -5,9 +5,9 @@
 #}
 {%- set platformset = [] %}
 {%- for data in configs %}
-  {%- set pfarchless = data.build_platform.split('-')[0] %}
-  {%- if pfarchless not in platformset %}
-    {%- do platformset.append(pfarchless) %}
+  {%- set os = data.build_platform.split('-')[0] %}
+  {%- if os not in platformset %}
+    {%- do platformset.append(os) %}
   {%- endif %}
 {%- endfor %}
 language: shell

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -273,14 +273,16 @@ def filter_conditional_values(
         return [ConditionalValue(value=value)]
 
     # a list of condition-values
+    filters = {
+        "os": os,
+        "platform": platform,
+        "provider": provider,
+    }
+
     ret = []
     for cv_item in value:
         new_cv_item = {"value": cv_item["value"]}
-        for cond_name, cond_expect in (
-            ("os", os),
-            ("platform", platform),
-            ("provider", provider),
-        ):
+        for cond_name, cond_expect in filters.items():
             cond_value: Union[list[str], str] = cv_item.get(cond_name, [cond_expect])
             if not isinstance(cond_value, list):
                 cond_value = [cond_value]

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -276,7 +276,7 @@ def filter_conditional_values(
         store_build_artifacts:
           - provider: github_actions
             value: true
-          - platform: [win-64, linux-64]  # matched as OR
+          - platform: [win_64, linux_64]  # matched as OR
             value: true
       ```
 
@@ -305,7 +305,7 @@ def filter_conditional_values(
 
     criteria = {
         "os": os,
-        "platform": platform,
+        "platform": platform.replace("-", "_"),
         "provider": provider,
     }
     ret = []

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -262,9 +262,7 @@ def filter_conditional_values(
     provider: Optional[str] = None,
 ) -> list[ConditionalValue]:
     """Filter conditional values from conda-forge.yml by specified
-    criteria, and return the matching values as a list of ConditionalValue.
-    The matched criteria are removed, leaving only the unmatched criteria
-    in ConditionalValue instances."""
+    criteria, and return the matching values as a list of ConditionalValue."""
 
     # direct value
     if value is None:
@@ -286,12 +284,11 @@ def filter_conditional_values(
             cond_value: Union[list[str], str] = cv_item.get(cond_name, [cond_expect])
             if not isinstance(cond_value, list):
                 cond_value = [cond_value]
-            if cond_expect is not None:
-                # filter by specified condition
-                if cond_expect not in cond_value:
-                    break
-            elif cond_name in cv_item:
-                # preserve the condition from from input
+            # filter by specified condition
+            if cond_expect is not None and cond_expect not in cond_value:
+                break
+            # preserve the condition from from input
+            if cond_name in cv_item:
                 new_cv_item[cond_name] = cond_value
         else:
             ret.append(ConditionalValue(**new_cv_item))

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -281,11 +281,11 @@ def filter_conditional_values(
       ```
 
       All items that matched the criteria will be returned, normalized to
-      `ConditianalValue` instances. Normally, you'd want to use the ultimate
+      `ConditionalValue` instances. Normally, you'd want to use the ultimate
       value from the list. If no items matched, an empty list will be returned.
 
     - A direct value, as from `store_build_artifacts: true`. In that case, a
-      list with a single `ConditionValue` instance will be returned.
+      list with a single `ConditionalValue` instance will be returned.
 
     - A `None`, i.e. when there is no `store_build_artifacts` key. In that case,
       an empty list will be returned.

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -281,8 +281,8 @@ def filter_conditional_values(
       ```
 
       All items that matched the criteria will be returned, normalized to
-      `ConditianalValue` instances. If no items matched, an empty list will be
-      returned.
+      `ConditianalValue` instances. Normally, you'd want to use the ultimate
+      value from the list. If no items matched, an empty list will be returned.
 
     - A direct value, as from `store_build_artifacts: true`. In that case, a
       list with a single `ConditionValue` instance will be returned.
@@ -291,32 +291,41 @@ def filter_conditional_values(
       an empty list will be returned.
     """
 
-    # direct value
+    # If None is passed, there is no value. Return an empty list.
     if value is None:
         return []
+
+    # If value is not a list, then a value has been assigned to the key
+    # directly. Wrap it in `ConditionalValue` and return as the only item.
     if not isinstance(value, list):
         return [ConditionalValue(value=value)]
 
-    # a list of condition-values
-    filters = {
+    # Otherwise, it's a list of "conditional values". Filter them using
+    # specified criteria.
+
+    criteria = {
         "os": os,
         "platform": platform,
         "provider": provider,
     }
-
     ret = []
-    for cv_item in value:
-        new_cv_item = {"value": cv_item["value"]}
-        for cond_name, cond_expect in filters.items():
-            cond_value: Union[list[str], str] = cv_item.get(cond_name, [cond_expect])
-            if not isinstance(cond_value, list):
-                cond_value = [cond_value]
-            # filter by specified condition
-            if cond_expect is not None and cond_expect not in cond_value:
-                break
-            # preserve the condition from from input
-            if cond_name in cv_item:
-                new_cv_item[cond_name] = cond_value
+    for value_item in value:
+        ret_item = {"value": value_item["value"]}
+        for criteria_key, criteria_expected in criteria.items():
+            if criteria_key in value_item:
+                criteria_got: Union[list[str], str] = value_item.get(
+                    criteria_key, [criteria_expected]
+                )
+                # Normalize the condition into a list.
+                if not isinstance(criteria_got, list):
+                    criteria_got = [criteria_got]
+                ret_item[criteria_key] = criteria_got
+                # Filter by it if requested.
+                if (
+                    criteria_expected is not None
+                    and criteria_expected not in criteria_got
+                ):
+                    break
         else:
-            ret.append(ConditionalValue(**new_cv_item))
+            ret.append(ConditionalValue(**ret_item))
     return ret

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime
 import json
 import os
@@ -8,7 +9,6 @@ import time
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional, Union
 
@@ -247,12 +247,15 @@ def ensure_standard_strings(cfg: Any) -> Any:
         return cfg
 
 
-@dataclass
+@dataclasses.dataclass
 class ConditionalValue:
     value: Any
     os: Optional[list[str]] = None
     platform: Optional[list[str]] = None
     provider: Optional[list[str]] = None
+
+    def __str__(self) -> str:
+        return str({k: v for k, v in dataclasses.asdict(self).items() if v is not None})
 
 
 def filter_conditional_values(
@@ -342,5 +345,11 @@ def get_workflow_settings(
             platform=platform,
             os=platform.split("-", 1)[0],
         )
+        if len(filtered) > 1:
+            raise ValueError(
+                f"More than one value matched for `workflow_settings."
+                f"{setting_key}` when provider={provider} and "
+                f"platform={platform}: {filtered[0]} vs. {filtered[1]}"
+            )
         data[setting_key] = filtered[-1].value if filtered else None
     return data

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 import jinja2
 import jinja2.sandbox
@@ -244,3 +244,40 @@ def ensure_standard_strings(cfg: Any) -> Any:
         return type(cfg)([ensure_standard_strings(v) for v in cfg])
     else:
         return cfg
+
+
+def conditional_value_any_matches(
+    conditional_value: Optional[Union[list[dict], bool]],
+    os: Optional[str] = None,
+    platform: Optional[str] = None,
+    provider: Optional[str] = None,
+) -> Optional[bool]:
+    """Establish if the "conditional value" can be true for the specified os,
+    platform and/or provider combination. Returns True if there is at least one
+    entry that could match all the specified restrictions (but may be further
+    restricted on conditions not passed to the function), False if all values
+    matching this specification evaluate to False, or None if there is no value
+    matching the specified restrictions (meaning a fallback may be in order)."""
+
+    if conditional_value in (None, False, True):
+        return conditional_value
+
+    def to_list(x: Union[str, list[str]]) -> list[str]:
+        if isinstance(x, list):
+            return x
+        return [x]
+
+    for cv_item in reversed(conditional_value):
+        print(to_list(cv_item.get("os", [os])))
+        if os is not None and os not in to_list(cv_item.get("os", [os])):
+            continue
+        if platform is not None and platform not in to_list(
+            cv_item.get("platform", [platform])
+        ):
+            continue
+        if provider is not None and provider not in to_list(
+            cv_item.get("provider", [provider])
+        ):
+            continue
+
+        return cv_item["value"]

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -8,6 +8,7 @@ import time
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional, Union
 
@@ -246,38 +247,50 @@ def ensure_standard_strings(cfg: Any) -> Any:
         return cfg
 
 
-def conditional_value_any_matches(
-    conditional_value: Optional[Union[list[dict], bool]],
+@dataclass
+class ConditionalValue:
+    value: Any
+    os: Optional[list[str]] = None
+    platform: Optional[list[str]] = None
+    provider: Optional[list[str]] = None
+
+
+def filter_conditional_values(
+    value: Any,
     os: Optional[str] = None,
     platform: Optional[str] = None,
     provider: Optional[str] = None,
-) -> Optional[bool]:
-    """Establish if the "conditional value" can be true for the specified os,
-    platform and/or provider combination. Returns True if there is at least one
-    entry that could match all the specified restrictions (but may be further
-    restricted on conditions not passed to the function), False if all values
-    matching this specification evaluate to False, or None if there is no value
-    matching the specified restrictions (meaning a fallback may be in order)."""
+) -> list[ConditionalValue]:
+    """Filter conditional values from conda-smithy.yml by specified
+    criteria, and return the matching values as a list of ConditionalValue.
+    The matched criteria are removed, leaving only the unmatched criteria
+    in ConditionalValue instances. If there is"""
 
-    if conditional_value in (None, False, True):
-        return conditional_value
+    # direct value
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        return [ConditionalValue(value=value)]
 
-    def to_list(x: Union[str, list[str]]) -> list[str]:
-        if isinstance(x, list):
-            return x
-        return [x]
-
-    for cv_item in reversed(conditional_value):
-        print(to_list(cv_item.get("os", [os])))
-        if os is not None and os not in to_list(cv_item.get("os", [os])):
-            continue
-        if platform is not None and platform not in to_list(
-            cv_item.get("platform", [platform])
+    # a list of condition-values
+    ret = []
+    for cv_item in value:
+        new_cv_item = {"value": cv_item["value"]}
+        for cond_name, cond_expect in (
+            ("os", os),
+            ("platform", platform),
+            ("provider", provider),
         ):
-            continue
-        if provider is not None and provider not in to_list(
-            cv_item.get("provider", [provider])
-        ):
-            continue
-
-        return cv_item["value"]
+            cond_value: Union[list[str], str] = cv_item.get(cond_name, [cond_expect])
+            if not isinstance(cond_value, list):
+                cond_value = [cond_value]
+            if cond_expect is not None:
+                # filter by specified condition
+                if cond_expect not in cond_value:
+                    break
+            elif cond_name in cv_item:
+                # preserve the condition from from input
+                new_cv_item[cond_name] = cond_value
+        else:
+            ret.append(ConditionalValue(**new_cv_item))
+    return ret

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -311,20 +311,15 @@ def filter_conditional_values(
     ret = []
     for value_item in value:
         ret_item = {"value": value_item["value"]}
-        for criteria_key, criteria_expected in criteria.items():
+        for criteria_key, needle in criteria.items():
             if criteria_key in value_item:
-                criteria_got: Union[list[str], str] = value_item.get(
-                    criteria_key, [criteria_expected]
-                )
+                haystack: Union[list[str], str] = value_item.get(criteria_key, [needle])
                 # Normalize the condition into a list.
-                if not isinstance(criteria_got, list):
-                    criteria_got = [criteria_got]
-                ret_item[criteria_key] = criteria_got
+                if not isinstance(haystack, list):
+                    haystack = [haystack]
+                ret_item[criteria_key] = haystack
                 # Filter by it if requested.
-                if (
-                    criteria_expected is not None
-                    and criteria_expected not in criteria_got
-                ):
+                if needle is not None and needle not in haystack:
                     break
         else:
             ret.append(ConditionalValue(**ret_item))

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -264,7 +264,7 @@ def filter_conditional_values(
     """Filter conditional values from conda-smithy.yml by specified
     criteria, and return the matching values as a list of ConditionalValue.
     The matched criteria are removed, leaving only the unmatched criteria
-    in ConditionalValue instances. If there is"""
+    in ConditionalValue instances."""
 
     # direct value
     if value is None:

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -324,3 +324,23 @@ def filter_conditional_values(
         else:
             ret.append(ConditionalValue(**ret_item))
     return ret
+
+
+def get_workflow_settings(
+    workflow_settings: dict[str, Any], provider: str, platform: str
+) -> dict[str, Any]:
+    """
+    Process the `workflow_settings` dictionary, returning the keys and specific
+    values for given provider and platform.
+    """
+
+    data = {}
+    for setting_key, setting_value in workflow_settings.items():
+        filtered = filter_conditional_values(
+            setting_value,
+            provider=provider,
+            platform=platform,
+            os=platform.split("-", 1)[0],
+        )
+        data[setting_key] = filtered[-1].value if filtered else None
+    return data

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -308,7 +308,7 @@ def filter_conditional_values(
 
     criteria = {
         "os": os,
-        "platform": platform.replace("-", "_"),
+        "platform": platform.replace("-", "_") if platform else None,
         "provider": provider,
     }
     ret = []

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -261,8 +261,35 @@ def filter_conditional_values(
     platform: Optional[str] = None,
     provider: Optional[str] = None,
 ) -> list[ConditionalValue]:
-    """Filter conditional values from conda-forge.yml by specified
-    criteria, and return the matching values as a list of ConditionalValue."""
+    """
+    Filter "conditional values" as found in `workflow_settings` by specified
+    criteria, and return a list normalized to `ConditionalValue` instances.
+
+    The `value` is the value corresponding to a `workflow_settings` key. It may
+    be:
+
+    - A list of "conditional value" dicts, such as the value of
+      `store_build_artifacts` in:
+
+      ```yaml
+      workflow_settings:
+        store_build_artifacts:
+          - provider: github_actions
+            value: true
+          - platform: [win-64, linux-64]  # matched as OR
+            value: true
+      ```
+
+      All items that matched the criteria will be returned, normalized to
+      `ConditianalValue` instances. If no items matched, an empty list will be
+      returned.
+
+    - A direct value, as from `store_build_artifacts: true`. In that case, a
+      list with a single `ConditionValue` instance will be returned.
+
+    - A `None`, i.e. when there is no `store_build_artifacts` key. In that case,
+      an empty list will be returned.
+    """
 
     # direct value
     if value is None:

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -261,7 +261,7 @@ def filter_conditional_values(
     platform: Optional[str] = None,
     provider: Optional[str] = None,
 ) -> list[ConditionalValue]:
-    """Filter conditional values from conda-smithy.yml by specified
+    """Filter conditional values from conda-forge.yml by specified
     criteria, and return the matching values as a list of ConditionalValue.
     The matched criteria are removed, leaving only the unmatched criteria
     in ConditionalValue instances."""

--- a/news/2500-unified-configuration.rst
+++ b/news/2500-unified-configuration.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* Add a new top-level ``workflow_settings`` configuration key for
+  ``conda-forge.yml`` that provides more fine-grained configuration for
+  workflows. initially, it can be used to control ``store_build_artifacts``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/2500-unified-configuration.rst
+++ b/news/2500-unified-configuration.rst
@@ -2,7 +2,7 @@
 
 * Add a new top-level ``workflow_settings`` configuration key for
   ``conda-forge.yml`` that provides more fine-grained configuration for
-  workflows. initially, it can be used to control ``store_build_artifacts``.
+  workflows. Initially, it can be used to control ``store_build_artifacts``. (#2500)
 
 **Changed:**
 

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -2445,3 +2445,52 @@ def test_github_actions_labels(py_recipe, jinja_env, label):
         )
     else:
         raise AssertionError("Bad label? Check test parameters.")
+
+
+@pytest.mark.parametrize("path", ["github_actions", "workflow_settings"])
+@pytest.mark.parametrize("value", [False, True])
+def test_store_build_artifacts_gha(py_recipe, jinja_env, path: str, value: bool):
+    forge_dir = py_recipe.recipe
+    forge_yml = Path(forge_dir, "conda-forge.yml")
+
+    with open(forge_yml, "a") as f:
+        f.write(textwrap.dedent(f"""\
+            provider:
+              linux_64: github_actions
+              osx_64: github_actions
+              win_64: github_actions
+            {path}:
+              store_build_artifacts: {value}
+        """))
+
+    config = configure_feedstock._load_forge_config(
+        forge_dir, "recipe/default_config.yaml"
+    )
+    configure_feedstock.render_github_actions(
+        jinja_env=jinja_env,
+        forge_config=config,
+        forge_dir=forge_dir,
+    )
+
+    conda_build_yml = Path(forge_dir, ".github/workflows/conda-build.yml")
+    with conda_build_yml.open() as f:
+        workflow = yaml.safe_load(f)
+
+    matrix = workflow["jobs"]["build"]["strategy"]["matrix"]["include"]
+    assert all(entry["STORE_BUILD_ARTIFACTS"] is value for entry in matrix)
+    if value:
+        assert all(entry.get("SHORT_CONFIG") for entry in matrix)
+
+    # check that artifacts steps are output / not output
+    steps = workflow["jobs"]["build"]["steps"]
+    step_names = set(step["name"] for step in steps)
+    wf_step_names = {
+        "Store conda build environment artifacts",
+        "Store conda build artifacts",
+        "Prepare conda build artifacts",
+        "Determine build outcome",
+    }
+    if value:
+        assert step_names.issuperset(wf_step_names)
+    else:
+        assert not step_names.intersection(wf_step_names)

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -2494,3 +2494,8 @@ def test_store_build_artifacts_gha(py_recipe, jinja_env, path: str, value: bool)
         assert step_names.issuperset(wf_step_names)
     else:
         assert not step_names.intersection(wf_step_names)
+
+    assert (
+        Path(forge_dir, ".scripts/create_conda_build_artifacts.bat").exists() is value
+    )
+    assert Path(forge_dir, ".scripts/create_conda_build_artifacts.sh").exists() is value

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -2499,3 +2499,63 @@ def test_store_build_artifacts_gha(py_recipe, jinja_env, path: str, value: bool)
         Path(forge_dir, ".scripts/create_conda_build_artifacts.bat").exists() is value
     )
     assert Path(forge_dir, ".scripts/create_conda_build_artifacts.sh").exists() is value
+
+
+@pytest.mark.parametrize("path", ["azure", "workflow_settings"])
+@pytest.mark.parametrize("value", [False, True])
+def test_store_build_artifacts_azure(py_recipe, jinja_env, path: str, value: bool):
+    forge_dir = py_recipe.recipe
+    forge_yml = Path(forge_dir, "conda-forge.yml")
+
+    with open(forge_yml, "a") as f:
+        f.write(textwrap.dedent(f"""\
+            provider:
+              linux_64: azure
+              osx_64: azure
+              win_64: azure
+            {path}:
+              store_build_artifacts: {value}
+        """))
+
+    config = configure_feedstock._load_forge_config(
+        forge_dir, "recipe/default_config.yaml"
+    )
+    configure_feedstock.render_azure(
+        jinja_env=jinja_env,
+        forge_config=config,
+        forge_dir=forge_dir,
+    )
+
+    for os_name in ("linux", "osx", "win"):
+        workflow_yml = Path(
+            forge_dir, ".azure-pipelines", f"azure-pipelines-{os_name}.yml"
+        )
+        with workflow_yml.open() as f:
+            workflow = yaml.safe_load(f)
+
+        matrix = workflow["jobs"][0]["strategy"]["matrix"]
+        assert all(entry["store_build_artifacts"] is value for entry in matrix.values())
+        if value:
+            assert all(entry.get("SHORT_CONFIG") for entry in matrix.values())
+
+        # check that artifacts steps are output / not output
+        steps = workflow["jobs"][0]["steps"]
+        step_names = set(step["displayName"] for step in steps)
+        wf_step_names = {
+            "Store conda build environment artifacts",
+            "Store conda build artifacts",
+            "Prepare conda build artifacts",
+        }
+        if value:
+            assert step_names.issuperset(wf_step_names)
+        else:
+            assert not step_names.intersection(wf_step_names)
+
+        assert (
+            Path(forge_dir, ".scripts/create_conda_build_artifacts.bat").exists()
+            is value
+        )
+        assert (
+            Path(forge_dir, ".scripts/create_conda_build_artifacts.sh").exists()
+            is value
+        )

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -2551,14 +2551,10 @@ def test_store_build_artifacts_azure(py_recipe, jinja_env, path: str, value: boo
         else:
             assert not step_names.intersection(wf_step_names)
 
-        assert (
-            Path(forge_dir, ".scripts/create_conda_build_artifacts.bat").exists()
-            is value
-        )
-        assert (
-            Path(forge_dir, ".scripts/create_conda_build_artifacts.sh").exists()
-            is value
-        )
+    assert (
+        Path(forge_dir, ".scripts/create_conda_build_artifacts.bat").exists() is value
+    )
+    assert Path(forge_dir, ".scripts/create_conda_build_artifacts.sh").exists() is value
 
 
 @pytest.mark.parametrize("ci", ["azure", "github_actions"])
@@ -2583,3 +2579,118 @@ def test_store_build_artifacts_duplicate_setting(py_recipe, jinja_env, ci: str):
         match=rf"`store_build_artifacts` both in `workflow_settings` and `{ci}` sections",
     ):
         configure_feedstock._load_forge_config(forge_dir, "recipe/default_config.yaml")
+
+
+def test_store_build_artifacts_gha_conditions(py_recipe, jinja_env):
+    forge_dir = py_recipe.recipe
+    forge_yml = Path(forge_dir, "conda-forge.yml")
+
+    with open(forge_yml, "a") as f:
+        f.write(textwrap.dedent("""\
+            provider:
+              linux_64: github_actions
+              linux_aarch64: github_actions
+              osx_64: github_actions
+              osx_arm64: github_actions
+              win_64: github_actions
+            workflow_settings:
+              store_build_artifacts:
+                - platform: linux_64
+                  value: true
+                - os: osx
+                  value: true
+        """))
+
+    config = configure_feedstock._load_forge_config(
+        forge_dir, "recipe/default_config.yaml"
+    )
+    configure_feedstock.render_github_actions(
+        jinja_env=jinja_env,
+        forge_config=config,
+        forge_dir=forge_dir,
+    )
+
+    conda_build_yml = Path(forge_dir, ".github/workflows/conda-build.yml")
+    with conda_build_yml.open() as f:
+        workflow = yaml.safe_load(f)
+
+    matrix = workflow["jobs"]["build"]["strategy"]["matrix"]["include"]
+    assert all(
+        entry["STORE_BUILD_ARTIFACTS"]
+        == entry["CONFIG"].startswith(("linux_64", "osx"))
+        for entry in matrix
+    )
+
+    # check that artifacts steps are output / not output
+    steps = workflow["jobs"]["build"]["steps"]
+    step_names = set(step["name"] for step in steps)
+    wf_step_names = {
+        "Store conda build environment artifacts",
+        "Store conda build artifacts",
+        "Prepare conda build artifacts",
+        "Determine build outcome",
+    }
+    assert step_names.issuperset(wf_step_names)
+
+    assert not Path(forge_dir, ".scripts/create_conda_build_artifacts.bat").exists()
+    assert Path(forge_dir, ".scripts/create_conda_build_artifacts.sh").exists()
+
+
+def test_store_build_artifacts_azure_conditions(py_recipe, jinja_env):
+    forge_dir = py_recipe.recipe
+    forge_yml = Path(forge_dir, "conda-forge.yml")
+
+    with open(forge_yml, "a") as f:
+        f.write(textwrap.dedent("""\
+            provider:
+              linux_64: azure
+              linux_aarch64: azure
+              osx_64: azure
+              osx_arm64: azure
+              win_64: azure
+            workflow_settings:
+              store_build_artifacts:
+                - platform: linux_64
+                  value: true
+                - os: osx
+                  value: true
+        """))
+
+    config = configure_feedstock._load_forge_config(
+        forge_dir, "recipe/default_config.yaml"
+    )
+    configure_feedstock.render_azure(
+        jinja_env=jinja_env,
+        forge_config=config,
+        forge_dir=forge_dir,
+    )
+
+    for os_name in ("linux", "osx", "win"):
+        workflow_yml = Path(
+            forge_dir, ".azure-pipelines", f"azure-pipelines-{os_name}.yml"
+        )
+        with workflow_yml.open() as f:
+            workflow = yaml.safe_load(f)
+
+        matrix = workflow["jobs"][0]["strategy"]["matrix"]
+        assert all(
+            entry["store_build_artifacts"]
+            is (True if entry["CONFIG"].startswith(("linux_64", "osx")) else None)
+            for entry in matrix.values()
+        )
+
+        # check that artifacts steps are output / not output
+        steps = workflow["jobs"][0]["steps"]
+        step_names = set(step["displayName"] for step in steps)
+        wf_step_names = {
+            "Store conda build environment artifacts",
+            "Store conda build artifacts",
+            "Prepare conda build artifacts",
+        }
+        if os_name != "win":
+            assert step_names.issuperset(wf_step_names)
+        else:
+            assert not step_names.intersection(wf_step_names)
+
+    assert not Path(forge_dir, ".scripts/create_conda_build_artifacts.bat").exists()
+    assert Path(forge_dir, ".scripts/create_conda_build_artifacts.sh").exists()

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -2559,3 +2559,27 @@ def test_store_build_artifacts_azure(py_recipe, jinja_env, path: str, value: boo
             Path(forge_dir, ".scripts/create_conda_build_artifacts.sh").exists()
             is value
         )
+
+
+@pytest.mark.parametrize("ci", ["azure", "github_actions"])
+def test_store_build_artifacts_duplicate_setting(py_recipe, jinja_env, ci: str):
+    forge_dir = py_recipe.recipe
+    forge_yml = Path(forge_dir, "conda-forge.yml")
+
+    with open(forge_yml, "a") as f:
+        f.write(textwrap.dedent(f"""\
+            provider:
+              linux_64: azure
+              osx_64: azure
+              win_64: azure
+            workflow_settings:
+              store_build_artifacts: true
+            {ci}:
+              store_build_artifacts: true
+        """))
+
+    with pytest.raises(
+        ValueError,
+        match=rf"`store_build_artifacts` both in `workflow_settings` and `{ci}` sections",
+    ):
+        configure_feedstock._load_forge_config(forge_dir, "recipe/default_config.yaml")

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -2734,3 +2734,93 @@ def test_store_build_artifacts_overlapping_conditions(py_recipe, jinja_env, ci: 
                 forge_config=config,
                 forge_dir=forge_dir,
             )
+
+
+def test_store_build_artifacts_gha_and_azure_conditions(py_recipe, jinja_env):
+    forge_dir = py_recipe.recipe
+    forge_yml = Path(forge_dir, "conda-forge.yml")
+
+    with open(forge_yml, "a") as f:
+        f.write(textwrap.dedent("""\
+            provider:
+              linux_64: github_actions
+              linux_aarch64: azure
+              osx_64: azure
+              osx_arm64: github_actions
+              win_64: azure
+            workflow_settings:
+              store_build_artifacts:
+                - os: osx
+                  provider: azure
+                  value: true
+                - os: linux
+                  provider: github_actions
+                  value: true
+        """))
+
+    config = configure_feedstock._load_forge_config(
+        forge_dir, "recipe/default_config.yaml"
+    )
+    configure_feedstock.render_azure(
+        jinja_env=jinja_env,
+        forge_config=config,
+        forge_dir=forge_dir,
+    )
+    configure_feedstock.render_github_actions(
+        jinja_env=jinja_env,
+        forge_config=config,
+        forge_dir=forge_dir,
+    )
+
+    # check github_actions workflows
+    conda_build_yml = Path(forge_dir, ".github/workflows/conda-build.yml")
+    with conda_build_yml.open() as f:
+        workflow = yaml.safe_load(f)
+
+    matrix = workflow["jobs"]["build"]["strategy"]["matrix"]["include"]
+    assert all(
+        entry["STORE_BUILD_ARTIFACTS"] == entry["CONFIG"].startswith("linux_64")
+        for entry in matrix
+    )
+
+    # check that artifacts steps are output / not output
+    steps = workflow["jobs"]["build"]["steps"]
+    step_names = set(step["name"] for step in steps)
+    wf_step_names = {
+        "Store conda build environment artifacts",
+        "Store conda build artifacts",
+        "Prepare conda build artifacts",
+        "Determine build outcome",
+    }
+    assert step_names.issuperset(wf_step_names)
+
+    # check azure workflows
+    for os_name in ("linux", "osx", "win"):
+        workflow_yml = Path(
+            forge_dir, ".azure-pipelines", f"azure-pipelines-{os_name}.yml"
+        )
+        with workflow_yml.open() as f:
+            workflow = yaml.safe_load(f)
+
+        matrix = workflow["jobs"][0]["strategy"]["matrix"]
+        assert all(
+            entry["store_build_artifacts"]
+            is (True if entry["CONFIG"].startswith("osx") else None)
+            for entry in matrix.values()
+        )
+
+        # check that artifacts steps are output / not output
+        steps = workflow["jobs"][0]["steps"]
+        step_names = set(step["displayName"] for step in steps)
+        wf_step_names = {
+            "Store conda build environment artifacts",
+            "Store conda build artifacts",
+            "Prepare conda build artifacts",
+        }
+        if os_name == "osx":
+            assert step_names.issuperset(wf_step_names)
+        else:
+            assert not step_names.intersection(wf_step_names)
+
+    assert not Path(forge_dir, ".scripts/create_conda_build_artifacts.bat").exists()
+    assert Path(forge_dir, ".scripts/create_conda_build_artifacts.sh").exists()

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -2694,3 +2694,43 @@ def test_store_build_artifacts_azure_conditions(py_recipe, jinja_env):
 
     assert not Path(forge_dir, ".scripts/create_conda_build_artifacts.bat").exists()
     assert Path(forge_dir, ".scripts/create_conda_build_artifacts.sh").exists()
+
+
+@pytest.mark.parametrize("ci", ["azure", "github_actions"])
+def test_store_build_artifacts_overlapping_conditions(py_recipe, jinja_env, ci: str):
+    forge_dir = py_recipe.recipe
+    forge_yml = Path(forge_dir, "conda-forge.yml")
+
+    with open(forge_yml, "a") as f:
+        f.write(textwrap.dedent(f"""\
+            provider:
+              linux_64: {ci}
+              osx_64: {ci}
+              win_64: {ci}
+            workflow_settings:
+              store_build_artifacts:
+                - platform: linux_64
+                  value: true
+                - os: linux
+                  value: true
+        """))
+
+    config = configure_feedstock._load_forge_config(
+        forge_dir, "recipe/default_config.yaml"
+    )
+    with pytest.raises(
+        ValueError,
+        match=r"More than one value matched for `workflow_settings.store_build_artifacts`",
+    ):
+        if ci == "azure":
+            configure_feedstock.render_azure(
+                jinja_env=jinja_env,
+                forge_config=config,
+                forge_dir=forge_dir,
+            )
+        else:
+            configure_feedstock.render_github_actions(
+                jinja_env=jinja_env,
+                forge_config=config,
+                forge_dir=forge_dir,
+            )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,13 @@
+from typing import Union
+
+import pytest
 from conda_build.metadata import MetaData
 from rattler_build_conda_compat.render import MetaData as RatlerBuildMetadata
 
 from conda_smithy.utils import (
     RATTLER_BUILD,
     _get_metadata_from_feedstock_dir,
+    conditional_value_any_matches,
     get_feedstock_name_from_meta,
 )
 
@@ -78,3 +82,78 @@ def test_get_feedstock_name_from_rattler_metadata_multiple_outputs(
     feedstock_name = get_feedstock_name_from_meta(metadata)
 
     assert feedstock_name == "mamba-split"
+
+
+@pytest.mark.parametrize(
+    "restrict,linux_value,linux_or_win_value",
+    [
+        ({}, True, True),
+        ({"os": "linux"}, True, True),
+        ({"os": "win"}, None, True),
+        ({"os": "osx"}, None, None),
+        ({"platform": "linux_64"}, True, True),
+        ({"provider": "azure"}, True, True),
+        ({"provider": "azure", "os": "linux"}, True, True),
+        ({"provider": "azure", "os": "win"}, None, True),
+        ({"provider": "azure", "os": "osx"}, None, None),
+    ],
+)
+def test_conditional_value_any_matches(
+    restrict: dict[str, Union[str, list[str]]],
+    linux_value: bool,
+    linux_or_win_value: bool,
+) -> None:
+    # value passed directly is always used
+    assert conditional_value_any_matches(True, **restrict) is True
+    assert conditional_value_any_matches(False, **restrict) is False
+
+    # no value
+    assert conditional_value_any_matches(None, **restrict) is None
+    assert conditional_value_any_matches([], **restrict) is None
+
+    # corner case: a value with no conditions
+    assert conditional_value_any_matches([{"value": True}], **restrict) is True
+    assert conditional_value_any_matches([{"value": False}], **restrict) is False
+
+    # corner case 2: final value with no conditions
+    assert (
+        conditional_value_any_matches(
+            [
+                {"os": "linux", "value": False},
+                {"provider": "azure", "value": False},
+                {"value": True},
+            ],
+            **restrict,
+        )
+        is True
+    )
+    assert (
+        conditional_value_any_matches(
+            [
+                {"os": "linux", "value": True},
+                {"provider": "azure", "value": True},
+                {"value": False},
+            ],
+            **restrict,
+        )
+        is False
+    )
+
+    assert (
+        conditional_value_any_matches(
+            [
+                {"os": "linux", "value": True},
+            ],
+            **restrict,
+        )
+        is linux_value
+    )
+    assert (
+        conditional_value_any_matches(
+            [
+                {"os": ["linux", "win"], "value": True},
+            ],
+            **restrict,
+        )
+        is linux_or_win_value
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -97,16 +97,16 @@ def test_filter_conditional_values() -> None:
     assert filter_conditional_values([{"os": ["linux", "win"], "value": True}]) == [
         ConditionalValue(True, os=["linux", "win"])
     ]
-    assert filter_conditional_values(
-        [
-            {
-                "os": ["linux", "win"],
-                "provider": "azure",
-                "platform": ["linux_64", "win_64"],
-                "value": True,
-            }
-        ]
-    ) == [
+
+    common_example_in = [
+        {
+            "os": ["linux", "win"],
+            "provider": "azure",
+            "platform": ["linux_64", "win_64"],
+            "value": True,
+        }
+    ]
+    common_example_out = [
         ConditionalValue(
             True,
             os=["linux", "win"],
@@ -115,103 +115,25 @@ def test_filter_conditional_values() -> None:
         )
     ]
 
+    assert filter_conditional_values(common_example_in) == common_example_out
+
     # filtering
-    assert filter_conditional_values(
-        [
-            {
-                "os": ["linux", "win"],
-                "provider": "azure",
-                "platform": ["linux_64", "win_64"],
-                "value": True,
-            }
-        ],
-        provider="azure",
-    ) == [
-        ConditionalValue(
-            True,
-            os=["linux", "win"],
-            platform=["linux_64", "win_64"],
-        )
-    ]
+    assert (
+        filter_conditional_values(common_example_in, provider="azure")
+        == common_example_out
+    )
+    assert filter_conditional_values(common_example_in, provider="github_actions") == []
+    assert (
+        filter_conditional_values(common_example_in, os="linux") == common_example_out
+    )
+    assert filter_conditional_values(common_example_in, os="win") == common_example_out
+    assert filter_conditional_values(common_example_in, os="osx") == []
     assert (
         filter_conditional_values(
-            [
-                {
-                    "os": ["linux", "win"],
-                    "provider": "azure",
-                    "platform": ["linux_64", "win_64"],
-                    "value": True,
-                }
-            ],
-            provider="github_actions",
+            common_example_in, os="linux", platform="linux_64", provider="azure"
         )
-        == []
+        == common_example_out
     )
-    assert filter_conditional_values(
-        [
-            {
-                "os": ["linux", "win"],
-                "provider": "azure",
-                "platform": ["linux_64", "win_64"],
-                "value": True,
-            }
-        ],
-        os="linux",
-    ) == [
-        ConditionalValue(
-            True,
-            platform=["linux_64", "win_64"],
-            provider=["azure"],
-        )
-    ]
-    assert filter_conditional_values(
-        [
-            {
-                "os": ["linux", "win"],
-                "provider": "azure",
-                "platform": ["linux_64", "win_64"],
-                "value": True,
-            }
-        ],
-        os="win",
-    ) == [
-        ConditionalValue(
-            True,
-            platform=["linux_64", "win_64"],
-            provider=["azure"],
-        )
-    ]
-    assert (
-        filter_conditional_values(
-            [
-                {
-                    "os": ["linux", "win"],
-                    "provider": "azure",
-                    "platform": ["linux_64", "win_64"],
-                    "value": True,
-                }
-            ],
-            os="osx",
-        )
-        == []
-    )
-    assert filter_conditional_values(
-        [
-            {
-                "os": ["linux", "win"],
-                "provider": "azure",
-                "platform": ["linux_64", "win_64"],
-                "value": True,
-            }
-        ],
-        os="linux",
-        platform="linux_64",
-        provider="azure",
-    ) == [
-        ConditionalValue(
-            True,
-        )
-    ]
     assert filter_conditional_values(
         [
             {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -137,6 +137,7 @@ def test_filter_conditional_values() -> None:
 
     result = filter_conditional_values(
         [
+            # these two should be preserved, since they do not specify os
             {
                 "provider": "azure",
                 "platform": ["linux_64", "win_64"],
@@ -146,6 +147,7 @@ def test_filter_conditional_values() -> None:
                 "provider": "github_actions",
                 "value": True,
             },
+            # this one gets filtered over os!="linux"
             {
                 "os": "win",
                 "value": True,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,11 @@
-from typing import Union
-
-import pytest
 from conda_build.metadata import MetaData
 from rattler_build_conda_compat.render import MetaData as RatlerBuildMetadata
 
 from conda_smithy.utils import (
     RATTLER_BUILD,
+    ConditionalValue,
     _get_metadata_from_feedstock_dir,
-    conditional_value_any_matches,
+    filter_conditional_values,
     get_feedstock_name_from_meta,
 )
 
@@ -84,76 +82,158 @@ def test_get_feedstock_name_from_rattler_metadata_multiple_outputs(
     assert feedstock_name == "mamba-split"
 
 
-@pytest.mark.parametrize(
-    "restrict,linux_value,linux_or_win_value",
-    [
-        ({}, True, True),
-        ({"os": "linux"}, True, True),
-        ({"os": "win"}, None, True),
-        ({"os": "osx"}, None, None),
-        ({"platform": "linux_64"}, True, True),
-        ({"provider": "azure"}, True, True),
-        ({"provider": "azure", "os": "linux"}, True, True),
-        ({"provider": "azure", "os": "win"}, None, True),
-        ({"provider": "azure", "os": "osx"}, None, None),
-    ],
-)
-def test_conditional_value_any_matches(
-    restrict: dict[str, Union[str, list[str]]],
-    linux_value: bool,
-    linux_or_win_value: bool,
-) -> None:
-    # value passed directly is always used
-    assert conditional_value_any_matches(True, **restrict) is True
-    assert conditional_value_any_matches(False, **restrict) is False
+def test_filter_conditional_values() -> None:
+    # direct values
+    assert filter_conditional_values(None) == []
+    assert filter_conditional_values(True) == [ConditionalValue(True)]
+    assert filter_conditional_values("foo") == [ConditionalValue("foo")]
 
-    # no value
-    assert conditional_value_any_matches(None, **restrict) is None
-    assert conditional_value_any_matches([], **restrict) is None
+    # no filtering
+    assert filter_conditional_values([]) == []
+    assert filter_conditional_values([{"value": True}]) == [ConditionalValue(True)]
+    assert filter_conditional_values([{"os": "linux", "value": True}]) == [
+        ConditionalValue(True, os=["linux"])
+    ]
+    assert filter_conditional_values([{"os": ["linux", "win"], "value": True}]) == [
+        ConditionalValue(True, os=["linux", "win"])
+    ]
+    assert filter_conditional_values(
+        [
+            {
+                "os": ["linux", "win"],
+                "provider": "azure",
+                "platform": ["linux_64", "win_64"],
+                "value": True,
+            }
+        ]
+    ) == [
+        ConditionalValue(
+            True,
+            os=["linux", "win"],
+            platform=["linux_64", "win_64"],
+            provider=["azure"],
+        )
+    ]
 
-    # corner case: a value with no conditions
-    assert conditional_value_any_matches([{"value": True}], **restrict) is True
-    assert conditional_value_any_matches([{"value": False}], **restrict) is False
-
-    # corner case 2: final value with no conditions
-    assert (
-        conditional_value_any_matches(
-            [
-                {"os": "linux", "value": False},
-                {"provider": "azure", "value": False},
-                {"value": True},
-            ],
-            **restrict,
+    # filtering
+    assert filter_conditional_values(
+        [
+            {
+                "os": ["linux", "win"],
+                "provider": "azure",
+                "platform": ["linux_64", "win_64"],
+                "value": True,
+            }
+        ],
+        provider="azure",
+    ) == [
+        ConditionalValue(
+            True,
+            os=["linux", "win"],
+            platform=["linux_64", "win_64"],
         )
-        is True
-    )
+    ]
     assert (
-        conditional_value_any_matches(
+        filter_conditional_values(
             [
-                {"os": "linux", "value": True},
-                {"provider": "azure", "value": True},
-                {"value": False},
+                {
+                    "os": ["linux", "win"],
+                    "provider": "azure",
+                    "platform": ["linux_64", "win_64"],
+                    "value": True,
+                }
             ],
-            **restrict,
+            provider="github_actions",
         )
-        is False
+        == []
     )
-
+    assert filter_conditional_values(
+        [
+            {
+                "os": ["linux", "win"],
+                "provider": "azure",
+                "platform": ["linux_64", "win_64"],
+                "value": True,
+            }
+        ],
+        os="linux",
+    ) == [
+        ConditionalValue(
+            True,
+            platform=["linux_64", "win_64"],
+            provider=["azure"],
+        )
+    ]
+    assert filter_conditional_values(
+        [
+            {
+                "os": ["linux", "win"],
+                "provider": "azure",
+                "platform": ["linux_64", "win_64"],
+                "value": True,
+            }
+        ],
+        os="win",
+    ) == [
+        ConditionalValue(
+            True,
+            platform=["linux_64", "win_64"],
+            provider=["azure"],
+        )
+    ]
     assert (
-        conditional_value_any_matches(
+        filter_conditional_values(
             [
-                {"os": "linux", "value": True},
+                {
+                    "os": ["linux", "win"],
+                    "provider": "azure",
+                    "platform": ["linux_64", "win_64"],
+                    "value": True,
+                }
             ],
-            **restrict,
+            os="osx",
         )
-        is linux_value
+        == []
     )
-    assert (
-        conditional_value_any_matches(
-            [
-                {"os": ["linux", "win"], "value": True},
-            ],
-            **restrict,
+    assert filter_conditional_values(
+        [
+            {
+                "os": ["linux", "win"],
+                "provider": "azure",
+                "platform": ["linux_64", "win_64"],
+                "value": True,
+            }
+        ],
+        os="linux",
+        platform="linux_64",
+        provider="azure",
+    ) == [
+        ConditionalValue(
+            True,
         )
-        is linux_or_win_value
-    )
+    ]
+    assert filter_conditional_values(
+        [
+            {
+                "provider": "azure",
+                "platform": ["linux_64", "win_64"],
+                "value": True,
+            },
+            {
+                "provider": "github_actions",
+                "value": True,
+            },
+            {
+                "os": "win",
+                "value": True,
+            },
+        ],
+        os="linux",
+    ) == [
+        ConditionalValue(
+            True,
+            platform=["linux_64", "win_64"],
+            provider=["azure"],
+        ),
+        ConditionalValue(True, provider=["github_actions"]),
+    ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -134,7 +134,8 @@ def test_filter_conditional_values() -> None:
         )
         == common_example_out
     )
-    assert filter_conditional_values(
+
+    result = filter_conditional_values(
         [
             {
                 "provider": "azure",
@@ -151,7 +152,8 @@ def test_filter_conditional_values() -> None:
             },
         ],
         os="linux",
-    ) == [
+    )
+    expected = [
         ConditionalValue(
             True,
             platform=["linux_64", "win_64"],
@@ -159,3 +161,4 @@ def test_filter_conditional_values() -> None:
         ),
         ConditionalValue(True, provider=["github_actions"]),
     ]
+    assert result == expected


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Introduce a unified configuration tree for more fine-grained settings of the CI setup. Currently, `store_build_artifacts` is implemented in the new format. The settings are rooted at `workflow_settings` top key, with its subkeys representing specific settings. The values can either represent a common value for all workflows, e.g.:

```yaml
workflow_settings:
  store_build_artifacts: true
```

or a list of multiple values with conditions describing when they apply, for example:

```yaml
workflow_settings:
  store_build_artifacts:
    - provider: github_actions
      value: true
    - platform: [win-64, linux-64]  # matched as an OR
      value: true
```

in which case the last value matching the given workflow is used.

Part of issue #2349.