### PR TITLE
add hint to remove linux_ppc64le

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -31,6 +31,7 @@ from conda_smithy.linter.hints import (
     hint_pip_no_build_backend,
     hint_pip_usage,
     hint_rattler_build_bld_bat,
+    hint_remove_ppc64le,
     hint_shellcheck_usage,
     hint_sources_should_not_mention_pypi_io_but_pypi_org,
     hint_space_separated_specs,
@@ -532,7 +533,9 @@ def run_conda_forge_specific(
     hints,
     recipe_version: int = 0,
 ):
-    lints_to_skip = _get_feedstock_config(recipe_dir).get("linter", {}).get("skip", [])
+
+    feedstock_config = _get_feedstock_config(recipe_dir)
+    lints_to_skip = feedstock_config.get("linter", {}).get("skip", [])
 
     # Retrieve sections from meta
     package_section = get_section(meta, "package", lints, recipe_version=recipe_version)
@@ -724,6 +727,10 @@ def run_conda_forge_specific(
             "for more information. If you didn't add any custom workflows, please "
             "consider rerendering your feedstock to remove deprecated workflows."
         )
+
+    # 16: note deprecation of ppc64le support
+    if "hint_remove_ppc64le" not in lints_to_skip:
+        hint_remove_ppc64le(feedstock_config, hints)
 
 
 def _format_validation_msg(error: jsonschema.ValidationError):

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -518,3 +518,18 @@ def hint_rattler_build_bld_bat(
             "(rattler-build recipe). rattler-build uses `build.bat` instead of `bld.bat` "
             "for Windows builds. Consider renaming `bld.bat` to `build.bat`."
         )
+
+
+def hint_remove_ppc64le(feedstock_config, hints):
+    """
+    hint for conda-forge.yml to remove linux_ppc64le
+    """
+    provider = feedstock_config.get("provider", {})
+    build_platform = feedstock_config.get("build_platform", {})
+    if provider.get("linux_ppc64le") or build_platform.get("linux_ppc64le"):
+        hints.append(
+            "Found linux_ppc64le in conda-forge.yml. "
+            "Conda-Forge is ending support for linux_ppc64le builds. "
+            "Consider removing linux_ppc64le from conda-forge.yml. "
+            "See https://github.com/conda-forge/conda-forge.github.io/issues/2781 for more information."
+        )

--- a/news/hint-remove-ppc.rst
+++ b/news/hint-remove-ppc.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* New hint to suggest removing linux_ppc64le builds
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
+import yaml
 
 import conda_smithy.lint_recipe as linter
 from conda_smithy.linter import hints
@@ -4664,6 +4665,33 @@ extra:
         else []
     )
     assert hints == []
+
+
+@pytest.mark.parametrize(
+    "found_in, should_hint",
+    [
+        ("provider", True),
+        ("build_platform", True),
+        (None, False),
+    ],
+)
+def test_hint_remove_ppc64le(tmp_path, found_in, should_hint):
+    expected_message = "Consider removing linux_ppc64le from conda-forge.yml"
+    with get_recipe_in_dir("v1_recipes/recipe-no-lint.yaml") as recipe_dir:
+        cf_config = {}
+        if found_in == "provider":
+            cf_config["provider"] = {"linux_ppc64le": "default"}
+        if found_in == "build_platform":
+            cf_config["build_platform"] = {"linux_ppc64le": "linux_64"}
+        cf_yaml = Path(recipe_dir).parent / "conda-forge.yml"
+        with cf_yaml.open("w") as f:
+            yaml.dump(cf_config, f)
+        lints, hints = linter.main(recipe_dir, return_hints=True, conda_forge=True)
+
+    if should_hint:
+        assert any(expected_message in hint for hint in hints)
+    else:
+        assert not any(expected_message in hint for hint in hints)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)

draft suggestion for https://github.com/conda-forge/conda-forge.github.io/issues/2781

This is just a hint, so doesn't cause any failures. It mainly gives feedstocks _permission_ to remove ppc64le builds.

Happy to have any suggestions for the wording.