### PR TITLE
fix: configure logger only once

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -734,10 +734,11 @@ class CISkeleton(Subcommand):
 
 def main(argv=None):
     logger = logging.getLogger("conda_smithy")
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT, None, "%"))
-    logger.addHandler(handler)
-    logger.setLevel(logging.INFO)
+    if len(logger.handlers) == 0:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT, None, "%"))
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
 
     parser = argparse.ArgumentParser(
         prog="conda smithy",

--- a/news/duplicate-logging-2515.rst
+++ b/news/duplicate-logging-2515.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed duplicate logging messages. (#2515)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

closes #2513 