### PR TITLE
fix: remove duplicate log entries by forcing logging.basicConfig to rerun

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -747,11 +747,7 @@ class CISkeleton(Subcommand):
 
 
 def main(argv=None):
-    logger = logging.getLogger("conda_smithy")
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT, None, "%"))
-    logger.addHandler(handler)
-    logger.setLevel(logging.INFO)
+    logging.basicConfig(level=logging.INFO, force=True)
 
     parser = argparse.ArgumentParser(
         prog="conda smithy",

--- a/news/2515-fix-duplicate-logs.rst
+++ b/news/2515-fix-duplicate-logs.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed duplicate log entries. (#2515)
+
+**Security:**
+
+* <news item>

--- a/news/2516-fix-duplicate-logs.rst
+++ b/news/2516-fix-duplicate-logs.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Fixed duplicate log entries. (#2515)
+* Fixed duplicate log entries. (#2516)
 
 **Security:**
 


### PR DESCRIPTION

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

closes #2513 