### PR TITLE
Replace black with ruff format [pyconde sprints]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,15 +6,12 @@ repos:
         exclude: (tests/recipes|conda_smithy.recipe)
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.3.1
-    hooks:
-    -   id: black
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.9
     hooks:
-        - id: ruff
+        - id: ruff-check
           args: [ --fix ]
+        - id: ruff-format
 
 ci:
     autofix_commit_msg: |

--- a/conda_smithy/anaconda_token_rotation.py
+++ b/conda_smithy/anaconda_token_rotation.py
@@ -144,8 +144,7 @@ def rotate_anaconda_token(
                             raise e
                         else:
                             err_msg = (
-                                f"Failed to rotate token for {user}/{project}"
-                                " on azure!"
+                                f"Failed to rotate token for {user}/{project} on azure!"
                             )
                             failed = True
                             raise RuntimeError(err_msg)

--- a/conda_smithy/ci_register.py
+++ b/conda_smithy/ci_register.py
@@ -198,8 +198,7 @@ def add_project_to_circle(user, project):
         "Accept": "application/json",
     }
     url_template = (
-        "https://circleci.com/api/v1.1/project/github/{component}?"
-        "circle-token={token}"
+        "https://circleci.com/api/v1.1/project/github/{component}?circle-token={token}"
     )
 
     # Note, we used to check to see whether the project was already registered, but it started

--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -104,8 +104,7 @@ class Init(Subcommand):
 
         super().__init__(
             parser,
-            "Create a feedstock git repository, which can contain "
-            "one conda recipes.",
+            "Create a feedstock git repository, which can contain one conda recipes.",
         )
         scp = self.subcommand_parser
         scp.add_argument(
@@ -570,7 +569,7 @@ class Regenerate(Subcommand):
     def __init__(self, parser):
         super().__init__(
             parser,
-            "Regenerate / update the CI support files of the " "feedstock.",
+            "Regenerate / update the CI support files of the feedstock.",
         )
         scp = self.subcommand_parser
         scp.add_argument(

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1521,15 +1521,19 @@ def _get_build_setup_line(forge_dir, platform, forge_config):
 
             """)
         elif platform == "win":
-            build_setup += textwrap.dedent("""\
+            build_setup += textwrap.dedent(
+                """\
                 :: Overriding global run_conda_forge_build_setup_win with local copy.
                 CALL {recipe_dir}\\run_conda_forge_build_setup_win
-            """.format(recipe_dir=forge_config["recipe_dir"]))
+            """.format(recipe_dir=forge_config["recipe_dir"])
+            )
         else:
-            build_setup += textwrap.dedent("""\
+            build_setup += textwrap.dedent(
+                """\
                 # Overriding global run_conda_forge_build_setup_osx with local copy.
                 source {recipe_dir}/run_conda_forge_build_setup_osx
-            """.format(recipe_dir=forge_config["recipe_dir"]))
+            """.format(recipe_dir=forge_config["recipe_dir"])
+            )
     else:
         if platform == "win":
             build_setup += textwrap.dedent("""\
@@ -1594,13 +1598,15 @@ def generate_yum_requirements(forge_config, forge_dir):
                 "yum_requirements.txt, please remove the file "
                 "or add some."
             )
-        yum_build_setup = textwrap.dedent("""\
+        yum_build_setup = textwrap.dedent(
+            """\
 
             # Install the yum requirements defined canonically in the
             # "recipe/yum_requirements.txt" file. After updating that file,
             # run "conda smithy rerender" and this line will be updated
             # automatically.
-            /usr/bin/sudo -n yum install -y {}""".format(" ".join(requirements)))
+            /usr/bin/sudo -n yum install -y {}""".format(" ".join(requirements))
+        )
     return yum_build_setup
 
 

--- a/conda_smithy/linter/conda_recipe_v1_linter.py
+++ b/conda_smithy/linter/conda_recipe_v1_linter.py
@@ -61,8 +61,9 @@ def lint_recipe_tests(
                     has_outputs_test = True
                 else:
                     no_test_hints.append(
-                        "It looks like the '{}' output doesn't "
-                        "have any tests.".format(output.get("name", "???"))
+                        "It looks like the '{}' output doesn't have any tests.".format(
+                            output.get("name", "???")
+                        )
                     )
             if has_outputs_test:
                 hints.extend(no_test_hints)

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -417,9 +417,9 @@ def hint_space_separated_specs(
         }.items():
             bad_specs = [req for req in reqs if not _ensure_spec_space_separated(req)]
             if bad_specs:
-                report.setdefault(output.get("name", f"output {i}"), {})[
-                    req_type
-                ] = bad_specs
+                report.setdefault(output.get("name", f"output {i}"), {})[req_type] = (
+                    bad_specs
+                )
 
     lines = []
     for output, requirements in report.items():

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -237,7 +237,7 @@ def lint_license_should_not_have_license(about_section, lints):
         and "licenseref" not in license.lower()
         and "-license" not in license.lower()
     ):
-        lints.append("The recipe `license` should not include the word " '"License".')
+        lints.append('The recipe `license` should not include the word "License".')
 
 
 def lint_should_be_empty_line(meta_fname, lints):

--- a/conda_smithy/variant_algebra.py
+++ b/conda_smithy/variant_algebra.py
@@ -24,7 +24,9 @@ from conda_build.config import Config
 from conda_build.utils import ensure_list
 
 
-def parse_variant(variant_file_content: str, config: Optional[Config] = None) -> dict[
+def parse_variant(
+    variant_file_content: str, config: Optional[Config] = None
+) -> dict[
     str,
     Union[
         list[str],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,13 +34,13 @@ include-package-data = true
 write_to = "conda_smithy/_version.py"
 write_to_template = "__version__ = '{version}'"
 
-[tool.black]
-# matches black's default value
+[tool.ruff]
+# Mention default explicitly
 line-length = 88
 
 [tool.ruff.lint]
 ignore = [
-    "E501",  # https://docs.astral.sh/ruff/faq/#is-the-ruff-linter-compatible-with-black
+    "E501",  # line length is enforced by the formatter
     "E731",  # lambdas are useful
 ]
 select = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,7 +192,6 @@ def r_recipe(config_yaml: ConfigYAML):
         os.path.join(config_yaml.workdir, "recipe", config_yaml.recipe_name),
         "w",
     ) as fh:
-
         r_recipe_template_path = os.path.abspath(
             os.path.join(
                 __file__, "../", "recipes", "r_recipe", config_yaml.recipe_name

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,11 +62,13 @@ def test_init_with_custom_config(py_recipe):
     # expected args object has
 
     with open(os.path.join(recipe, "recipe", "conda-forge.yml"), "w") as fp:
-        fp.write(dedent("""\
+        fp.write(
+            dedent("""\
             bot:
               automerge: true
               run_deps_from_wheel: true
-            """))
+            """)
+        )
 
     args = InitArgs(
         recipe_directory=os.path.join(recipe, "recipe"),

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -793,11 +793,13 @@ def test_migrator_cfp_override(recipe_migration_cfep9, jinja_env):
     os.makedirs(cfp_migration_dir, exist_ok=True)
 
     with open(os.path.join(cfp_migration_dir, "zlib.yaml"), "w") as f:
-        f.write(textwrap.dedent("""
+        f.write(
+            textwrap.dedent("""
                 migrator_ts: 1
                 zlib:
                    - 1001
-                """))
+                """)
+        )
     render_func(
         jinja_env=jinja_env,
         forge_config=recipe_migration_cfep9.config,
@@ -2288,23 +2290,23 @@ def test_render_pixi(
     pixi = tomllib.loads(pixi_text)
 
     if not shellcheck:
-        assert (
-            "shellcheck" not in pixi_text
-        ), "pixi.toml should not mention `shellcheck`"
+        assert "shellcheck" not in pixi_text, (
+            "pixi.toml should not mention `shellcheck`"
+        )
     else:
         platforms = pixi["workspace"]["platforms"]
-        assert (
-            platform_without_shellcheck in platforms
-        ), f"expected {platform_without_shellcheck} in pixi workspace platforms"
-        assert (
-            "win-64" in platforms
-        ), "expected an aliased platform in pixi workspace platforms"
+        assert platform_without_shellcheck in platforms, (
+            f"expected {platform_without_shellcheck} in pixi workspace platforms"
+        )
+        assert "win-64" in platforms, (
+            "expected an aliased platform in pixi workspace platforms"
+        )
         shellcheck_platforms = pixi["feature"]["shellcheck"]["platforms"]
         smithy_env = pixi["environments"]["smithy"]
         assert shellcheck_platforms, "`shellcheck` should be enabled on _some_ platform"
-        assert (
-            platform_without_shellcheck not in shellcheck_platforms
-        ), f"`shellcheck` should not be enabled for {platform_without_shellcheck}"
+        assert platform_without_shellcheck not in shellcheck_platforms, (
+            f"`shellcheck` should not be enabled for {platform_without_shellcheck}"
+        )
 
         assert "shellcheck" in smithy_env, "`smithy` env should have `shellcheck`"
 
@@ -2318,12 +2320,14 @@ def test_configure_feedstock_rattler_build_conda_compat_round_trip():
     with tempfile.TemporaryDirectory() as tmpdir:
         fname = os.path.join(tmpdir, "variants.yaml")
         with open(fname, "w") as fp:
-            fp.write(textwrap.dedent("""
+            fp.write(
+                textwrap.dedent("""
                 varkey:
                 - "val1"
                 - 'val2'
                 - val
-                """))
+                """)
+            )
 
         cfg = parse_recipe_config_file(fname, {})
         assert "ruamel.yaml" in _dumps(cfg)
@@ -2442,14 +2446,16 @@ def test_store_build_artifacts_gha(py_recipe, jinja_env, path: str, value: bool)
     forge_yml = Path(forge_dir, "conda-forge.yml")
 
     with open(forge_yml, "a") as f:
-        f.write(textwrap.dedent(f"""\
+        f.write(
+            textwrap.dedent(f"""\
             provider:
               linux_64: github_actions
               osx_64: github_actions
               win_64: github_actions
             {path}:
               store_build_artifacts: {value}
-        """))
+        """)
+        )
 
     config = configure_feedstock._load_forge_config(
         forge_dir, "recipe/default_config.yaml"
@@ -2496,14 +2502,16 @@ def test_store_build_artifacts_azure(py_recipe, jinja_env, path: str, value: boo
     forge_yml = Path(forge_dir, "conda-forge.yml")
 
     with open(forge_yml, "a") as f:
-        f.write(textwrap.dedent(f"""\
+        f.write(
+            textwrap.dedent(f"""\
             provider:
               linux_64: azure
               osx_64: azure
               win_64: azure
             {path}:
               store_build_artifacts: {value}
-        """))
+        """)
+        )
 
     config = configure_feedstock._load_forge_config(
         forge_dir, "recipe/default_config.yaml"
@@ -2551,7 +2559,8 @@ def test_store_build_artifacts_duplicate_setting(py_recipe, jinja_env, ci: str):
     forge_yml = Path(forge_dir, "conda-forge.yml")
 
     with open(forge_yml, "a") as f:
-        f.write(textwrap.dedent(f"""\
+        f.write(
+            textwrap.dedent(f"""\
             provider:
               linux_64: azure
               osx_64: azure
@@ -2560,7 +2569,8 @@ def test_store_build_artifacts_duplicate_setting(py_recipe, jinja_env, ci: str):
               store_build_artifacts: true
             {ci}:
               store_build_artifacts: true
-        """))
+        """)
+        )
 
     with pytest.raises(
         ValueError,
@@ -2574,7 +2584,8 @@ def test_store_build_artifacts_gha_conditions(py_recipe, jinja_env):
     forge_yml = Path(forge_dir, "conda-forge.yml")
 
     with open(forge_yml, "a") as f:
-        f.write(textwrap.dedent("""\
+        f.write(
+            textwrap.dedent("""\
             provider:
               linux_64: github_actions
               linux_aarch64: github_actions
@@ -2587,7 +2598,8 @@ def test_store_build_artifacts_gha_conditions(py_recipe, jinja_env):
                   value: true
                 - os: osx
                   value: true
-        """))
+        """)
+        )
 
     config = configure_feedstock._load_forge_config(
         forge_dir, "recipe/default_config.yaml"
@@ -2629,7 +2641,8 @@ def test_store_build_artifacts_azure_conditions(py_recipe, jinja_env):
     forge_yml = Path(forge_dir, "conda-forge.yml")
 
     with open(forge_yml, "a") as f:
-        f.write(textwrap.dedent("""\
+        f.write(
+            textwrap.dedent("""\
             provider:
               linux_64: azure
               linux_aarch64: azure
@@ -2642,7 +2655,8 @@ def test_store_build_artifacts_azure_conditions(py_recipe, jinja_env):
                   value: true
                 - os: osx
                   value: true
-        """))
+        """)
+        )
 
     config = configure_feedstock._load_forge_config(
         forge_dir, "recipe/default_config.yaml"
@@ -2690,7 +2704,8 @@ def test_store_build_artifacts_overlapping_conditions(py_recipe, jinja_env, ci: 
     forge_yml = Path(forge_dir, "conda-forge.yml")
 
     with open(forge_yml, "a") as f:
-        f.write(textwrap.dedent(f"""\
+        f.write(
+            textwrap.dedent(f"""\
             provider:
               linux_64: {ci}
               osx_64: {ci}
@@ -2701,7 +2716,8 @@ def test_store_build_artifacts_overlapping_conditions(py_recipe, jinja_env, ci: 
                   value: true
                 - os: linux
                   value: true
-        """))
+        """)
+        )
 
     config = configure_feedstock._load_forge_config(
         forge_dir, "recipe/default_config.yaml"
@@ -2729,7 +2745,8 @@ def test_store_build_artifacts_gha_and_azure_conditions(py_recipe, jinja_env):
     forge_yml = Path(forge_dir, "conda-forge.yml")
 
     with open(forge_yml, "a") as f:
-        f.write(textwrap.dedent("""\
+        f.write(
+            textwrap.dedent("""\
             provider:
               linux_64: github_actions
               linux_aarch64: azure
@@ -2744,7 +2761,8 @@ def test_store_build_artifacts_gha_and_azure_conditions(py_recipe, jinja_env):
                 - os: linux
                   provider: github_actions
                   value: true
-        """))
+        """)
+        )
 
     config = configure_feedstock._load_forge_config(
         forge_dir, "recipe/default_config.yaml"

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -440,36 +440,46 @@ def test_cbc_osx_lints_variants_yaml(
                 fh.write(textwrap.dedent("c_stdlib_version:\n"))
 
                 if v_std is not None:
-                    fh.write(textwrap.dedent(f"""\
+                    fh.write(
+                        textwrap.dedent(f"""\
                             - if: {std_selector} and {arch1}
                               then: {v_std[0]}
-                        """))
+                        """)
+                    )
                 if v_std is not None and len(v_std) > 1:
-                    fh.write(textwrap.dedent(f"""\
+                    fh.write(
+                        textwrap.dedent(f"""\
                             - if: {std_selector} and {arch2}
                               then: {v_std[1]}
-                        """))
+                        """)
+                    )
                 if with_linux:
-                    fh.write(textwrap.dedent("""\
+                    fh.write(
+                        textwrap.dedent("""\
                             - if: linux
                               then: 2.17
-                        """))
+                        """)
+                    )
             if sdk is not None:
                 # often SDK is set uniformly for osx; test this as well
                 if len(sdk) == 2:
-                    fh.write(textwrap.dedent(f"""\
+                    fh.write(
+                        textwrap.dedent(f"""\
                             MACOSX_SDK_VERSION:
                               - if: osx and {"arm64" if reverse_arch[2] else "x86_64"}
                                 then: {sdk[0]}
                               - if: osx and {"x86_64" if reverse_arch[2] else "arm64"}
                                 then: {sdk[1]}
-                        """))
+                        """)
+                    )
                 else:
-                    fh.write(textwrap.dedent(f"""\
+                    fh.write(
+                        textwrap.dedent(f"""\
                             MACOSX_SDK_VERSION:
                               - if: osx
                                 then: {sdk[0]}
-                        """))
+                        """)
+                    )
         # run the linter
         lints = linter.main(recipe_dir, conda_forge=True)
         # show CBC/hints for debugging
@@ -2260,12 +2270,14 @@ class TestCliRecipeLint(unittest.TestCase):
     def test_cli_fail(self):
         with tmp_directory() as recipe_dir:
             with open(os.path.join(recipe_dir, "meta.yaml"), "w") as fh:
-                fh.write(textwrap.dedent("""
+                fh.write(
+                    textwrap.dedent("""
                     package:
                         name: 'test_package'
                     build: []
                     requirements: []
-                    """))
+                    """)
+                )
             child = subprocess.Popen(
                 ["conda-smithy", "recipe-lint", recipe_dir],
                 stdout=subprocess.PIPE,
@@ -2276,7 +2288,8 @@ class TestCliRecipeLint(unittest.TestCase):
     def test_cli_success(self):
         with tmp_directory() as recipe_dir:
             with open(os.path.join(recipe_dir, "meta.yaml"), "w") as fh:
-                fh.write(textwrap.dedent("""
+                fh.write(
+                    textwrap.dedent("""
                     package:
                         name: 'test_package'
                         version: 1.0.0
@@ -2294,7 +2307,8 @@ class TestCliRecipeLint(unittest.TestCase):
                         recipe-maintainers:
                             - a
                             - b
-                    """))
+                    """)
+                )
             child = subprocess.Popen(
                 ["conda-smithy", "recipe-lint", recipe_dir],
                 stdout=subprocess.PIPE,
@@ -2305,7 +2319,8 @@ class TestCliRecipeLint(unittest.TestCase):
     def test_cli_environ(self):
         with tmp_directory() as recipe_dir:
             with open(os.path.join(recipe_dir, "meta.yaml"), "w") as fh:
-                fh.write(textwrap.dedent("""
+                fh.write(
+                    textwrap.dedent("""
                     package:
                         name: 'test_package'
                         version: 1.0.0
@@ -2325,7 +2340,8 @@ class TestCliRecipeLint(unittest.TestCase):
                         recipe-maintainers:
                             - a
                             - b
-                    """))
+                    """)
+                )
             child = subprocess.Popen(
                 ["conda-smithy", "recipe-lint", recipe_dir],
                 stdout=subprocess.PIPE,
@@ -2401,7 +2417,8 @@ class TestCliRecipeLint(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as tmpdir:
             with open(os.path.join(tmpdir, "meta.yaml"), "w") as f:
-                f.write(textwrap.dedent("""
+                f.write(
+                    textwrap.dedent("""
                         package:
                           name: foo
                           version: 0
@@ -2427,7 +2444,8 @@ class TestCliRecipeLint(unittest.TestCase):
                           recipe-maintainers:
                             - a
                             - b
-                        """))
+                        """)
+                )
 
             open(os.path.join(tmpdir, "conda_build_config.yaml"), "w").close()
 
@@ -2477,18 +2495,22 @@ def test_lint_duplicate_cfyml():
                 """)
 
         with open(cfyml, "w") as fh:
-            fh.write(textwrap.dedent("""
+            fh.write(
+                textwrap.dedent("""
                     blah: 1
                     blah: 2
-                    """))
+                    """)
+            )
 
         lints = linter.main(recipe_dir, conda_forge=True)
         assert any(lint.startswith(expected_message) for lint in lints)
 
         with open(cfyml, "w") as fh:
-            fh.write(textwrap.dedent("""
+            fh.write(
+                textwrap.dedent("""
                     blah: 1
-                    """))
+                    """)
+            )
 
         lints = linter.main(recipe_dir, conda_forge=True)
         assert not any(lint.startswith(expected_message) for lint in lints)
@@ -2510,10 +2532,12 @@ def test_cfyml_wrong_os_version():
                 """)
 
         with open(cfyml, "w") as fh:
-            fh.write(textwrap.dedent("""
+            fh.write(
+                textwrap.dedent("""
                     os_version:
                       linux_64: wrong
-                    """))
+                    """)
+            )
 
         lints = linter.main(recipe_dir, conda_forge=True)
         assert any(expected_message in lint for lint in lints)
@@ -3899,7 +3923,8 @@ extra:
 def test_lint_recipe_parses_ok():
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "meta.yaml"), "w") as f:
-            f.write(textwrap.dedent("""
+            f.write(
+                textwrap.dedent("""
                     package:
                       name: foo
 
@@ -3920,7 +3945,8 @@ def test_lint_recipe_parses_ok():
                       recipe-maintainers:
                         - a
                         - b
-                    """))
+                    """)
+            )
         lints, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
         assert not any(
             lint.startswith(
@@ -3936,7 +3962,8 @@ def test_lint_recipe_parses_ok():
 def test_lint_recipe_parses_forblock():
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "meta.yaml"), "w") as f:
-            f.write(textwrap.dedent("""
+            f.write(
+                textwrap.dedent("""
                     package:
                       name: foo
                     build:
@@ -3955,7 +3982,8 @@ def test_lint_recipe_parses_forblock():
                       recipe-maintainers:
                           - a
                           - b
-                    """))
+                    """)
+            )
         lints, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
         assert not any(
             lint.startswith(
@@ -3976,7 +4004,8 @@ def test_lint_recipe_parses_forblock():
 def test_lint_recipe_parses_spacing():
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "meta.yaml"), "w") as f:
-            f.write(textwrap.dedent("""
+            f.write(
+                textwrap.dedent("""
                     package:
                       name: foo
                     build:
@@ -3993,7 +4022,8 @@ def test_lint_recipe_parses_spacing():
                       recipe-maintainers:
                           - a
                           - b
-                    """))
+                    """)
+            )
         lints, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
         assert not any(
             lint.startswith(
@@ -4020,7 +4050,8 @@ def test_lint_recipe_parses_spacing():
 def test_lint_recipe_parses_v1_spacing():
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:
-            f.write(textwrap.dedent("""
+            f.write(
+                textwrap.dedent("""
                     package:
                       name: blah
 
@@ -4037,7 +4068,8 @@ def test_lint_recipe_parses_v1_spacing():
                       recipe-maintainers:
                         - a
                         - b
-                    """))
+                    """)
+            )
         lints, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
         assert not any(
             lint.startswith(
@@ -4057,7 +4089,8 @@ def test_lint_recipe_parses_v1_duplicate_keys():
     """
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:
-            f.write(textwrap.dedent("""
+            f.write(
+                textwrap.dedent("""
                     package:
                       name: blah
 
@@ -4075,7 +4108,8 @@ def test_lint_recipe_parses_v1_duplicate_keys():
                       recipe-maintainers:
                         - a
                         - b
-                    """))
+                    """)
+            )
         lints, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
         assert any(
             lint.startswith(
@@ -4098,12 +4132,14 @@ def test_lint_recipe_parses_v1_duplicate_keys():
 def test_lint_recipe_v1_invalid_schema_version():
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:
-            f.write(textwrap.dedent("""
+            f.write(
+                textwrap.dedent("""
                     schema_version: 2
 
                     package:
                       name: blah
-                    """))
+                    """)
+            )
         lints, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
         assert lints == ["Unsupported recipe.yaml schema version 2"]
 
@@ -4167,7 +4203,8 @@ def test_lint_recipe_v1_python_min_in_python_version(text):
 def test_lint_recipe_v1_comment_selectors():
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:
-            f.write(textwrap.dedent("""
+            f.write(
+                textwrap.dedent("""
                 package:
                   name: test
                   version: 1.2.3
@@ -4199,7 +4236,8 @@ def test_lint_recipe_v1_comment_selectors():
                 extra:
                   recipe-maintainers:
                     - a
-                """))
+                """)
+            )
         lints, _ = linter.main(tmpdir, return_hints=True, conda_forge=True)
         assert lints == [
             "Selectors in comment form no longer work in v1 recipes. "
@@ -4212,11 +4250,13 @@ def test_lint_recipe_v1_comment_selectors():
 def test_version_zero(filename: str):
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, filename), "w") as f:
-            f.write(textwrap.dedent("""
+            f.write(
+                textwrap.dedent("""
                 package:
                   name: test
                   version: 0
-                """))
+                """)
+            )
         lints, _ = linter.main(tmpdir, return_hints=True, conda_forge=True)
         assert "Package version is missing." not in lints
 
@@ -4256,7 +4296,8 @@ def test_bad_specs(spec, result):
     ],
 )
 def test_bad_specs_report(tmp_path, spec, ok):
-    (tmp_path / "meta.yaml").write_text(textwrap.dedent(f"""
+    (tmp_path / "meta.yaml").write_text(
+        textwrap.dedent(f"""
             package:
                 name: foo
             requirements:
@@ -4267,7 +4308,8 @@ def test_bad_specs_report(tmp_path, spec, ok):
                 requirements:
                   host:
                     - {spec}
-            """))
+            """)
+    )
 
     _, hints = linter.main(tmp_path, return_hints=True)
     print(hints)
@@ -4391,10 +4433,12 @@ def test_cfyml_obsolete_os_version():
                 """)
 
         with open(cfyml, "w") as fh:
-            fh.write(textwrap.dedent("""
+            fh.write(
+                textwrap.dedent("""
                     os_version:
                       linux_64: cos7
-                    """))
+                    """)
+            )
 
         _, hints = linter.main(recipe_dir, conda_forge=True, return_hints=True)
         assert any(expected_message in hint for hint in hints)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -312,11 +312,13 @@ def test_schema_with_rattler_build_conda_compat():
     with tempfile.TemporaryDirectory() as tmpdir:
         pth = os.path.join(tmpdir, "conda-forge.yml")
         with open(pth, "w") as fp:
-            fp.write(textwrap.dedent("""\
+            fp.write(
+                textwrap.dedent("""\
                 bot:
                 version_updates:
                     random_fraction_to_keep: 0.02
-                """))
+                """)
+            )
         with open(pth) as fp:
             cfyaml = get_yaml().load(fp)
 

--- a/tests/test_variant_algebra.py
+++ b/tests/test_variant_algebra.py
@@ -58,12 +58,15 @@ def test_add():
 
 
 def test_ordering():
-    start = parse_variant(dedent("""\
+    start = parse_variant(
+        dedent("""\
     c_compiler:
         - toolchain
-    """))
+    """)
+    )
 
-    mig_compiler = parse_variant(dedent("""\
+    mig_compiler = parse_variant(
+        dedent("""\
     __migrator:
         ordering:
             c_compiler:
@@ -71,7 +74,8 @@ def test_ordering():
                 - gcc
     c_compiler:
         - gcc
-    """))
+    """)
+    )
 
     res = variant_add(start, mig_compiler)
     assert res["c_compiler"] == ["gcc"]
@@ -79,13 +83,16 @@ def test_ordering():
 
 def test_ordering_with_tail():
     # c.f. https://github.com/conda-forge/conda-smithy/issues/2331
-    start = parse_variant(dedent("""\
+    start = parse_variant(
+        dedent("""\
     cuda_compiler_version:
         - "None"
         - "12.6"
-    """))
+    """)
+    )
 
-    cuda_migrator = parse_variant(dedent("""\
+    cuda_migrator = parse_variant(
+        dedent("""\
     __migrator:
         ordering:
             cuda_compiler_version:
@@ -94,7 +101,8 @@ def test_ordering_with_tail():
                 - "12.9"
     cuda_compiler_version:
         - "12.9"
-    """))
+    """)
+    )
 
     res = variant_add(start, cuda_migrator)
     assert res["cuda_compiler_version"] == ["None", "12.9"]
@@ -105,7 +113,8 @@ def test_ordering_with_primary_key(gcc_for_12dot6):
     # ensure that GCC pins matching the respective CUDA versions get merged
     # correctly; the GCC pin for 12.6 should never get picked since that CUDA
     # version gets dropped in the merge of the primary keys (based on ordering).
-    start = parse_variant(dedent(f"""\
+    start = parse_variant(
+        dedent(f"""\
     cuda_compiler_version:
         - "None"
         - "12.6"
@@ -115,9 +124,11 @@ def test_ordering_with_primary_key(gcc_for_12dot6):
     zip_keys:
         - - c_compiler_version
           - cuda_compiler_version
-    """))
+    """)
+    )
 
-    cuda_migrator = parse_variant(dedent("""\
+    cuda_migrator = parse_variant(
+        dedent("""\
     __migrator:
         primary_key: cuda_compiler_version
         ordering:
@@ -129,7 +140,8 @@ def test_ordering_with_primary_key(gcc_for_12dot6):
         - "12.9"
     c_compiler_version:
         - "14"
-    """))
+    """)
+    )
 
     res = variant_add(start, cuda_migrator)
     assert res["cuda_compiler_version"] == ["None", "12.9"]
@@ -142,7 +154,8 @@ def test_ordering_with_tail_and_readd(initial_min):
     # while also allowing an opt-in migrator to re-add CUDA 11.8, see
     # https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7472
     # since CUDA for PPC was removed, need to handle cuda_compiler_version_min == "None"
-    start = parse_variant(dedent(f"""\
+    start = parse_variant(
+        dedent(f"""\
     cuda_compiler:
         - cuda-nvcc
     cuda_compiler_version:
@@ -150,9 +163,11 @@ def test_ordering_with_tail_and_readd(initial_min):
         - "12.6"
     cuda_compiler_version_min:
         - "{initial_min}"
-    """))
+    """)
+    )
 
-    cuda129_migrator = parse_variant(dedent("""\
+    cuda129_migrator = parse_variant(
+        dedent("""\
     __migrator:
         ordering:
             cuda_compiler_version:
@@ -162,9 +177,11 @@ def test_ordering_with_tail_and_readd(initial_min):
                 - "11.8"
     cuda_compiler_version:
         - "12.9"
-    """))
+    """)
+    )
 
-    cuda118_migrator = parse_variant(dedent("""\
+    cuda118_migrator = parse_variant(
+        dedent("""\
     __migrator:
         operation: key_add
         primary_key: cuda_compiler_version
@@ -191,7 +208,8 @@ def test_ordering_with_tail_and_readd(initial_min):
         - "11.8"
     cuda_compiler:
         - nvcc
-    """))
+    """)
+    )
 
     res = variant_add(start, cuda129_migrator)
     res2 = variant_add(res, cuda118_migrator)
@@ -206,7 +224,8 @@ def test_ordering_with_coinciding_pk():
     # cannot be the primary key, because it needs to be zipped into `cuda_compiler_version`).
     # therefore, this tests that uniqueness a new _set_ of values across the relevant zip_keys
     # will still be inserted, not discarded
-    start = parse_variant(dedent("""\
+    start = parse_variant(
+        dedent("""\
     cuda_compiler:
         - cuda-nvcc
     cuda_compiler_version:
@@ -215,9 +234,11 @@ def test_ordering_with_coinciding_pk():
     # does not participate in first two migrations!
     arm_variant_type:
         - "sbsa"
-    """))
+    """)
+    )
 
-    cuda129_migrator = parse_variant(dedent("""\
+    cuda129_migrator = parse_variant(
+        dedent("""\
     __migrator:
         ordering:
             cuda_compiler_version:
@@ -227,9 +248,11 @@ def test_ordering_with_coinciding_pk():
                 - "11.8"
     cuda_compiler_version:
         - "12.9"
-    """))
+    """)
+    )
 
-    cuda130_migrator = parse_variant(dedent("""\
+    cuda130_migrator = parse_variant(
+        dedent("""\
     __migrator:
         operation: key_add
         primary_key: cuda_compiler_version
@@ -241,9 +264,11 @@ def test_ordering_with_coinciding_pk():
                 - "13.0"
     cuda_compiler_version:
         - "13.0"
-    """))
+    """)
+    )
 
-    tegra_migrator = parse_variant(dedent("""\
+    tegra_migrator = parse_variant(
+        dedent("""\
     __migrator:
         operation: key_add
         primary_key: cuda_compiler_version
@@ -259,7 +284,8 @@ def test_ordering_with_coinciding_pk():
         - "12.9"
     arm_variant_type:
         - "tegra"
-    """))
+    """)
+    )
 
     res = variant_add(start, cuda129_migrator)
     res2 = variant_add(res, cuda130_migrator)
@@ -271,7 +297,8 @@ def test_ordering_with_coinciding_pk():
 @pytest.mark.parametrize("initial_min", ["12.6", "None"])
 def test_fail_on_missing_zip_component(initial_min):
     # since CUDA for PPC was removed, need to handle cuda_compiler_version_min == "None"
-    start = parse_variant(dedent(f"""\
+    start = parse_variant(
+        dedent(f"""\
     cuda_compiler:
         - cuda-nvcc
     cuda_compiler_version:
@@ -285,11 +312,13 @@ def test_fail_on_missing_zip_component(initial_min):
     zip_keys:
         - - cuda_compiler_version
           - c_stdlib_version
-    """))
+    """)
+    )
 
     # if this migrator is missing c_stdlib_version, the migration should not be
     # insert `c_stdlib_version: None` silently, but the rerender needs to fail
-    cuda118_migrator = parse_variant(dedent("""\
+    cuda118_migrator = parse_variant(
+        dedent("""\
     __migrator:
         operation: key_add
         primary_key: cuda_compiler_version
@@ -319,19 +348,23 @@ def test_fail_on_missing_zip_component(initial_min):
     # commented out intentionally!
     # c_stdlib_version:
     #     - "2.17"
-    """))
+    """)
+    )
 
     with pytest.raises(ValueError):
         variant_add(start, cuda118_migrator)
 
 
 def test_no_ordering():
-    start = parse_variant(dedent("""\
+    start = parse_variant(
+        dedent("""\
     xyz:
         - 1
-    """))
+    """)
+    )
 
-    mig_compiler = parse_variant(dedent("""\
+    mig_compiler = parse_variant(
+        dedent("""\
     __migrator:
         kind:
             version
@@ -339,19 +372,23 @@ def test_no_ordering():
             1
     xyz:
         - 2
-    """))
+    """)
+    )
 
     res = variant_add(start, mig_compiler)
     assert res["xyz"] == ["2"]
 
 
 def test_ordering_downgrade():
-    start = parse_variant(dedent("""\
+    start = parse_variant(
+        dedent("""\
     jpeg:
         - 3.0
-    """))
+    """)
+    )
 
-    mig_compiler = parse_variant(dedent("""\
+    mig_compiler = parse_variant(
+        dedent("""\
     __migrator:
         ordering:
             jpeg:
@@ -359,43 +396,52 @@ def test_ordering_downgrade():
                 - 2.0
     jpeg:
         - 2.0
-    """))
+    """)
+    )
 
     res = variant_add(start, mig_compiler)
     assert res["jpeg"] == ["2.0"]
 
 
 def test_ordering_space():
-    start = parse_variant(dedent("""\
+    start = parse_variant(
+        dedent("""\
     python:
         - 2.7
-    """))
+    """)
+    )
 
-    mig_compiler = parse_variant(dedent("""\
+    mig_compiler = parse_variant(
+        dedent("""\
     python:
         - 2.7 *_cpython
-    """))
+    """)
+    )
 
     res = variant_add(start, mig_compiler)
     assert res["python"] == ["2.7 *_cpython"]
 
 
 def test_new_pinned_package():
-    start = parse_variant(dedent("""\
+    start = parse_variant(
+        dedent("""\
     pin_run_as_build:
         jpeg:
             max_pin: x
     jpeg:
         - 3.0
-    """))
+    """)
+    )
 
-    mig_compiler = parse_variant(dedent("""\
+    mig_compiler = parse_variant(
+        dedent("""\
     pin_run_as_build:
         gprc-cpp:
             max_pin: x.x
     gprc-cpp:
         - 1.23
-    """))
+    """)
+    )
 
     res = variant_add(start, mig_compiler)
     assert res["gprc-cpp"] == ["1.23"]
@@ -403,7 +449,8 @@ def test_new_pinned_package():
 
 
 def test_zip_keys():
-    start = parse_variant(dedent("""\
+    start = parse_variant(
+        dedent("""\
     zip_keys:
         -
             - vc
@@ -411,9 +458,11 @@ def test_zip_keys():
         -
             - qt
             - pyqt
-    """))
+    """)
+    )
 
-    mig_compiler = parse_variant(dedent("""\
+    mig_compiler = parse_variant(
+        dedent("""\
     zip_keys:
         -
             - python
@@ -422,7 +471,8 @@ def test_zip_keys():
         -
             - root
             - c_compiler
-    """))
+    """)
+    )
 
     res = variant_add(start, mig_compiler)
 
@@ -431,7 +481,8 @@ def test_zip_keys():
 
 
 def test_migrate_windows_compilers():
-    start = parse_variant(dedent("""
+    start = parse_variant(
+        dedent("""
         c_compiler:
             - vs2008
             - vs2015
@@ -441,16 +492,19 @@ def test_migrate_windows_compilers():
         zip_keys:
             - - vc
               - c_compiler
-        """))
+        """)
+    )
 
-    mig = parse_variant(dedent("""
+    mig = parse_variant(
+        dedent("""
         c_compiler:
             - vs2008
             - vs2017
         vc:
             - '9'
             - '14.1'
-        """))
+        """)
+    )
 
     res = variant_add(start, mig)
 
@@ -460,21 +514,25 @@ def test_migrate_windows_compilers():
 
 
 def test_pin_run_as_build():
-    start = parse_variant(dedent("""\
+    start = parse_variant(
+        dedent("""\
     pin_run_as_build:
         python:
             max_pin: x.x
         boost-cpp:
             max_pin: x
-    """))
+    """)
+    )
 
-    mig_compiler = parse_variant(dedent("""\
+    mig_compiler = parse_variant(
+        dedent("""\
     pin_run_as_build:
         boost-cpp:
             max_pin: x.x
         rust:
             max_pin: x
-    """))
+    """)
+    )
 
     res = variant_add(start, mig_compiler)
 
@@ -483,7 +541,8 @@ def test_pin_run_as_build():
 
 def test_py39_migration():
     """Test that running the python 3.9 keyadd migrator has the desired effect."""
-    base = parse_variant(dedent("""
+    base = parse_variant(
+        dedent("""
             python:
               - 3.6.* *_cpython    # [not (osx and arm64)]
               - 3.7.* *_cpython    # [not (osx and arm64)]
@@ -497,9 +556,11 @@ def test_py39_migration():
                 - cuda_compiler_version     # ["linux-64"]
                 - docker_image              # ["linux-64"]
 
-            """))
+            """)
+    )
 
-    migration_pypy = parse_variant(dedent("""
+    migration_pypy = parse_variant(
+        dedent("""
     python:
       - 3.6.* *_cpython   # [not (osx and arm64)]
       - 3.7.* *_cpython   # [not (osx and arm64)]
@@ -524,9 +585,11 @@ def test_py39_migration():
         - python
         - numpy
         - python_impl
-    """))
+    """)
+    )
 
-    migration_py39 = parse_variant(dedent("""
+    migration_py39 = parse_variant(
+        dedent("""
         __migrator:
             operation: key_add
             primary_key: python
@@ -544,7 +607,8 @@ def test_py39_migration():
           - 1.100
         python_impl:
           - cpython
-        """))
+        """)
+    )
 
     res = variant_add(base, migration_pypy)
     res2 = variant_add(res, migration_py39)
@@ -572,7 +636,8 @@ def test_py39_migration():
 
 def test_multiple_key_add_migration():
     """Test that running the python 3.9 keyadd migrator has the desired effect."""
-    base = parse_variant(dedent("""
+    base = parse_variant(
+        dedent("""
             python:
               - 3.6.* *_cpython    # [not (osx and arm64)]
               - 3.7.* *_cpython    # [not (osx and arm64)]
@@ -586,9 +651,11 @@ def test_multiple_key_add_migration():
                 - cuda_compiler_version     # ["linux-64"]
                 - docker_image              # ["linux-64"]
 
-            """))
+            """)
+    )
 
-    migration_pypy = parse_variant(dedent("""
+    migration_pypy = parse_variant(
+        dedent("""
     python:
       - 3.6.* *_cpython   # [not (osx and arm64)]
       - 3.7.* *_cpython   # [not (osx and arm64)]
@@ -613,9 +680,11 @@ def test_multiple_key_add_migration():
         - python
         - numpy
         - python_impl
-    """))
+    """)
+    )
 
-    migration_py39 = parse_variant(dedent("""
+    migration_py39 = parse_variant(
+        dedent("""
         __migrator:
             operation: key_add
             primary_key: python
@@ -637,7 +706,8 @@ def test_multiple_key_add_migration():
         python_impl:
           - cpython
           - cpython
-        """))
+        """)
+    )
 
     res = variant_add(base, migration_pypy)
     res2 = variant_add(res, migration_py39)
@@ -666,7 +736,8 @@ def test_multiple_key_add_migration():
 
 
 def test_variant_key_remove():
-    base = parse_variant(dedent("""
+    base = parse_variant(
+        dedent("""
     python:
       - 3.6.* *_cpython
       - 3.8.* *_cpython
@@ -684,8 +755,10 @@ def test_variant_key_remove():
         - python
         - numpy
         - python_impl
-    """))
-    removal = parse_variant(dedent("""
+    """)
+    )
+    removal = parse_variant(
+        dedent("""
             __migrator:
                 operation: key_remove
                 primary_key: python
@@ -698,7 +771,8 @@ def test_variant_key_remove():
                         - 3.9.* *_cpython
             python:
               - 3.6.* *_cpython
-            """))
+            """)
+    )
 
     res = variant_add(base, removal)
 
@@ -778,7 +852,8 @@ def test_variant_remove_add(platform, arch):
         config=config,
     )
 
-    add_py39 = parse_variant(dedent("""
+    add_py39 = parse_variant(
+        dedent("""
         __migrator:
             operation: key_add
             primary_key: python
@@ -789,7 +864,8 @@ def test_variant_remove_add(platform, arch):
           - 1.100
         python_impl:
           - cpython
-        """))
+        """)
+    )
 
     res = variant_add(base, remove)
     res = variant_add(res, add)


### PR DESCRIPTION
cc @jaimergp 

This PR changes from `black` to `ruff format`.

What's not included is the result of running this which will create a large diff with `dedent()` calls:
```bash
ruff format .
```
