### PR TITLE
[PyCon DE Sprints] Bump minimum Python version to 3.11

### DIFF
--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -1,8 +1,8 @@
 import copy
 import os
 import re
-import sys
 import time
+import tomllib
 from collections.abc import Mapping, Sequence
 from functools import lru_cache
 from glob import glob
@@ -15,11 +15,6 @@ from conda_build.metadata import (
 )
 from rattler_build_conda_compat import loader as rattler_loader
 from rattler_build_conda_compat.recipe_sources import get_all_sources
-
-if sys.version_info[:2] < (3, 11):
-    import tomli as tomllib
-else:
-    import tomllib
 
 FIELDS = copy.deepcopy(_CONDA_BUILD_FIELDS)
 

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -4,7 +4,7 @@
 # To regenerate conda_smithy/data/conda-forge.{json,yml}, run `python -m conda_smithy.schema` in the repo root.
 
 import json
-from enum import Enum
+from enum import Enum, StrEnum
 from functools import lru_cache
 from inspect import cleandoc
 from typing import Annotated, Any, Literal, Optional, Union
@@ -12,12 +12,6 @@ from typing import Annotated, Any, Literal, Optional, Union
 import yaml
 from conda.base.constants import KNOWN_SUBDIRS
 from pydantic import BaseModel, ConfigDict, Field, WithJsonSchema, create_model
-
-try:
-    from enum import StrEnum
-except ImportError:
-    from backports.strenum import StrEnum
-
 
 # use relative imports to ensure that we don't pick up the data paths from
 # a non-development conda-smithy installed in site-packages

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python>=3.6
+  - python>=3.11
   # Development dependencies
   - pip
   - python-build

--- a/environment.yml
+++ b/environment.yml
@@ -38,7 +38,6 @@ dependencies:
   - pydantic >=2.11,<3
   - pixi >=0.59.0
   - jsonschema
-  - backports.strenum
   - exceptiongroup
   # py-rattler's API subject to change, pin to minor
   - py-rattler >=0.22,<0.23

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,6 @@ dependencies:
   - python-build
   - setuptools>=45
   - setuptools_scm>=8.1
-  - tomli>=1.0.0
   - pre-commit
   - mock
   - pytest

--- a/news/2523-bump-python-to-311.rst
+++ b/news/2523-bump-python-to-311.rst
@@ -1,0 +1,3 @@
+**Changed:**
+
+* Bump minimum Python version to 3.11. (#2523)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ line-length = 88
 ignore = [
     "E501",  # https://docs.astral.sh/ruff/faq/#is-the-ruff-linter-compatible-with-black
     "E731",  # lambdas are useful
+    # part of migration to Python 3.11, to be resolved in a separate PR
+    "UP007",  # `typing.Union[A, B]` -> `A | B`
+    "UP045",  # `typing.Optional[A]` -> `A | None`
 ]
 select = [
     # pyflakes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 description = "A package to create repositories for conda recipes, and automate their building with CI tools on Linux, OSX and Windows."
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 
 [project.urls]
 home = "https://github.com/conda-forge/conda-smithy"

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -4,9 +4,9 @@ import logging
 import os
 import re
 import shutil
-import sys
 import tempfile
 import textwrap
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -21,11 +21,6 @@ from conda_smithy.configure_feedstock import (
     _read_forge_config,
 )
 from conda_smithy.utils import ensure_standard_strings
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
 
 
 def test_platforms_populated():


### PR DESCRIPTION
Implicitly, this is already the case due to the [dependency](https://github.com/conda-forge/conda-recipe-manager-feedstock/blob/5f21af50abf9a72f79b0b79e3bb89a9f9919520c/recipe/meta.yaml#L3) on 'conda-recipe-manager>=0.9'. Also:

* Remove dependency `tomli` (Python 3.11 includes `tomllib`)
* Remove dependency `backports.strenum` (Python 3.11 includes `enum.StrEnum`)
* Disable ruff rules `UP007` and `UP045` (deferred to another PR to keep this one short and focused)
    * [UP007](https://docs.astral.sh/ruff/rules/non-pep604-annotation-union/): `typing.Union[A, B]` -> `A | B`
    * [UP045](https://docs.astral.sh/ruff/rules/non-pep604-annotation-optional/): `typing.Optional[A]` -> `A | None`

Checklist
* [x] Added a ``news`` entry
* [x] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)