### PR TITLE
Use `CONDA_BLD_PATH` consistently in templates

### DIFF
--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -101,12 +101,12 @@ jobs:
         export CI=azure
         export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
         export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
-        export CONDA_BLD_DIR=build_artifacts
+        export CONDA_BLD_PATH=build_artifacts
         export ARTIFACT_STAGING_DIR="$(Build.ArtifactStagingDirectory)"
-        # Archive everything in CONDA_BLD_DIR except environments
+        # Archive everything in CONDA_BLD_PATH except environments
         export BLD_ARTIFACT_PREFIX=conda_artifacts
         if [[ "$AGENT_JOBSTATUS" == "Failed" ]]; then
-          # Archive the CONDA_BLD_DIR environments only when the job fails
+          # Archive the CONDA_BLD_PATH environments only when the job fails
           export ENV_ARTIFACT_PREFIX=conda_envs
         fi
         ./.scripts/create_conda_build_artifacts.sh

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -47,12 +47,12 @@ jobs:
       export CI=azure
       export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
       export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
-      export CONDA_BLD_DIR=/Users/runner/miniforge3/conda-bld
+      export CONDA_BLD_PATH=/Users/runner/miniforge3/conda-bld
       export ARTIFACT_STAGING_DIR="$(Build.ArtifactStagingDirectory)"
-      # Archive everything in CONDA_BLD_DIR except environments
+      # Archive everything in CONDA_BLD_PATH except environments
       export BLD_ARTIFACT_PREFIX=conda_artifacts
       if [[ "$AGENT_JOBSTATUS" == "Failed" ]]; then
-        # Archive the CONDA_BLD_DIR environments only when the job fails
+        # Archive the CONDA_BLD_PATH environments only when the job fails
         export ENV_ARTIFACT_PREFIX=conda_envs
       fi
       ./.scripts/create_conda_build_artifacts.sh

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -84,7 +84,7 @@ jobs:
         set CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
         set FEEDSTOCK_NAME=$(build.Repository.Name)
         set ARTIFACT_STAGING_DIR=$(Build.ArtifactStagingDirectory)
-        set CONDA_BLD_DIR=$(CONDA_BLD_PATH)
+        set CONDA_BLD_PATH=$(CONDA_BLD_PATH)
         set BLD_ARTIFACT_PREFIX=conda_artifacts
         if "%AGENT_JOBSTATUS%" == "Failed" (
             set ENV_ARTIFACT_PREFIX=conda_envs

--- a/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
@@ -7,7 +7,7 @@ rem CI_RUN_ID (unique identifier for the CI job run)
 rem FEEDSTOCK_NAME
 rem CONFIG (build matrix configuration string)
 rem SHORT_CONFIG (uniquely-shortened configuration string)
-rem CONDA_BLD_DIR (path to the conda-bld directory)
+rem CONDA_BLD_PATH (path to the conda-bld directory)
 rem ARTIFACT_STAGING_DIR (use working directory if unset)
 rem BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
 rem ENV_ARTIFACT_PREFIX (prefix for the conda build environments artifact name, skip if unset)
@@ -20,7 +20,7 @@ rem ENV_ARTIFACT_NAME
 rem ENV_ARTIFACT_PATH
 
 rem Check that the conda-build directory exists
-if not exist %CONDA_BLD_DIR% (
+if not exist %CONDA_BLD_PATH% (
     echo conda-build directory does not exist
     exit 1
 )
@@ -42,7 +42,7 @@ if defined BLD_ARTIFACT_PREFIX (
     echo BLD_ARTIFACT_NAME: !BLD_ARTIFACT_NAME!
 
     set "BLD_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%BLD_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.zip"
-    7z a "!BLD_ARTIFACT_PATH!" "%CONDA_BLD_DIR%" -xr^^!.git/ -xr^^!_*_env*/ -xr^^!*_cache/ -bb
+    7z a "!BLD_ARTIFACT_PATH!" "%CONDA_BLD_PATH%" -xr^^!.git/ -xr^^!_*_env*/ -xr^^!*_cache/ -bb
     if errorlevel 1 exit 1
     echo BLD_ARTIFACT_PATH: !BLD_ARTIFACT_PATH!
 
@@ -62,7 +62,7 @@ if defined ENV_ARTIFACT_PREFIX (
     echo ENV_ARTIFACT_NAME: !ENV_ARTIFACT_NAME!
 
     set "ENV_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%ENV_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.zip"
-    7z a "!ENV_ARTIFACT_PATH!" -r "%CONDA_BLD_DIR%"/_*_env*/ -bb
+    7z a "!ENV_ARTIFACT_PATH!" -r "%CONDA_BLD_PATH%"/_*_env*/ -bb
     if errorlevel 1 exit 1
     echo ENV_ARTIFACT_PATH: !ENV_ARTIFACT_PATH!
 

--- a/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
@@ -7,7 +7,7 @@
 # FEEDSTOCK_NAME
 # CONFIG (build matrix configuration string)
 # SHORT_CONFIG (uniquely-shortened configuration string)
-# CONDA_BLD_DIR (path to the conda-bld directory)
+# CONDA_BLD_PATH (path to the conda-bld directory)
 # ARTIFACT_STAGING_DIR (use working directory if unset)
 # BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
 # ENV_ARTIFACT_PREFIX (prefix for the conda build environments artifact name, skip if unset)
@@ -26,7 +26,7 @@ source .scripts/logging_utils.sh
 set -e
 
 # Check that the conda-build directory exists
-if [ ! -d "$CONDA_BLD_DIR" ]; then
+if [ ! -d "$CONDA_BLD_PATH" ]; then
     echo "conda-build directory does not exist"
     exit 1
 fi
@@ -64,8 +64,8 @@ if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
     ( startgroup "Archive conda build directory" ) 2> /dev/null
 
     # Try 7z and fall back to zip if it fails (for cross-platform use)
-    if ! 7z a "$BLD_ARTIFACT_PATH" "$CONDA_BLD_DIR" '-xr!.git/' '-xr!_*_env*/' '-xr!*_cache/' -bb; then
-        pushd "$CONDA_BLD_DIR"
+    if ! 7z a "$BLD_ARTIFACT_PATH" "$CONDA_BLD_PATH" '-xr!.git/' '-xr!_*_env*/' '-xr!*_cache/' -bb; then
+        pushd "$CONDA_BLD_PATH"
         zip -r -y -T "$BLD_ARTIFACT_PATH" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
         popd
     fi
@@ -92,8 +92,8 @@ if [[ ! -z "$ENV_ARTIFACT_PREFIX" ]]; then
     ( startgroup "Archive conda build environments" ) 2> /dev/null
 
     # Try 7z and fall back to zip if it fails (for cross-platform use)
-    if ! 7z a "$ENV_ARTIFACT_PATH" -r "$CONDA_BLD_DIR"/'_*_env*/' -bb; then
-        pushd "$CONDA_BLD_DIR"
+    if ! 7z a "$ENV_ARTIFACT_PATH" -r "$CONDA_BLD_PATH"/'_*_env*/' -bb; then
+        pushd "$CONDA_BLD_PATH"
         zip -r -y -T "$ENV_ARTIFACT_PATH" . -i '*_*_env*/*'
         popd
     fi

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -208,7 +208,7 @@ jobs:
       env:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
+        CONDA_BLD_PATH: C:\bld
         MINIFORGE_HOME: {% raw %}${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}{% endraw %}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
@@ -261,15 +261,15 @@ jobs:
         export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
         export ARTIFACT_STAGING_DIR="$GITHUB_WORKSPACE"
         if [ $OS == "macos" ]; then
-          export CONDA_BLD_DIR="${MINIFORGE_HOME:-${HOME}/miniforge3}/conda-bld"
+          export CONDA_BLD_PATH="${MINIFORGE_HOME:-${HOME}/miniforge3}/conda-bld"
         elif [ $OS == "windows" ]; then
           # this needs to be consistent with build step, see above
-          export CONDA_BLD_DIR="C:\\bld"
+          export CONDA_BLD_PATH="C:\\bld"
         else
-          export CONDA_BLD_DIR="build_artifacts"
+          export CONDA_BLD_PATH="build_artifacts"
         fi
-        # Archive everything in CONDA_BLD_DIR except environments
-        # Archive the CONDA_BLD_DIR environments only when the job fails
+        # Archive everything in CONDA_BLD_PATH except environments
+        # Archive the CONDA_BLD_PATH environments only when the job fails
         # Use different prefix for successful and failed build artifacts
         # so random failures don't prevent rebuilds from creating artifacts.
         if [ $JOB_STATUS == "failure" ]; then

--- a/news/2528-conda-bld-path.rst
+++ b/news/2528-conda-bld-path.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Update templates to use ``CONDA_BLD_PATH`` for build directory consistently. (#2528)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Replace the `CONDA_BLD_DIR` directory used when storing build artifacts with `CONDA_BLD_PATH` that is used when building, to ensure consistency and avoid unnecessary confusion.

