### PR TITLE
fix: check teams found by slug and default to a search if we do not find them

### DIFF
--- a/conda_smithy/github.py
+++ b/conda_smithy/github.py
@@ -3,6 +3,7 @@ import copy
 import json
 import logging
 import os
+import re
 from random import choice
 
 import github
@@ -24,6 +25,7 @@ from conda_smithy.utils import (
 )
 
 logger = logging.getLogger(__name__)
+SLUGIFY_RE = re.compile(r"[^a-zA-Z0-9]+")
 
 
 def gh_token():
@@ -313,6 +315,26 @@ def remove_from_project(gh, org, project):
     repo.remove_from_collaborators(user.login)
 
 
+def _guess_team_slug(team_name):
+    """Guess a team's slug.
+
+    Github does the following to team names to make slugs:
+
+      - replaces any special characters or spaces with "-"
+      - replaces any characters not in a-z or 0-9 with their
+        closest lower-case ascii equivalent (e.g., A -> a,
+        e with an accent -> e, etc.)
+      - if the resulting team slug is not unique, it may append
+        a number to the team
+
+    This function guesses the most likely team slug for a team
+    name. If you get the team from the API with this slug, you
+    MUST check the that the team you got has the same name as the
+    name you expected.
+    """
+    return SLUGIFY_RE.sub("-", team_name.lower()).strip("-").lstrip("-")
+
+
 def configure_github_team(
     meta, gh_repo, org, feedstock_name, remove=True, gh: Github | None = None
 ):
@@ -365,9 +387,22 @@ def configure_github_team(
     fs_team = None
     current_maintainers = set()
 
-    if not repo_fs_team:
-        team_desc = f"The {choice(superlative)} {team_name} contributors!"
+    if repo_fs_team:
+        fs_team = repo_fs_team
 
+    if fs_team is None:
+        # NEVER search for a github team by guessing its slug, or if you do,
+        # check that the team name matches after you get it.
+        guessed_slug = _guess_team_slug(team_name)
+        try:
+            fs_team = org.get_team_by_slug(guessed_slug)
+            assert fs_team.name == team_name
+        except Exception:
+            fs_team = None
+
+    team_desc = f"The {choice(superlative)} {team_name} contributors!"
+
+    if fs_team is None:
         try:
             # first try to make it since a search of the org will be expensive
             fs_team = create_team(
@@ -376,14 +411,18 @@ def configure_github_team(
                 team_desc,
             )
         except Exception:
+            fs_team = None
+
+    if fs_team is None:
+        try:
             # try a full search of the org or the local cache
             fs_team = get_cached_team(
                 org,
                 team_name,
                 description=team_desc,
             )
-    else:
-        fs_team = repo_fs_team
+        except Exception:
+            fs_team = None
 
     if fs_team is None:
         raise RuntimeError(

--- a/conda_smithy/github.py
+++ b/conda_smithy/github.py
@@ -362,22 +362,33 @@ def configure_github_team(
         (team for team in current_maintainer_teams if team.name == team_name),
         None,
     )
+    fs_team = None
     current_maintainers = set()
 
-    try:
-        org_fs_team = org.get_team_by_slug(team_name)
-    except Exception:
-        org_fs_team = None
+    if not repo_fs_team:
+        team_desc = f"The {choice(superlative)} {team_name} contributors!"
 
-    if not org_fs_team:
-        # team does not exist so make it
-        fs_team = create_team(
-            org,
-            team_name,
-            f"The {choice(superlative)} {team_name} contributors!",
-        )
+        try:
+            # first try to make it since a search of the org will be expensive
+            fs_team = create_team(
+                org,
+                team_name,
+                team_desc,
+            )
+        except Exception:
+            # try a full search of the org or the local cache
+            fs_team = get_cached_team(
+                org,
+                team_name,
+                description=team_desc,
+            )
     else:
-        fs_team = org_fs_team
+        fs_team = repo_fs_team
+
+    if fs_team is None:
+        raise RuntimeError(
+            f"Could not find feedstock team for feedstock {feedstock_name}!"
+        )
 
     if not repo_fs_team:
         # team is not added to repo so do that

--- a/news/team-by-name-2535.rst
+++ b/news/team-by-name-2535.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Do not use team name as slug when trying to find feedstock teams. (#2535)
+* fix: check teams found by slug and default to a search if we do not find them (#2535)
 
 **Security:**
 

--- a/news/team-by-name-2535.rst
+++ b/news/team-by-name-2535.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Do not use team name as slug when trying to find feedstock teams. (#2535)
+
+**Security:**
+
+* <news item>

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -62,7 +62,6 @@ def test_github_configure_github_team_all_new(
     gh_repo.get_teams.assert_called_once_with()
     org.get_team_by_slug.assert_has_calls(
         [
-            mock.call("pkg1"),
             mock.call("team"),
         ]
     )
@@ -130,6 +129,7 @@ def test_github_configure_github_team_add(
 
     pkg1_team = mock.MagicMock()
     pkg1_team.slug = "pkg1"
+    pkg1_team.name = "pkg1"
     user1 = mock.MagicMock()
     user1.login = "user1"
     user2 = mock.MagicMock()
@@ -185,7 +185,6 @@ def test_github_configure_github_team_add(
     gh_repo.get_teams.assert_called_once_with()
     org.get_team_by_slug.assert_has_calls(
         [
-            mock.call("pkg1"),
             mock.call("new-team"),
             mock.call("pkg1"),
         ]
@@ -251,6 +250,7 @@ def test_github_configure_github_team_add_user_changed_id(
 
     pkg1_team = mock.MagicMock()
     pkg1_team.slug = "pkg1"
+    pkg1_team.name = "pkg1"
     user1 = mock.MagicMock()
     user1.login = "user1"
     pkg1_team.get_members.return_value = [
@@ -308,7 +308,6 @@ def test_github_configure_github_team_add_user_changed_id(
     gh_repo.get_teams.assert_called_once_with()
     org.get_team_by_slug.assert_has_calls(
         [
-            mock.call("pkg1"),
             mock.call("new-team"),
             mock.call("pkg1"),
         ]
@@ -379,6 +378,7 @@ def test_github_configure_github_team_add_changed_user_id_team_remove(
 
     pkg1_team = mock.MagicMock()
     pkg1_team.slug = "pkg1"
+    pkg1_team.name = "pkg1"
     user1 = mock.MagicMock()
     user1.login = "user1"
     user411 = mock.MagicMock()
@@ -443,7 +443,6 @@ def test_github_configure_github_team_add_changed_user_id_team_remove(
     gh_repo.get_teams.assert_called_once_with()
     org.get_team_by_slug.assert_has_calls(
         [
-            mock.call("pkg1"),
             mock.call("new-team"),
             mock.call("team"),
             mock.call("pkg1"),

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -2,8 +2,20 @@ import json
 import unittest.mock as mock
 
 import github
+import pytest
 
-from conda_smithy.github import configure_github_team
+from conda_smithy.github import _guess_team_slug, configure_github_team
+
+
+@pytest.mark.parametrize(
+    "team,slug",
+    [
+        (" - - - blah@$!#$!$- ", "blah"),
+        ("-R.nmf five", "r-nmf-five"),
+    ],
+)
+def test_guess_team_slug(team, slug):
+    assert _guess_team_slug(team) == slug
 
 
 @mock.patch("conda_smithy.github.has_in_members")
@@ -62,8 +74,10 @@ def test_github_configure_github_team_all_new(
     gh_repo.get_teams.assert_called_once_with()
     org.get_team_by_slug.assert_has_calls(
         [
+            mock.call("pkg1"),
             mock.call("team"),
-        ]
+        ],
+        any_order=True,
     )
     create_team.assert_called_once()  # did not patch random.choice so do not assert actual call
     create_team.return_value.add_to_repos.assert_called_once_with(gh_repo)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This call is causing team update errors in the webservices.