### PR TITLE
Return deprecated schema field hints directly

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2474,7 +2474,7 @@ def _read_forge_config(forge_dir, forge_yml=None):
 
     # Validate loaded configuration against a JSON schema.
     validate_lints, validate_hints = validate_json_schema(file_config)
-    for err in chain(validate_lints, validate_hints):
+    for err in validate_lints:
         logger.warning(
             "%s: %s = %s -> %s",
             os.path.relpath(forge_yml, forge_dir),
@@ -2483,6 +2483,8 @@ def _read_forge_config(forge_dir, forge_yml=None):
             err.message,
         )
         logger.debug("Relevant schema:\n%s", json.dumps(err.schema, indent=2))
+    for hint in validate_hints:
+        logger.warning("%s: %s", os.path.relpath(forge_yml, forge_dir), hint)
 
     # The config is just the union of the defaults, and the overridden
     # values.

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -838,7 +838,7 @@ def main(recipe_dir, conda_forge=False, return_hints=False, feedstock_dir=None):
     )
 
     results.extend([_format_validation_msg(err) for err in validation_errors])
-    hints.extend([_format_validation_msg(hint) for hint in validation_hints])
+    hints.extend(validation_hints)
 
     if return_hints:
         return results, hints

--- a/conda_smithy/validate_schema.py
+++ b/conda_smithy/validate_schema.py
@@ -17,28 +17,24 @@ CONDA_FORGE_YAML_SCHEMA_FILE = (
 )
 
 
-# this is actually not an error, therefore the naming is okay
-class DeprecatedFieldWarning(ValidationError):  # noqa: N818
-    pass
+class DeprecatedValidator:
+    def __init__(self):
+        self.hints = []
+
+    def __call__(self, validator, value, instance, schema):
+        if value and instance is not None:
+            self.hints.append(
+                f"'{schema['title']}' is deprecated.\n{schema['description']}"
+            )
 
 
-def deprecated_validator(validator, value, instance, schema):
-    if value and instance is not None:
-        yield DeprecatedFieldWarning(
-            f"'{schema['title']}' is deprecated.\n{schema['description']}"
-        )
-
-
-def get_validator_class():
+def get_validator_class(deprecated_validator):
     all_validators = dict(Draft202012Validator.VALIDATORS)
     all_validators["deprecated"] = deprecated_validator
 
     return validators.create(
         meta_schema=Draft202012Validator.META_SCHEMA, validators=all_validators
     )
-
-
-_VALIDATOR_CLASS = get_validator_class()
 
 
 def validate_json_schema(
@@ -68,14 +64,8 @@ def validate_json_schema(
             "CONDA_SMITHY_BOT_SCHEMA_URI"
         ]
 
-    validator = _VALIDATOR_CLASS(
+    deprecated_validator = DeprecatedValidator()
+    validator = get_validator_class(deprecated_validator)(
         _json_schema, registry=Registry(retrieve=_get_json_schema)
     )
-    lints = []
-    hints = []
-    for error in validator.iter_errors(config):
-        if isinstance(error, DeprecatedFieldWarning):
-            hints.append(error)
-        else:
-            lints.append(error)
-    return lints, hints
+    return list(validator.iter_errors(config)), deprecated_validator.hints

--- a/news/2540-schema-deprecated.rst
+++ b/news/2540-schema-deprecated.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Deprecated schema fields that aren't top-level are now correctly reported as hints. (#2540)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Pass the deprecated schema field hints directly via the validator class rather than through the jsonschema logic.  The latter does not seem to work correctly when deprecated fields are non-toplevel.

Fixes #2537