### PR TITLE
fix: context rendering with variant

### DIFF
--- a/conda_smithy/linter/conda_recipe_v1_linter.py
+++ b/conda_smithy/linter/conda_recipe_v1_linter.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 
 from rattler_build_conda_compat.jinja.jinja import (
     RecipeWithContext,
-    render_recipe_with_context,
+    resolve_recipe_metadata,
 )
 from rattler_build_conda_compat.outputs import is_staging_output
 
@@ -113,14 +113,14 @@ def hint_noarch_usage(
 
 
 def get_recipe_name(recipe_content: RecipeWithContext) -> str:
-    rendered_context_recipe = render_recipe_with_context(recipe_content)
+    rendered_context_recipe = resolve_recipe_metadata(recipe_content)
     package_name = rendered_context_recipe.get("package", {}).get("name", "").strip()
     recipe_name = rendered_context_recipe.get("recipe", {}).get("name", "").strip()
     return package_name or recipe_name
 
 
 def get_recipe_version(recipe_content: RecipeWithContext) -> Optional[str]:
-    rendered_context_recipe = render_recipe_with_context(recipe_content)
+    rendered_context_recipe = resolve_recipe_metadata(recipe_content)
     package_version = rendered_context_recipe.get("package", {}).get("version")
     recipe_version = rendered_context_recipe.get("recipe", {}).get("version")
 

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -9,7 +9,7 @@ from collections.abc import Sequence
 from typing import Any, Literal, Optional
 
 from conda.models.version import VersionOrder
-from rattler_build_conda_compat.jinja.jinja import render_recipe_with_context
+from rattler_build_conda_compat.jinja.jinja import resolve_recipe_metadata
 from rattler_build_conda_compat.loader import parse_recipe_config_file
 from ruamel.yaml import CommentedSeq
 
@@ -551,7 +551,7 @@ def lint_pin_subpackages(
     recipe_version: int = 0,
 ):
     if recipe_version == 1:
-        meta = render_recipe_with_context(meta)
+        meta = resolve_recipe_metadata(meta)
         # use the rendered versions here
         package_section = meta.get("package", {})
         outputs_section = meta.get("outputs", [])


### PR DESCRIPTION
@baszalmstra found an issue converting the `vc-feedstock` to v1 recipe. The context section requires some values coming from the variant definition.

Rendering the context _without_ the variant failed the rerendering.

This still needs some testing. Alternatively, we could be more lenient in `rattler-build-conda-compat` and ignore lines in context that fail to render. Sister PR: https://github.com/conda-forge/rattler-build-conda-compat/pull/121

Checklist
* [ ] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
