### PR TITLE
Hint when dependency specifiers override pins

### DIFF
--- a/conda_smithy/data/linter-messages.json
+++ b/conda_smithy/data/linter-messages.json
@@ -97,6 +97,18 @@
       "path": ".github/workflows/*.y*ml"
     },
     {
+      "name": "PinnedDependencyOverridden",
+      "identifier": "CF-006",
+      "category": "CF",
+      "kind": "hint",
+      "added_in": "<3.56",
+      "deprecated_in": "",
+      "documentation": "Hint when dependency specification overrides a pin.",
+      "message": "${output} output overrides versions pinned in the feedstock:\n${bad_specs_list}\nRequirement spec should not list version specifiers to respect conda-forge-pinning. If you need to force another version, please override the pin via `conda_build_config.yaml`.",
+      "examples": [],
+      "path": ""
+    },
+    {
       "name": "NoDuplicateKeys",
       "identifier": "FC-001",
       "category": "FC",

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -27,6 +27,7 @@ from conda_smithy.linter import conda_recipe_v1_linter
 from conda_smithy.linter import messages as msg
 from conda_smithy.linter.hints import (
     hint_check_spdx,
+    hint_dependency_pins,
     hint_noarch_python_use_python_min,
     hint_os_version,
     hint_pip_no_build_backend,
@@ -626,6 +627,8 @@ def run_conda_forge_specific(
         ci_support_files = glob(os.path.join(recipe_dir, "..", ".ci_support", "*.yaml"))
         if not ci_support_files:
             lints.append(msg.cf.NoVariantConfigs().as_string())
+    else:
+        ci_support_files = []
 
     # 8: Ensure the recipe specifies a Python build backend if needed
     if "hint_pip_no_build_backend" not in lints_to_skip:
@@ -723,6 +726,9 @@ def run_conda_forge_specific(
         lints.append(
             msg.cf.NoCustomGHAWorkflows(path=f"{gha_workflows}/*.yaml").as_string()
         )
+
+    # 16: Check for requirements overriding dependency pins
+    hint_dependency_pins(requirements_section, outputs_section, ci_support_files, hints)
 
 
 def _format_validation_msg(error: jsonschema.ValidationError):

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -469,3 +469,82 @@ def hint_rattler_build_bld_bat(
     bld_bat_path = os.path.join(recipe_dir, "bld.bat")
     if os.path.exists(bld_bat_path):
         hints.append(msg.r.RattlerBldBat().as_string())
+
+
+def _is_pin_overridden(spec: str, pins: set[str]) -> bool:
+    from conda import CondaError
+    from conda.models.match_spec import MatchSpec
+
+    if "#" in spec:
+        spec = spec.split("#")[0]
+    spec = spec.strip()
+
+    # exclude jinja2 stubs or expressions
+    if "{{" in spec or any(
+        spec.startswith(stub)
+        for stub in [
+            "compatible_pin ",
+            "subpackage_pin ",
+        ]
+    ):
+        return False
+
+    fields = spec.split()
+    if len(fields) not in (2, 3):
+        return False
+
+    try:
+        match_spec = MatchSpec(spec)
+    except CondaError:
+        return False
+
+    return match_spec.name in pins and match_spec.version
+
+
+def hint_dependency_pins(
+    requirements_section,
+    outputs_section,
+    ci_support_files,
+    hints,
+):
+    """Hint for dependencies that override pinning"""
+
+    if not ci_support_files:
+        return
+
+    potential_pins = set()
+    for pin_file in ci_support_files:
+        # TODO: can we do this better?
+        with open(pin_file, encoding="utf-8") as fh:
+            pin_yaml = get_yaml().load(fh)
+        potential_pins.update(pin_yaml.keys())
+
+    report = {}
+    for req_type, reqs in requirements_section.items():
+        if req_type != "host":
+            continue
+        bad_specs = [
+            req for req in (reqs or ()) if _is_pin_overridden(req, potential_pins)
+        ]
+        if bad_specs:
+            report.setdefault("top-level", {})[req_type] = bad_specs
+    for i, output in enumerate(outputs_section):
+        requirements_section = output.get("requirements") or {}
+        if not hasattr(requirements_section, "items"):
+            # not a dict, but a list (CB2 style)
+            requirements_section = {"run": requirements_section}
+        for req_type, reqs in requirements_section.items():
+            if req_type != "host":
+                continue
+            bad_specs = [req for req in reqs if _is_pin_overridden(req, potential_pins)]
+            if bad_specs:
+                report.setdefault(output.get("name", f"output {i}"), {})[
+                    req_type
+                ] = bad_specs
+
+    for output, requirements in report.items():
+        hints.append(
+            msg.cf.PinnedDependencyOverridden(
+                output=output, bad_specs=requirements
+            ).as_string()
+        )

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -471,12 +471,15 @@ def hint_rattler_build_bld_bat(
         hints.append(msg.r.RattlerBldBat().as_string())
 
 
-def _check_pin_overridden(specs: list[str], pins: set[str]) -> Generator[str]:
+def _check_pin_overridden(
+    requirements_section: dict[str, list[str]], pins: set[str]
+) -> Generator[str]:
     from conda import CondaError
     from conda.models.match_spec import MatchSpec
 
     packages_found = {}
 
+    specs = requirements_section.get("host") or []
     for spec in specs:
         if "#" in spec:
             spec = spec.split("#")[0]
@@ -526,25 +529,17 @@ def hint_dependency_pins(
         potential_pins.update(pin_yaml.keys())
 
     report = {}
-    for req_type, reqs in requirements_section.items():
-        if req_type != "host" or reqs is None:
-            continue
-        bad_specs = list(_check_pin_overridden(reqs or [], potential_pins))
-        if bad_specs:
-            report.setdefault("top-level", {})[req_type] = bad_specs
+    bad_specs = list(_check_pin_overridden(requirements_section, potential_pins))
+    if bad_specs:
+        report.setdefault("top-level", {})["host"] = bad_specs
     for i, output in enumerate(outputs_section):
         requirements_section = output.get("requirements") or {}
         if not hasattr(requirements_section, "items"):
             # not a dict, but a list (CB2 style)
             requirements_section = {"run": requirements_section}
-        for req_type, reqs in requirements_section.items():
-            if req_type != "host" or reqs is None:
-                continue
-            bad_specs = list(_check_pin_overridden(reqs or [], potential_pins))
-            if bad_specs:
-                report.setdefault(output.get("name", f"output {i}"), {})[
-                    req_type
-                ] = bad_specs
+        bad_specs = list(_check_pin_overridden(requirements_section, potential_pins))
+        if bad_specs:
+            report.setdefault(output.get("name", f"output {i}"), {})["host"] = bad_specs
 
     for output, requirements in report.items():
         hints.append(

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -521,7 +521,7 @@ def hint_dependency_pins(
 
     report = {}
     for req_type, reqs in requirements_section.items():
-        if req_type != "host":
+        if req_type != "host" or reqs is None:
             continue
         bad_specs = [
             req for req in (reqs or ()) if _is_pin_overridden(req, potential_pins)
@@ -534,7 +534,7 @@ def hint_dependency_pins(
             # not a dict, but a list (CB2 style)
             requirements_section = {"run": requirements_section}
         for req_type, reqs in requirements_section.items():
-            if req_type != "host":
+            if req_type != "host" or reqs is None:
                 continue
             bad_specs = [req for req in reqs if _is_pin_overridden(req, potential_pins)]
             if bad_specs:

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -5,7 +5,7 @@ import re
 import shutil
 import subprocess
 import sys
-from collections.abc import Mapping
+from collections.abc import Generator, Mapping
 from glob import glob
 from typing import Any
 
@@ -471,34 +471,40 @@ def hint_rattler_build_bld_bat(
         hints.append(msg.r.RattlerBldBat().as_string())
 
 
-def _is_pin_overridden(spec: str, pins: set[str]) -> bool:
+def _check_pin_overridden(specs: list[str], pins: set[str]) -> Generator[str]:
     from conda import CondaError
     from conda.models.match_spec import MatchSpec
 
-    if "#" in spec:
-        spec = spec.split("#")[0]
-    spec = spec.strip()
+    packages_found = {}
 
-    # exclude jinja2 stubs or expressions
-    if "{{" in spec or any(
-        spec.startswith(stub)
-        for stub in [
-            "compatible_pin ",
-            "subpackage_pin ",
-        ]
-    ):
-        return False
+    for spec in specs:
+        if "#" in spec:
+            spec = spec.split("#")[0]
+        spec = spec.strip()
 
-    fields = spec.split()
-    if len(fields) not in (2, 3):
-        return False
+        try:
+            match_spec = MatchSpec(spec)
+        except CondaError:
+            # this covers specs using jinja expressions like:
+            #   - python ${{ python_min }}
+            #   - blah ${{ blah }}
+            continue
 
-    try:
-        match_spec = MatchSpec(spec)
-    except CondaError:
-        return False
+        packages_found.setdefault(match_spec.name, []).append(
+            (match_spec.version, spec)
+        )
 
-    return match_spec.name in pins and match_spec.version
+    for package, matches in packages_found.items():
+        # skip packages that are referenced more than once, to cover patterns
+        # like:
+        #   - blah
+        #   - blah >=3.7
+        if len(matches) > 1:
+            continue
+        assert len(matches) == 1
+        version, spec = matches[0]
+        if package in pins and version is not None:
+            yield spec
 
 
 def hint_dependency_pins(
@@ -523,9 +529,7 @@ def hint_dependency_pins(
     for req_type, reqs in requirements_section.items():
         if req_type != "host" or reqs is None:
             continue
-        bad_specs = [
-            req for req in (reqs or ()) if _is_pin_overridden(req, potential_pins)
-        ]
+        bad_specs = list(_check_pin_overridden(reqs or [], potential_pins))
         if bad_specs:
             report.setdefault("top-level", {})[req_type] = bad_specs
     for i, output in enumerate(outputs_section):
@@ -536,7 +540,7 @@ def hint_dependency_pins(
         for req_type, reqs in requirements_section.items():
             if req_type != "host" or reqs is None:
                 continue
-            bad_specs = [req for req in reqs if _is_pin_overridden(req, potential_pins)]
+            bad_specs = list(_check_pin_overridden(reqs or [], potential_pins))
             if bad_specs:
                 report.setdefault(output.get("name", f"output {i}"), {})[
                     req_type

--- a/conda_smithy/linter/messages/conda_forge.py
+++ b/conda_smithy/linter/messages/conda_forge.py
@@ -112,3 +112,29 @@ class NoCustomGHAWorkflows(LinterMessage):
         "consider rerendering your feedstock to remove deprecated workflows."
     )
     path: str = ".github/workflows/*.y*ml"
+
+
+@dataclass(kw_only=True)
+class PinnedDependencyOverridden(LinterMessage):
+    """
+    Hint when dependency specification overrides a pin.
+    """
+
+    kind = "hint"
+    identifier = "CF-006"
+    message = (
+        "${output} output overrides versions pinned in the feedstock:\n"
+        "${bad_specs_list}\n"
+        "Requirement spec should not list version specifiers to respect "
+        "conda-forge-pinning. If you need to force another version, "
+        "please override the pin via `conda_build_config.yaml`."
+    )
+    output: str
+    bad_specs: dict[str, list[str]]
+
+    def _render_attributes(self):
+        bad_specs_list = []
+        for req_type, specs in self.bad_specs.items():
+            specs = [f"`{spec}`" for spec in specs]
+            bad_specs_list.append(f"- In section {req_type}: {', '.join(specs)}")
+        return {"output": self.output, "bad_specs_list": bad_specs_list}

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -2465,7 +2465,7 @@ def test_lint_no_builds():
         assert any(lint.startswith(expected_message) for lint in lints)
 
         with open(os.path.join(ci_support_dir, "blah.yaml"), "w") as fh:
-            fh.write("blah")
+            fh.write("blah:\n- foo")
 
         lints = linter.main(recipe_dir, conda_forge=True)
         assert not any(lint.startswith(expected_message) for lint in lints)

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4718,5 +4718,77 @@ extra:
     assert hints == []
 
 
+def test_hint_pinned_dependency_override() -> None:
+    recipe = """\
+context:
+  version: "1.0"
+
+package:
+  name: foo
+  version: ${{ version }}
+
+build:
+  number: 1
+
+requirements:
+  host:
+    - libhwloc >=2.5
+    - not_pinned >=3.7,<4
+    - if: win
+      then: windows_only >=1.1
+
+tests:
+  - script:
+    - true
+
+about:
+  homepage: https://example.com
+  license: GPL-3.0-or-later
+  license_file:
+    - COPYING
+  summary: test
+
+extra:
+  recipe-maintainers:
+    - mgorny
+"""
+
+    linux_pinning = """\
+libhwloc:
+- 2.12
+"""
+
+    win_pinning = """\
+libhwloc:
+- 2.12
+windows_only:
+- 2.0
+"""
+
+    with tmp_directory() as feedstock_dir:
+        recipe_dir = os.path.join(feedstock_dir, "recipe")
+        os.mkdir(recipe_dir)
+        with open(os.path.join(recipe_dir, "recipe.yaml"), "w") as fh:
+            fh.write(recipe)
+
+        ci_support_dir = os.path.join(feedstock_dir, ".ci_support")
+        os.mkdir(ci_support_dir)
+        with open(os.path.join(ci_support_dir, "linux_64.yaml"), "w") as fh:
+            fh.write(linux_pinning)
+        with open(os.path.join(ci_support_dir, "win_64.yaml"), "w") as fh:
+            fh.write(win_pinning)
+
+        lints, hints = linter.main(recipe_dir, return_hints=True, conda_forge=True)
+
+    assert lints == []
+    assert hints == [
+        "top-level output overrides versions pinned in the feedstock:\n"
+        "['- In section host: `libhwloc >=2.5`, `windows_only >=1.1`']\n"
+        "Requirement spec should not list version specifiers to respect "
+        "conda-forge-pinning. If you need to force another version, please "
+        "override the pin via `conda_build_config.yaml`.",
+    ]
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4732,10 +4732,15 @@ build:
 
 requirements:
   host:
+    - blah ${{ blah }}
     - libhwloc >=2.5
     - not_pinned >=3.7,<4
     - if: win
       then: windows_only >=1.1
+    - pin_plus_min
+    - pin_plus_min >=5.4.3
+  run:
+    - another_dep >=5
 
 tests:
   - script:
@@ -4756,11 +4761,31 @@ extra:
     linux_pinning = """\
 libhwloc:
 - 2.12
+python:
+- 3.12.* *_cpython
+python_min:
+- 3.10
+blah:
+- 1.2
+pin_plus_min:
+- 6.0
+another_dep:
+- 10
 """
 
     win_pinning = """\
 libhwloc:
 - 2.12
+python:
+- 3.12.* *_cpython
+python_min:
+- 3.10
+blah:
+- 1.2
+pin_plus_min:
+- 6.0
+another_dep:
+- 10
 windows_only:
 - 2.0
 """


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Emit a hint when a dependency specifier in the recipe overrides a pinned dependency version.  This seems to be a common pitfall, for example when you copy dependency specifiers from upstream without realizing that a dependency such as:

    host:
    - libhwloc >=2.5

will actually cause the pinned version to be ignored, and force the newest `libhwloc`, leading to conflicting dependency constraints across packages.