### PR TITLE
Support GitHub Actions badges and skip irrelevant Azure details in generated README

### DIFF
--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -166,6 +166,8 @@ Current build status
           <tbody>
           {%- for variant in variants -%}
             {%- set variant_os = variant.split('_')[0] -%}
+            {%- set platform = variant.split('_')[:2] | join('_') -%}
+            {%- if "azure" in provider[platform] -%}
             <tr>
               <td>{{ variant.strip('_') }}</td>
               <td>
@@ -174,6 +176,7 @@ Current build status
                 </a>
               </td>
             </tr>
+            {%- endif -%}
           {%- endfor %}
           </tbody>
         </table>

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -71,7 +71,7 @@ Current build status
     <td>All platforms:</td>
     <td>
       <a href="https://github.com/{{ github.user_or_org }}/{{ github.repo_name }}/actions/workflows/conda-build.yml">
-        <img src="https://github.com/{{ github.user_or_org }}/{{ github.repo_name }}/actions/workflows/conda-build.yml/badge.svg?event=push">
+        <img src="https://github.com/{{ github.user_or_org }}/{{ github.repo_name }}/actions/workflows/conda-build.yml/badge.svg?event=push&branch={{ github.branch_name }}">
       </a>
     </td>
   </tr>
@@ -142,7 +142,7 @@ Current build status
     <td>GitHub Actions</td>
     <td>
       <a href="https://github.com/{{ github.user_or_org }}/{{ github.repo_name }}/actions/workflows/conda-build.yml">
-        <img src="https://github.com/{{ github.user_or_org }}/{{ github.repo_name }}/actions/workflows/conda-build.yml/badge.svg?event=push">
+        <img src="https://github.com/{{ github.user_or_org }}/{{ github.repo_name }}/actions/workflows/conda-build.yml/badge.svg?event=push&branch={{ github.branch_name }}">
       </a>
     </td>
   </tr>

--- a/conda_smithy/templates/README.md.tmpl
+++ b/conda_smithy/templates/README.md.tmpl
@@ -66,6 +66,15 @@ Current build status
       </a>
     </td>
   </tr>
+  {%- elif github_actions.enabled -%}
+  <tr>
+    <td>All platforms:</td>
+    <td>
+      <a href="https://github.com/{{ github.user_or_org }}/{{ github.repo_name }}/actions/workflows/conda-build.yml">
+        <img src="https://github.com/{{ github.user_or_org }}/{{ github.repo_name }}/actions/workflows/conda-build.yml/badge.svg?event=push">
+      </a>
+    </td>
+  </tr>
   {%- elif azure.enabled -%}
   <tr>
     {#- Sample url #-}
@@ -124,6 +133,16 @@ Current build status
     <td>
       <a href="https://ci.appveyor.com/project/{{ github.user_or_org }}/{{ appveyor_url_name }}/branch/{{ github.branch_name }}">
         <img alt="windows" src="{{ shield }}appveyor/ci/{{ github.user_or_org }}/{{ appveyor_url_name }}/{{ github.branch_name }}.svg?label=Windows">
+      </a>
+    </td>
+  </tr>
+  {%- endif -%}
+  {%- if github_actions.enabled -%}
+  <tr>
+    <td>GitHub Actions</td>
+    <td>
+      <a href="https://github.com/{{ github.user_or_org }}/{{ github.repo_name }}/actions/workflows/conda-build.yml">
+        <img src="https://github.com/{{ github.user_or_org }}/{{ github.repo_name }}/actions/workflows/conda-build.yml/badge.svg?event=push">
       </a>
     </td>
   </tr>

--- a/news/2547-readme-badges.rst
+++ b/news/2547-readme-badges.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Badges for workflows using GitHub Actions are now included in ``README.md``. (#2547)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Azure badges for configs that are not run on Azure are no longer included in ``README.md``. (#2547)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #2510

<!--
Please add any other relevant info below:
-->
Two combined changes:
1. Include GitHub Actions status badge when used.
2. List status badges only for Azure jobs that are actually run on Azure.