### PR TITLE
Fix a crash when checking for overridden pins in v1 if:/else:

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -728,7 +728,9 @@ def run_conda_forge_specific(
         )
 
     # 16: Check for requirements overriding dependency pins
-    hint_dependency_pins(requirements_section, outputs_section, ci_support_files, hints)
+    hint_dependency_pins(
+        requirements_section, outputs_section, ci_support_files, hints, recipe_version
+    )
 
 
 def _format_validation_msg(error: jsonschema.ValidationError):

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -476,7 +476,7 @@ def hint_rattler_build_bld_bat(
 def _check_pin_overridden(
     requirements_section: dict[str, list[str]],
     pins: set[str],
-    recipe_version: int = 1,
+    recipe_version: int,
 ) -> Generator[str]:
     from conda import CondaError
     from conda.models.match_spec import MatchSpec
@@ -521,7 +521,7 @@ def hint_dependency_pins(
     outputs_section,
     ci_support_files,
     hints,
-    recipe_version: int = 1,
+    recipe_version: int,
 ):
     """Hint for dependencies that override pinning"""
 

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -474,7 +474,9 @@ def hint_rattler_build_bld_bat(
 
 
 def _check_pin_overridden(
-    requirements_section: dict[str, list[str]], pins: set[str]
+    requirements_section: dict[str, list[str]],
+    pins: set[str],
+    recipe_version: int,
 ) -> Generator[str]:
     from conda import CondaError
     from conda.models.match_spec import MatchSpec
@@ -482,6 +484,8 @@ def _check_pin_overridden(
     packages_found = {}
 
     specs = requirements_section.get("host") or []
+    if recipe_version == 1:
+        specs = flatten_v1_if_else(specs)
     for spec in specs:
         if "#" in spec:
             spec = spec.split("#")[0]
@@ -517,6 +521,7 @@ def hint_dependency_pins(
     outputs_section,
     ci_support_files,
     hints,
+    recipe_version: int,
 ):
     """Hint for dependencies that override pinning"""
 
@@ -531,7 +536,9 @@ def hint_dependency_pins(
         potential_pins.update(pin_yaml.keys())
 
     report = {}
-    bad_specs = list(_check_pin_overridden(requirements_section, potential_pins))
+    bad_specs = list(
+        _check_pin_overridden(requirements_section, potential_pins, recipe_version)
+    )
     if bad_specs:
         report.setdefault("top-level", {})["host"] = bad_specs
     for i, output in enumerate(outputs_section):
@@ -539,7 +546,9 @@ def hint_dependency_pins(
         if not hasattr(requirements_section, "items"):
             # not a dict, but a list (CB2 style)
             requirements_section = {"run": requirements_section}
-        bad_specs = list(_check_pin_overridden(requirements_section, potential_pins))
+        bad_specs = list(
+            _check_pin_overridden(requirements_section, potential_pins, recipe_version)
+        )
         if bad_specs:
             report.setdefault(output.get("name", f"output {i}"), {})["host"] = bad_specs
 

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -476,7 +476,7 @@ def hint_rattler_build_bld_bat(
 def _check_pin_overridden(
     requirements_section: dict[str, list[str]],
     pins: set[str],
-    recipe_version: int,
+    recipe_version: int = 1,
 ) -> Generator[str]:
     from conda import CondaError
     from conda.models.match_spec import MatchSpec
@@ -521,7 +521,7 @@ def hint_dependency_pins(
     outputs_section,
     ci_support_files,
     hints,
-    recipe_version: int,
+    recipe_version: int = 1,
 ):
     """Hint for dependencies that override pinning"""
 

--- a/news/2546-hint-pins.rst
+++ b/news/2546-hint-pins.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Hint when dependency specifiers override pins (#2546)
+* Hint when dependency specifiers override pins (#2546, #2553)
 
 **Changed:**
 

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4723,7 +4723,7 @@ def test_hint_pinned_dependency_override(outputs: bool) -> None:
     midpart = """\
 requirements:
   host:
-    - blah ${ blah }
+    - blah ${{ blah }}
     - libhwloc >=2.5
     - not_pinned >=3.7,<4
     - if: win

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4718,21 +4718,12 @@ extra:
     assert hints == []
 
 
-def test_hint_pinned_dependency_override() -> None:
-    recipe = """\
-context:
-  version: "1.0"
-
-package:
-  name: foo
-  version: ${{ version }}
-
-build:
-  number: 1
-
+@pytest.mark.parametrize("outputs", (False, True))
+def test_hint_pinned_dependency_override(outputs: bool) -> None:
+    midpart = """\
 requirements:
   host:
-    - blah ${{ blah }}
+    - blah ${ blah }
     - libhwloc >=2.5
     - not_pinned >=3.7,<4
     - if: win
@@ -4744,7 +4735,28 @@ requirements:
 
 tests:
   - script:
-    - true
+    - true\
+"""
+    if outputs:
+        midpart = f"""\
+outputs:
+  - package:
+      name: foo
+{textwrap.indent(midpart, '    ')}\
+"""
+
+    recipe = f"""\
+context:
+  version: "1.0"
+
+{'recipe' if outputs else 'package'}:
+  name: foo
+  version: ${{{{ version }}}}
+
+build:
+  number: 1
+
+{midpart}
 
 about:
   homepage: https://example.com
@@ -4807,7 +4819,8 @@ windows_only:
 
     assert lints == []
     assert hints == [
-        "top-level output overrides versions pinned in the feedstock:\n"
+        f"{'output 0' if outputs else 'top-level'} output overrides versions "
+        "pinned in the feedstock:\n"
         "['- In section host: `libhwloc >=2.5`, `windows_only >=1.1`']\n"
         "Requirement spec should not list version specifiers to respect "
         "conda-forge-pinning. If you need to force another version, please "


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
It looks like the conditions are inlined already when in top-level `requirements` but not when in `outputs`.