### PR TITLE
Deduplicate loading `conda-forge.yml`

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -148,7 +148,8 @@ def lintify_meta_yaml(
     lints = []
     hints = []
     major_sections = list(meta.keys())
-    lints_to_skip = _get_feedstock_config(recipe_dir).get("linter", {}).get("skip", [])
+    feedstock_config_keys = _get_feedstock_config(recipe_dir)
+    lints_to_skip = feedstock_config_keys.get("linter", {}).get("skip", [])
 
     # If the recipe_dir exists (no guarantee within this function) , we can
     # find the meta.yaml within it.
@@ -273,7 +274,12 @@ def lintify_meta_yaml(
     # 14: Run conda-forge specific lints
     if conda_forge:
         run_conda_forge_specific(
-            meta, recipe_dir, lints, hints, recipe_version=recipe_version
+            meta,
+            recipe_dir,
+            lints,
+            hints,
+            recipe_version=recipe_version,
+            feedstock_config=feedstock_config_keys,
         )
 
     # 15: Check if we are using legacy patterns
@@ -287,8 +293,7 @@ def lintify_meta_yaml(
     noarch_value = build_section.get("noarch")
     lint_noarch(noarch_value, lints)
 
-    # Interlude: load feedstock and recipe config
-    feedstock_config_keys = _get_feedstock_config(recipe_dir)
+    # Interlude: load recipe config
     recipe_config_keys = _get_recipe_config_keys(recipe_dir)
 
     # 18: noarch doesn't work with selectors for runtime dependencies
@@ -409,7 +414,7 @@ def lintify_meta_yaml(
     )
 
     # 3: suggest fixing all recipe/*.sh shellcheck findings
-    hint_shellcheck_usage(recipe_dir, hints)
+    hint_shellcheck_usage(recipe_dir, hints, feedstock_config=feedstock_config_keys)
 
     # 4: Check for SPDX
     hint_check_spdx(about_section, hints)
@@ -524,18 +529,16 @@ def _team_exists(org_team: str) -> bool:
 
 
 def run_conda_forge_specific(
-    meta,
-    recipe_dir,
-    lints,
-    hints,
-    recipe_version: int = 0,
+    meta, recipe_dir, lints, hints, recipe_version: int = 0, feedstock_config=None
 ):
     if recipe_version == 1:
         recipe_fname = os.path.join(recipe_dir or "", "recipe.yaml")
     else:
         recipe_fname = os.path.join(recipe_dir or "", "meta.yaml")
 
-    lints_to_skip = _get_feedstock_config(recipe_dir).get("linter", {}).get("skip", [])
+    if feedstock_config is None:
+        feedstock_config = _get_feedstock_config(recipe_dir)
+    lints_to_skip = feedstock_config.get("linter", {}).get("skip", [])
 
     # Retrieve sections from meta
     package_section = get_section(meta, "package", lints, recipe_version=recipe_version)

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -92,20 +92,25 @@ def hint_suggest_noarch(
                     hints.append(msg.r.SuggestNoarch().as_string())
 
 
-def hint_shellcheck_usage(recipe_dir, hints):
+def hint_shellcheck_usage(recipe_dir, hints, feedstock_config=None):
     shellcheck_enabled = False
     shell_scripts = []
     if recipe_dir:
         shell_scripts = glob(os.path.join(recipe_dir, "*.sh"))
-        forge_yaml = find_local_config_file(recipe_dir, "conda-forge.yml")
-        if shell_scripts and forge_yaml:
-            with open(forge_yaml, encoding="utf-8") as fh:
-                code = get_yaml().load(fh)
-                shellcheck_enabled = code.get("shellcheck", {}).get(
-                    "enabled", shellcheck_enabled
-                )
+        if not shell_scripts:
+            return
+        if feedstock_config is None:
+            forge_yaml = find_local_config_file(recipe_dir, "conda-forge.yml")
+            if forge_yaml:
+                with open(forge_yaml, encoding="utf-8") as fh:
+                    feedstock_config = get_yaml().load(fh)
+            else:
+                feedstock_config = {}
 
-        if shellcheck_enabled and shutil.which("shellcheck") and shell_scripts:
+        shellcheck_enabled = feedstock_config.get("shellcheck", {}).get(
+            "enabled", shellcheck_enabled
+        )
+        if shellcheck_enabled and shutil.which("shellcheck"):
             cmd = [
                 "shellcheck",
                 "--enable=all",

--- a/news/2555-conda-forge-yml-loading.rst
+++ b/news/2555-conda-forge-yml-loading.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Optimized the code to avoid unnecessary loading ``conda-forge.yml`` multiple times. (#2555)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Deduplicate a few places where `conda-forge.yml` was loaded independently.  Instead, load it once when beginning to lint, and pass along to other functions.  A fallback path to load it directly was left in these functions to preserve API compatibility.

The only remaining duplication is when it's loaded to check for duplicate keys.

