### PR TITLE
Update to current latest conda-build (26.3)

### DIFF
--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -2093,7 +2093,7 @@
           "type": "null"
         }
       ],
-      "description": "This option can be used to override the default `conda-forge-ci-setup` package.\nCan be given with `${url or channel_alias}::package_name`,\ndefaults to conda-forge channel_alias if no prefix is given.\n\n```yaml\nremote_ci_setup: [\"conda-forge-ci-setup=4\", \"conda-build>=24.1\"]\n```",
+      "description": "This option can be used to override the default `conda-forge-ci-setup` package.\nCan be given with `${url or channel_alias}::package_name`,\ndefaults to conda-forge channel_alias if no prefix is given.\n\n```yaml\nremote_ci_setup: [\"conda-forge-ci-setup=4\", \"conda-build>=26.3\"]\n```",
       "title": "Remote Ci Setup"
     },
     "shellcheck": {

--- a/conda_smithy/data/conda-forge.yml
+++ b/conda_smithy/data/conda-forge.yml
@@ -133,7 +133,7 @@ provider:
 recipe_dir: recipe
 remote_ci_setup:
 - conda-forge-ci-setup=4
-- conda-build>=24.1
+- conda-build>=26.3
 secrets: []
 shellcheck:
   enabled: false

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -850,7 +850,7 @@ class ConfigModel(BaseModel):
     remote_ci_setup: Optional[Union[str, list[str]]] = Field(
         default_factory=lambda: [
             "conda-forge-ci-setup=4",
-            "conda-build>=24.1",
+            "conda-build>=26.3",
         ],
         description=cleandoc("""
         This option can be used to override the default `conda-forge-ci-setup` package.
@@ -858,7 +858,7 @@ class ConfigModel(BaseModel):
         defaults to conda-forge channel_alias if no prefix is given.
 
         ```yaml
-        remote_ci_setup: ["conda-forge-ci-setup=4", "conda-build>=24.1"]
+        remote_ci_setup: ["conda-forge-ci-setup=4", "conda-build>=26.3"]
         ```
         """),
     )

--- a/news/2558-update-default-conda-build-min-263.rst
+++ b/news/2558-update-default-conda-build-min-263.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Update ``remote_ci_setup`` to use ``conda-build`` version ``26.3`` or newer. (#2558)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [x] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Update the default `conda-build` lower bound to the most recent version (26.3). Feedstocks can of course still override this.