### PR TITLE
fix: remove use of deprecated `ns_cfg` function

### DIFF
--- a/conda_smithy/variant_algebra.py
+++ b/conda_smithy/variant_algebra.py
@@ -44,10 +44,10 @@ def parse_variant(variant_file_content: str, config: Optional[Config] = None) ->
         from conda_build.config import Config
 
         config = Config()
-    from conda_build.metadata import ns_cfg, select_lines
+    from conda_build.metadata import get_selectors, select_lines
 
     contents = select_lines(
-        variant_file_content, ns_cfg(config), variants_in_place=False
+        variant_file_content, get_selectors(config), variants_in_place=False
     )
     content = yaml.load(contents, Loader=yaml.loader.BaseLoader) or {}
     variants.trim_empty_keys(content)

--- a/news/2559-deprecated-ns-cfg.rst
+++ b/news/2559-deprecated-ns-cfg.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed import of deprecated function ``ns_cfg`` from ``conda-build``. (#2559)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [x] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [x] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
