### PR TITLE
Add a `workflow_settings.pagefile_size` key

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2567,14 +2567,25 @@ def _read_forge_config(forge_dir, forge_yml=None):
             )
             del config["azure"]["settings_linux"]["swapfile_size"]
         else:
-            # Convert old keys to new settings.
-            config["workflow_settings"]["pagefile_size"].append(
-                {
-                    "provider": "azure",
-                    "os": "linux",
-                    "value": config["azure"]["settings_linux"]["swapfile_size"],
-                }
-            )
+            value_re = re.compile(r"(\d+)GiB")
+            if (
+                value_match := value_re.fullmatch(
+                    config["azure"]["settings_linux"]["swapfile_size"]
+                )
+            ) is not None:
+                config["workflow_settings"]["pagefile_size"].append(
+                    {
+                        "provider": "azure",
+                        "os": "linux",
+                        "value": int(value_match.group(1)),
+                    }
+                )
+            else:
+                logger.warning(
+                    "`azure.settings_linux.swapfile_size` has invalid value `%s`, "
+                    "should be `{number}GiB`",
+                    config["azure"]["settings_linux"]["swapfile_size"],
+                )
 
     if "SET_PAGEFILE" in file_config.get("azure", {}).get("settings_win", {}).get(
         "variables", {}
@@ -2592,9 +2603,9 @@ def _read_forge_config(forge_dir, forge_yml=None):
                     "provider": "azure",
                     "os": "win",
                     "value": (
-                        "16GiB"
+                        16
                         if config["azure"]["settings_win"]["variables"]["SET_PAGEFILE"]
-                        else "0"
+                        else 0
                     ),
                 }
             )

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1904,11 +1904,15 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
             "D:" if on_hosted_runner or on_namespace else "C:",
         )
         data.update(workflow_settings)
+        script_suffix = ".bat" if platform == "win" else ".sh"
         if data["store_build_artifacts"]:
-            script_suffix = ".bat" if platform == "win" else ".sh"
             template_files.append(
                 f".scripts/create_conda_build_artifacts{script_suffix}"
             )
+        if data["pagefile_size"] != 0 and platform in ("linux", "win"):
+            template_files.append(f".scripts/create_pagefile{script_suffix}")
+            if platform == "win":
+                template_files.append(".scripts/SetPageFileSize.ps1")
 
         if platform == "linux":
             data["docker_run_args"] = forge_config["docker"]["run_args"]
@@ -2046,10 +2050,14 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
             config_rendered["docker_run_args"] = forge_config["docker"]["run_args"]
 
         config_rendered.update(workflow_settings)
+        script_suffix = ".bat" if platform == "win" else ".sh"
         if config_rendered["store_build_artifacts"]:
             config_rendered["SHORT_CONFIG"] = data["short_config_name"]
-            script_suffix = ".bat" if platform == "win" else ".sh"
             template_files.append(f".scripts/create_conda_build_artifacts{script_suffix}")
+        if config_rendered["pagefile_size"] != 0 and platform in ("linux", "win"):
+            template_files.append(f".scripts/create_pagefile{script_suffix}")
+            if platform == "win":
+                template_files.append(".scripts/SetPageFileSize.ps1")
         azure_settings["strategy"]["matrix"][data["config_name"]] = config_rendered
         # fmt: on
 
@@ -2972,6 +2980,9 @@ def get_common_scripts(forge_dir):
         "run_osx_build.sh",
         "create_conda_build_artifacts.bat",
         "create_conda_build_artifacts.sh",
+        "create_pagefile.bat",
+        "create_pagefile.sh",
+        "SetPageFileSize.ps1",
     ]:
         yield os.path.join(forge_dir, ".scripts", old_file)
 
@@ -2991,6 +3002,9 @@ def clear_scripts(forge_dir):
             "run_win_build.bat",
             "create_conda_build_artifacts.bat",
             "create_conda_build_artifacts.sh",
+            "create_pagefile.bat",
+            "create_pagefile.sh",
+            "SetPageFileSize.ps1",
         ]:
             remove_file(os.path.join(forge_dir, folder, old_file))
 

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2592,7 +2592,7 @@ def _read_forge_config(forge_dir, forge_yml=None):
                     "provider": "azure",
                     "os": "win",
                     "value": (
-                        "8GiB"
+                        "16GiB"
                         if config["azure"]["settings_win"]["variables"]["SET_PAGEFILE"]
                         else "0"
                     ),

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2559,6 +2559,46 @@ def _read_forge_config(forge_dir, forge_yml=None):
                 "variables"
             ].pop("CONDA_FORGE_DOCKER_RUN_ARGS")
 
+    if "swapfile_size" in file_config.get("azure", {}).get("settings_linux", {}):
+        if "pagefile_size" in file_config.get("workflow_settings", {}):
+            logger.warning(
+                "`azure.settings_linux.swapfile_size` is ignored when "
+                "`workflow_settings.pagefile_size` is set",
+            )
+            del config["azure"]["settings_linux"]["swapfile_size"]
+        else:
+            # Convert old keys to new settings.
+            config["workflow_settings"]["pagefile_size"].append(
+                {
+                    "provider": "azure",
+                    "os": "linux",
+                    "value": config["azure"]["settings_linux"]["swapfile_size"],
+                }
+            )
+
+    if "SET_PAGEFILE" in file_config.get("azure", {}).get("settings_win", {}).get(
+        "variables", {}
+    ):
+        if "pagefile_size" in file_config.get("workflow_settings", {}):
+            logger.warning(
+                "`azure.settings_win.variables.SET_PAGEFILE` is ignored when "
+                "`workflow_settings.pagefile_size` is set",
+            )
+            del config["azure"]["settings_win"]["variables"]["SET_PAGEFILE"]
+        else:
+            # Convert old keys to new settings.
+            config["workflow_settings"]["pagefile_size"].append(
+                {
+                    "provider": "azure",
+                    "os": "win",
+                    "value": (
+                        "8GiB"
+                        if config["azure"]["settings_win"]["variables"]["SET_PAGEFILE"]
+                        else "0"
+                    ),
+                }
+            )
+
     # check for conda-smithy 2.x matrix which we can't auto-migrate
     # to conda_build_config
     if file_config.get("matrix") and not os.path.exists(

--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -483,6 +483,84 @@
       "title": "ConditionalValue_<class 'bool'>",
       "type": "object"
     },
+    "ConditionalValue__class__int__": {
+      "properties": {
+        "os": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/PlatformsAliases"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/PlatformsAliases"
+            },
+            {
+              "$ref": "#/$defs/Nullable"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Operating systems to set environment variable on (default: all)",
+          "title": "Os"
+        },
+        "platform": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Platforms"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/Platforms"
+            },
+            {
+              "$ref": "#/$defs/Nullable"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Platforms to set environment variable on (default: all)",
+          "title": "Platform"
+        },
+        "provider": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/CIservices"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/CIservices"
+            },
+            {
+              "$ref": "#/$defs/Nullable"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "CI providers to set environment variable on (default: all)",
+          "title": "Provider"
+        },
+        "value": {
+          "default": null,
+          "description": "Option value",
+          "title": "Value",
+          "type": "integer"
+        }
+      },
+      "title": "ConditionalValue_<class 'int'>",
+      "type": "object"
+    },
     "ConditionalValue__class__str__": {
       "properties": {
         "os": {
@@ -942,11 +1020,11 @@
         "pagefile_size": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "integer"
             },
             {
               "items": {
-                "$ref": "#/$defs/ConditionalValue__class__str__"
+                "$ref": "#/$defs/ConditionalValue__class__int__"
               },
               "type": "array"
             },
@@ -958,7 +1036,7 @@
             }
           ],
           "default": [],
-          "description": "Override the default paging (swap) file size. Specify along with\nthe unit, e.g. \"8GiB\".",
+          "description": "Override the default paging (swap) file size, in GiB.\nFor example, 8 means 8 GiB.",
           "title": "Pagefile Size"
         }
       },

--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -119,7 +119,7 @@
         },
         "settings_win": {
           "$ref": "#/$defs/AzureRunnerSettings",
-          "description": "Windows-specific settings for runners. Aside from overriding the `vmImage`,\nyou can also specify `install_atl: true` in case you need the ATL components\nfor MSVC; these don't get installed by default anymore, see\nhttps://github.com/actions/runner-images/issues/9873\n\nFinally, under `variables`, some important things you can set are:\n\n- ~~`CONDA_BLD_PATH`~~: Location of the conda-build workspace. Deprecated, use\n  `workflow_settings.build_workspace_dir` instead.\n- ~~`MINIFORGE_HOME`~~: Location of the base environment installation. Deprecated,\n  use `workflow_settings.tools_install_dir` instead.\n- `SET_PAGEFILE`: `\"True\"` to increase the pagefile size via conda-forge-ci-setup.\n\nIf you are running out of space in `D:`, consider changing to `C:`.\nIt's a slower drive but has more space available. We recommend you keep\nboth `CONDA_BLD_PATH` and `MINIFORGE_HOME` in the same drive for performance."
+          "description": "Windows-specific settings for runners. Aside from overriding the `vmImage`,\nyou can also specify `install_atl: true` in case you need the ATL components\nfor MSVC; these don't get installed by default anymore, see\nhttps://github.com/actions/runner-images/issues/9873\n\nFinally, under `variables`, some important things you can set are:\n\n- ~~`CONDA_BLD_PATH`~~: Location of the conda-build workspace. Deprecated, use\n  `workflow_settings.build_workspace_dir` instead.\n- ~~`MINIFORGE_HOME`~~: Location of the base environment installation. Deprecated,\n  use `workflow_settings.tools_install_dir` instead.\n- ~~`SET_PAGEFILE`~~: `\"True\"` to increase the pagefile size via conda-forge-ci-setup.\n  Deprecated, use `workflow_settings.pagefile_size` instead.\n\nIf you are running out of space in `D:`, consider changing to `C:`.\nIt's a slower drive but has more space available. We recommend you keep\nboth `CONDA_BLD_PATH` and `MINIFORGE_HOME` in the same drive for performance."
         },
         "user_or_org": {
           "anyOf": [
@@ -203,7 +203,7 @@
             }
           ],
           "default": null,
-          "description": "Swapfile size in GiB",
+          "description": "Deprecated. Swapfile size in GiB.\nUse `workflow_settings.pagefile_size` instead.",
           "title": "Swapfile Size"
         },
         "timeoutInMinutes": {
@@ -938,6 +938,28 @@
           "default": [],
           "description": "Directory to build in.",
           "title": "Build Workspace Dir"
+        },
+        "pagefile_size": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/$defs/ConditionalValue__class__str__"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/Nullable"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": [],
+          "description": "Override the default paging (swap) file size. Specify along with\nthe unit, e.g. \"8GiB\".",
+          "title": "Pagefile Size"
         }
       },
       "title": "WorkflowSettings",

--- a/conda_smithy/data/conda-forge.yml
+++ b/conda_smithy/data/conda-forge.yml
@@ -146,5 +146,6 @@ travis: {}
 woodpecker: {}
 workflow_settings:
   build_workspace_dir: []
+  pagefile_size: []
   store_build_artifacts: []
   tools_install_dir: []

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -575,6 +575,7 @@ def hint_deprecated_environment_variables(
         "CONDA_BLD_PATH": "workflow_settings.build_workspace_dir",
         "CONDA_FORGE_DOCKER_RUN_ARGS": "docker.run_args",
         "MINIFORGE_HOME": "workflow_settings.tools_install_dir",
+        "SET_PAGEFILE": "workflow_settings.pagefile_size",
     }
 
     azure = forge_config.get("azure", {})

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -90,7 +90,11 @@ class AzureRunnerSettings(BaseModel):
     )
 
     swapfile_size: Optional[Union[str, Nullable]] = Field(
-        default=None, description="Swapfile size in GiB"
+        default=None,
+        description=cleandoc("""
+            Deprecated. Swapfile size in GiB.
+            Use `workflow_settings.pagefile_size` instead.
+        """),
     )
 
     timeout_in_minutes: Optional[int] = Field(
@@ -206,7 +210,8 @@ class AzureConfig(BaseModel):
               `workflow_settings.build_workspace_dir` instead.
             - ~~`MINIFORGE_HOME`~~: Location of the base environment installation. Deprecated,
               use `workflow_settings.tools_install_dir` instead.
-            - `SET_PAGEFILE`: `"True"` to increase the pagefile size via conda-forge-ci-setup.
+            - ~~`SET_PAGEFILE`~~: `"True"` to increase the pagefile size via conda-forge-ci-setup.
+              Deprecated, use `workflow_settings.pagefile_size` instead.
 
             If you are running out of space in `D:`, consider changing to `C:`.
             It's a slower drive but has more space available. We recommend you keep
@@ -528,6 +533,16 @@ class WorkflowSettings(BaseModel):
         default=[],
         description=cleandoc("""
         Directory to build in.
+        """),
+    )
+
+    pagefile_size: Optional[
+        Union[str, list[conditional_value(str, None)], Nullable]
+    ] = Field(
+        default=[],
+        description=cleandoc("""
+        Override the default paging (swap) file size. Specify along with
+        the unit, e.g. "8GiB".
         """),
     )
 

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -537,12 +537,12 @@ class WorkflowSettings(BaseModel):
     )
 
     pagefile_size: Optional[
-        Union[str, list[conditional_value(str, None)], Nullable]
+        Union[int, list[conditional_value(int, None)], Nullable]
     ] = Field(
         default=[],
         description=cleandoc("""
-        Override the default paging (swap) file size. Specify along with
-        the unit, e.g. "8GiB".
+        Override the default paging (swap) file size, in GiB.
+        For example, 8 means 8 GiB.
         """),
     )
 

--- a/conda_smithy/templates/SetPageFileSize.ps1.tmpl
+++ b/conda_smithy/templates/SetPageFileSize.ps1.tmpl
@@ -1,0 +1,197 @@
+<#
+.SYNOPSIS
+  Configure Pagefile on Windows machine
+.NOTES
+  Author:         Aleksandr Chebotov
+.EXAMPLE
+  SetPageFileSize.ps1 -MinimumSize 4GB -MaximumSize 8GB -DiskRoot "D:"
+#>
+
+# this file taken 1:1 (with the exception of this comment & the parameter echo) from the MIT-licensed
+# https://github.com/al-cheb/configure-pagefile-action/blob/916fa29e5d27bd4e8eef3666869afbaaee27d9eb/scripts/SetPageFileSize.ps1
+
+param(
+    [System.UInt64] $MinimumSize = 8gb ,
+    [System.UInt64] $MaximumSize = 8gb ,
+    [System.String] $DiskRoot = "D:"
+)
+
+# https://referencesource.microsoft.com/#System.IdentityModel/System/IdentityModel/NativeMethods.cs,619688d876febbe1
+# https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/mm/modwrite/create.htm
+# https://referencesource.microsoft.com/#mscorlib/microsoft/win32/safehandles/safefilehandle.cs,9b08210f3be75520
+# https://referencesource.microsoft.com/#mscorlib/system/security/principal/tokenaccesslevels.cs,6eda91f498a38586
+# https://www.autoitscript.com/forum/topic/117993-api-ntcreatepagingfile/
+
+$source = @'
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+using System.Text;
+using Microsoft.Win32;
+using Microsoft.Win32.SafeHandles;
+
+namespace Util
+{
+    class NativeMethods
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct LUID
+        {
+            internal uint LowPart;
+            internal uint HighPart;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct LUID_AND_ATTRIBUTES
+        {
+            internal LUID Luid;
+            internal uint Attributes;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct TOKEN_PRIVILEGE
+        {
+            internal uint PrivilegeCount;
+            internal LUID_AND_ATTRIBUTES Privilege;
+
+            internal static readonly uint Size = (uint)Marshal.SizeOf(typeof(TOKEN_PRIVILEGE));
+        }
+
+        [StructLayoutAttribute(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        internal struct UNICODE_STRING
+        {
+            internal UInt16 length;
+            internal UInt16 maximumLength;
+            internal string buffer;
+        }
+
+        [DllImport("kernel32.dll", SetLastError=true)]
+        internal static extern IntPtr LocalFree(IntPtr handle);
+
+        [DllImport("advapi32.dll", ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true, PreserveSig = false)]
+        internal static extern bool LookupPrivilegeValueW(
+            [In] string lpSystemName,
+            [In] string lpName,
+            [Out] out LUID luid
+        );
+
+        [DllImport("advapi32.dll", SetLastError = true, PreserveSig = false)]
+        internal static extern bool AdjustTokenPrivileges(
+            [In] SafeCloseHandle tokenHandle,
+            [In] bool disableAllPrivileges,
+            [In] ref TOKEN_PRIVILEGE newState,
+            [In] uint bufferLength,
+            [Out] out TOKEN_PRIVILEGE previousState,
+            [Out] out uint returnLength
+        );
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Auto, SetLastError = true, PreserveSig = false)]
+        internal static extern bool OpenProcessToken(
+            [In] IntPtr processToken,
+            [In] int desiredAccess,
+            [Out] out SafeCloseHandle tokenHandle
+        );
+
+        [DllImport("ntdll.dll", CharSet = CharSet.Unicode, SetLastError = true, CallingConvention = CallingConvention.StdCall)]
+        internal static extern Int32 NtCreatePagingFile(
+            [In] ref UNICODE_STRING pageFileName,
+            [In] ref Int64 minimumSize,
+            [In] ref Int64 maximumSize,
+            [In] UInt32 flags
+        );
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern uint QueryDosDeviceW(
+            string lpDeviceName,
+            StringBuilder lpTargetPath,
+            int ucchMax
+        );
+    }
+
+    public sealed class SafeCloseHandle: SafeHandleZeroOrMinusOneIsInvalid
+    {
+        [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true)]
+        internal extern static bool CloseHandle(IntPtr handle);
+
+        private SafeCloseHandle() : base(true)
+        {
+        }
+
+        public SafeCloseHandle(IntPtr preexistingHandle, bool ownsHandle) : base(ownsHandle)
+        {
+            SetHandle(preexistingHandle);
+        }
+
+        override protected bool ReleaseHandle()
+        {
+            return CloseHandle(handle);
+        }
+    }
+
+    public class PageFile
+    {
+        public static void SetPageFileSize(long minimumValue, long maximumValue, string lpDeviceName)
+        {
+            SetPageFilePrivilege();
+            StringBuilder lpTargetPath = new StringBuilder(260);
+
+            UInt32 resultQueryDosDevice = NativeMethods.QueryDosDeviceW(lpDeviceName, lpTargetPath, lpTargetPath.Capacity);
+            if (resultQueryDosDevice == 0)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            string pageFilePath = lpTargetPath.ToString() + "\\pagefile.sys";
+
+            NativeMethods.UNICODE_STRING pageFileName = new NativeMethods.UNICODE_STRING
+            {
+                length = (ushort)(pageFilePath.Length * 2),
+                maximumLength = (ushort)(2 * (pageFilePath.Length + 1)),
+                buffer = pageFilePath
+            };
+
+            Int32 resultNtCreatePagingFile = NativeMethods.NtCreatePagingFile(ref pageFileName, ref minimumValue, ref maximumValue, 0);
+            if (resultNtCreatePagingFile != 0)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            Console.WriteLine("PageFile: {0} / {1} bytes for {2}", minimumValue, maximumValue, pageFilePath);
+        }
+
+        static void SetPageFilePrivilege()
+        {
+            const int SE_PRIVILEGE_ENABLED = 0x00000002;
+            const int AdjustPrivileges = 0x00000020;
+            const int Query = 0x00000008;
+
+            NativeMethods.LUID luid;
+            NativeMethods.LookupPrivilegeValueW(null, "SeCreatePagefilePrivilege", out luid);
+
+            SafeCloseHandle hToken;
+            NativeMethods.OpenProcessToken(
+                Process.GetCurrentProcess().Handle,
+                AdjustPrivileges | Query,
+                out hToken
+            );
+
+            NativeMethods.TOKEN_PRIVILEGE previousState;
+            NativeMethods.TOKEN_PRIVILEGE newState;
+            uint previousSize = 0;
+            newState.PrivilegeCount = 1;
+            newState.Privilege.Luid = luid;
+            newState.Privilege.Attributes = SE_PRIVILEGE_ENABLED;
+
+            NativeMethods.AdjustTokenPrivileges(hToken, false, ref newState, NativeMethods.TOKEN_PRIVILEGE.Size, out previousState, out previousSize);
+        }
+    }
+}
+'@
+
+Add-Type -TypeDefinition $source
+
+echo Parameters: $minimumSize, $maximumSize, $diskRoot
+# Set SetPageFileSize
+[Util.PageFile]::SetPageFileSize($minimumSize, $maximumSize, $diskRoot)

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -48,8 +48,9 @@ jobs:
          df -h
     displayName: Manage disk space
 {%- endif %}
-{%- if not (azure.settings_linux.swapfile_size|string).startswith("0") %}
   - script: |
+        PAGEFILE_SIZE=$(pagefile_size)
+        [[ ${PAGEFILE_SIZE} == 0* ]] && exit
         SWAPFILE=/swapfile
         # If there is already a swapfile, disable it and remove it
         if swapon --show | grep -q $SWAPFILE; then
@@ -57,12 +58,11 @@ jobs:
             sudo swapoff $SWAPFILE || true
         fi
         [ -f "$SWAPFILE" ] && sudo rm -f $SWAPFILE
-        sudo fallocate -l {{ azure.settings_linux.swapfile_size }} $SWAPFILE
+        sudo fallocate -l "${PAGEFILE_SIZE}" $SWAPFILE
         sudo chmod 600 $SWAPFILE
         sudo mkswap $SWAPFILE
         sudo swapon $SWAPFILE
     displayName: Create swap file
-{%- endif %}
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -49,8 +49,8 @@ jobs:
     displayName: Manage disk space
 {%- endif %}
   - script: |
-        PAGEFILE_SIZE=$(pagefile_size)
-        [[ ${PAGEFILE_SIZE} == 0* ]] && exit
+        SET_PAGEFILE_SIZE=$(pagefile_size)
+        [[ ${SET_PAGEFILE_SIZE} -le 0 ]] && exit
         SWAPFILE=/swapfile
         # If there is already a swapfile, disable it and remove it
         if swapon --show | grep -q $SWAPFILE; then
@@ -58,7 +58,7 @@ jobs:
             sudo swapoff $SWAPFILE || true
         fi
         [ -f "$SWAPFILE" ] && sudo rm -f $SWAPFILE
-        sudo fallocate -l "${PAGEFILE_SIZE}" $SWAPFILE
+        sudo fallocate -l "${SET_PAGEFILE_SIZE}GiB" $SWAPFILE
         sudo chmod 600 $SWAPFILE
         sudo mkswap $SWAPFILE
         sudo swapon $SWAPFILE

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -8,6 +8,9 @@
   {%- if os == 'linux' and data.store_build_artifacts %}
     {%- set vars.store_build_artifacts = True %}
   {%- endif %}
+  {%- if os == 'linux' and data.pagefile_size != 0 %}
+    {%- set vars.create_pagefile = True %}
+  {%- endif %}
 {%- endfor %}
 
 jobs:
@@ -48,9 +51,11 @@ jobs:
          df -h
     displayName: Manage disk space
 {%- endif %}
+{%- if vars.create_pagefile %}
   - script: |
         .scripts/create_pagefile.sh "$(pagefile_size)"
-    displayName: Create swap file
+    displayName: Create page file
+{%- endif %}
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -49,19 +49,7 @@ jobs:
     displayName: Manage disk space
 {%- endif %}
   - script: |
-        SET_PAGEFILE_SIZE=$(pagefile_size)
-        [[ ${SET_PAGEFILE_SIZE} -le 0 ]] && exit
-        SWAPFILE=/swapfile
-        # If there is already a swapfile, disable it and remove it
-        if swapon --show | grep -q $SWAPFILE; then
-            echo "Disabling existing swapfile..."
-            sudo swapoff $SWAPFILE || true
-        fi
-        [ -f "$SWAPFILE" ] && sudo rm -f $SWAPFILE
-        sudo fallocate -l "${SET_PAGEFILE_SIZE}GiB" $SWAPFILE
-        sudo chmod 600 $SWAPFILE
-        sudo mkswap $SWAPFILE
-        sudo swapon $SWAPFILE
+        .scripts/create_pagefile.sh "$(pagefile_size)"
     displayName: Create swap file
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -57,6 +57,9 @@ jobs:
 {%- endif %}
 
     - script: |
+        if "%SET_PAGEFILE_SIZE:~0,1%" NEQ "0" (
+            set SET_PAGEFILE=True
+        )
         call ".scripts\run_win_build.bat"
       displayName: Run Windows build
       env:
@@ -73,6 +76,7 @@ jobs:
 {%- if upload_on_branch %}
         UPLOAD_ON_BRANCH: {{ upload_on_branch }}
 {%- endif %}
+        SET_PAGEFILE_SIZE: $(pagefile_size)
 {%- for secret in secrets %}
         {{ secret }}: $({{ secret }})
 {%- endfor %}

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -57,7 +57,7 @@ jobs:
 {%- endif %}
 
     - script: |
-        call ".scripts\create_pagefile.bat" %SET_PAGEFILE_SIZE%
+        call ".scripts\create_pagefile.bat" $(pagefile_size)
         call ".scripts\run_win_build.bat"
       displayName: Run Windows build
       env:
@@ -74,7 +74,6 @@ jobs:
 {%- if upload_on_branch %}
         UPLOAD_ON_BRANCH: {{ upload_on_branch }}
 {%- endif %}
-        SET_PAGEFILE_SIZE: $(pagefile_size)
 {%- for secret in secrets %}
         {{ secret }}: $({{ secret }})
 {%- endfor %}

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -57,7 +57,7 @@ jobs:
 {%- endif %}
 
     - script: |
-        if "%SET_PAGEFILE_SIZE:~0,1%" NEQ "0" (
+        if "%SET_PAGEFILE_SIZE%" NEQ "0" (
             set SET_PAGEFILE=True
         )
         call ".scripts\run_win_build.bat"

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -8,6 +8,9 @@
   {%- if os == 'win' and data.store_build_artifacts %}
     {%- set vars.store_build_artifacts = True %}
   {%- endif %}
+  {%- if os == 'win' and data.pagefile_size != 0 %}
+    {%- set vars.create_pagefile = True %}
+  {%- endif %}
 {%- endfor %}
 
 jobs:
@@ -56,8 +59,14 @@ jobs:
         $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
 {%- endif %}
 
+{%- if vars.create_pagefile %}
     - script: |
         call ".scripts\create_pagefile.bat" $(pagefile_size)
+      env:
+        CONDA_BLD_PATH: $(build_workspace_dir)
+      displayName: Create page file
+{%- endif %}
+    - script: |
         call ".scripts\run_win_build.bat"
       displayName: Run Windows build
       env:

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -57,9 +57,7 @@ jobs:
 {%- endif %}
 
     - script: |
-        if "%SET_PAGEFILE_SIZE%" NEQ "0" (
-            set SET_PAGEFILE=True
-        )
+        call ".scripts\create_pagefile.bat" "%SET_PAGEFILE_SIZE%"
         call ".scripts\run_win_build.bat"
       displayName: Run Windows build
       env:

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -57,7 +57,7 @@ jobs:
 {%- endif %}
 
     - script: |
-        call ".scripts\create_pagefile.bat" "%SET_PAGEFILE_SIZE%"
+        call ".scripts\create_pagefile.bat" %SET_PAGEFILE_SIZE%
         call ".scripts\run_win_build.bat"
       displayName: Run Windows build
       env:

--- a/conda_smithy/templates/create_pagefile.bat.tmpl
+++ b/conda_smithy/templates/create_pagefile.bat.tmpl
@@ -5,7 +5,7 @@ set SET_PAGEFILE_SIZE=%1
 :: Increase pagefile size, cf. https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/155
 set ThisScriptsDirectory=%~dp0
 set EntryPointPath=%ThisScriptsDirectory%SetPageFileSize.ps1
-REM Try to use different drive than CONDA_BLD_PATH-location for pagefile, if available
+:: Try to use different drive than CONDA_BLD_PATH-location for pagefile, if available
 set PageFileDrive=C:
 if /i "%CONDA_BLD_PATH:~0,2%" == "C:" (
     if exist D:\ set "PageFileDrive=D:"
@@ -21,3 +21,4 @@ if "%SET_PAGEFILE_SIZE%" GTR "0" (
         PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize "%SET_PAGEFILE_SIZE%GB" -MaximumSize "%SET_PAGEFILE_SIZE%GB" -DiskRoot \"%PageFileDrive%\""
     )
 )
+exit /b

--- a/conda_smithy/templates/create_pagefile.bat.tmpl
+++ b/conda_smithy/templates/create_pagefile.bat.tmpl
@@ -1,0 +1,33 @@
+setlocal enableextensions enabledelayedexpansion
+
+set SET_PAGEFILE_SIZE=%1%
+if "%SET_PAGEFILE_SIZE%" NEQ "0" (
+    set SET_PAGEFILE=True
+)
+if "%CONDA_BLD_PATH%" == "" (
+    set "CONDA_BLD_PATH=C:\bld"
+)
+
+:: Increase pagefile size, cf. https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/155
+:: Both in the recipe and in the final package, this script is co-located with SetPageFileSize.ps1, see meta.yaml
+set ThisScriptsDirectory=%~dp0
+set EntryPointPath=%ThisScriptsDirectory%SetPageFileSize.ps1
+REM use different drive than CONDA_BLD_PATH-location for pagefile
+set PageFileDrive=
+if /i "%CONDA_BLD_PATH%" == "C:\bld" set "PageFileDrive=D:"
+if /i "%CONDA_BLD_PATH%" == "C:\bld\" set "PageFileDrive=D:"
+if /i "%CONDA_BLD_PATH%" == "C:\\bld\\" set "PageFileDrive=D:"
+if /i "%CONDA_BLD_PATH%" == "D:\bld" set "PageFileDrive=C:"
+if /i "%CONDA_BLD_PATH%" == "D:\bld\" set "PageFileDrive=C:"
+if /i "%CONDA_BLD_PATH%" == "D:\\bld\\" set "PageFileDrive=C:"
+
+:: Only run if SET_PAGEFILE is set; EntryPointPath needs to be set outside if-condition when not using EnableDelayedExpansion.
+if "%SET_PAGEFILE%" NEQ "" (
+    if not "%PageFileDrive%" == "" (
+        echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 16GB in %PageFileDrive%
+        REM Inspired by:
+        REM https://blog.danskingdom.com/allow-others-to-run-your-powershell-scripts-from-a-batch-file-they-will-love-you-for-it/
+        REM Drive-letter needs to be escaped in quotes
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 16GB -DiskRoot \"%PageFileDrive%\""
+    )
+)

--- a/conda_smithy/templates/create_pagefile.bat.tmpl
+++ b/conda_smithy/templates/create_pagefile.bat.tmpl
@@ -1,9 +1,6 @@
 setlocal enableextensions enabledelayedexpansion
 
 set SET_PAGEFILE_SIZE=%1%
-if "%SET_PAGEFILE_SIZE%" NEQ "0" (
-    set SET_PAGEFILE=True
-)
 if "%CONDA_BLD_PATH%" == "" (
     set "CONDA_BLD_PATH=C:\bld"
 )
@@ -21,13 +18,13 @@ if /i "%CONDA_BLD_PATH%" == "D:\bld" set "PageFileDrive=C:"
 if /i "%CONDA_BLD_PATH%" == "D:\bld\" set "PageFileDrive=C:"
 if /i "%CONDA_BLD_PATH%" == "D:\\bld\\" set "PageFileDrive=C:"
 
-:: Only run if SET_PAGEFILE is set; EntryPointPath needs to be set outside if-condition when not using EnableDelayedExpansion.
-if "%SET_PAGEFILE%" NEQ "" (
+:: Only run if SET_PAGEFILE_SIZE is set; EntryPointPath needs to be set outside if-condition when not using EnableDelayedExpansion.
+if "%SET_PAGEFILE_SIZE%" GTR "0" (
     if not "%PageFileDrive%" == "" (
-        echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to 16GB in %PageFileDrive%
+        echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to %SET_PAGEFILE_SIZE% GiB in %PageFileDrive%
         REM Inspired by:
         REM https://blog.danskingdom.com/allow-others-to-run-your-powershell-scripts-from-a-batch-file-they-will-love-you-for-it/
         REM Drive-letter needs to be escaped in quotes
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize 8GB -MaximumSize 16GB -DiskRoot \"%PageFileDrive%\""
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize "%SET_PAGEFILE_SIZE%GB" -MaximumSize "%SET_PAGEFILE_SIZE%GB" -DiskRoot \"%PageFileDrive%\""
     )
 )

--- a/conda_smithy/templates/create_pagefile.bat.tmpl
+++ b/conda_smithy/templates/create_pagefile.bat.tmpl
@@ -1,6 +1,6 @@
 setlocal enableextensions enabledelayedexpansion
 
-set SET_PAGEFILE_SIZE=%1
+set PAGEFILE_SIZE=%1
 
 :: Increase pagefile size, cf. https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/155
 set ThisScriptsDirectory=%~dp0
@@ -11,14 +11,14 @@ if /i "%CONDA_BLD_PATH:~0,2%" == "C:" (
     if exist D:\ set "PageFileDrive=D:"
 )
 
-:: Only run if SET_PAGEFILE_SIZE is set; EntryPointPath needs to be set outside if-condition when not using EnableDelayedExpansion.
-if "%SET_PAGEFILE_SIZE%" GTR "0" (
+:: Only run if PAGEFILE_SIZE is set; EntryPointPath needs to be set outside if-condition when not using EnableDelayedExpansion.
+if "%PAGEFILE_SIZE%" GTR "0" (
     if not "%PageFileDrive%" == "" (
-        echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to %SET_PAGEFILE_SIZE% GiB in %PageFileDrive%
+        echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to %PAGEFILE_SIZE% GiB in %PageFileDrive%
         REM Inspired by:
         REM https://blog.danskingdom.com/allow-others-to-run-your-powershell-scripts-from-a-batch-file-they-will-love-you-for-it/
         REM Drive-letter needs to be escaped in quotes
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize "%SET_PAGEFILE_SIZE%GB" -MaximumSize "%SET_PAGEFILE_SIZE%GB" -DiskRoot \"%PageFileDrive%\""
+        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize "%PAGEFILE_SIZE%GB" -MaximumSize "%PAGEFILE_SIZE%GB" -DiskRoot \"%PageFileDrive%\""
     )
 )
 exit /b

--- a/conda_smithy/templates/create_pagefile.bat.tmpl
+++ b/conda_smithy/templates/create_pagefile.bat.tmpl
@@ -1,12 +1,11 @@
 setlocal enableextensions enabledelayedexpansion
 
-set SET_PAGEFILE_SIZE=%1%
+set SET_PAGEFILE_SIZE=%1
 
 :: Increase pagefile size, cf. https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/155
-:: Both in the recipe and in the final package, this script is co-located with SetPageFileSize.ps1, see meta.yaml
 set ThisScriptsDirectory=%~dp0
 set EntryPointPath=%ThisScriptsDirectory%SetPageFileSize.ps1
-REM use different drive than CONDA_BLD_PATH-location for pagefile
+REM Try to use different drive than CONDA_BLD_PATH-location for pagefile, if available
 set PageFileDrive=C:
 if /i "%CONDA_BLD_PATH:~0,2%" == "C:" (
     if exist D:\ set "PageFileDrive=D:"

--- a/conda_smithy/templates/create_pagefile.bat.tmpl
+++ b/conda_smithy/templates/create_pagefile.bat.tmpl
@@ -1,22 +1,16 @@
 setlocal enableextensions enabledelayedexpansion
 
 set SET_PAGEFILE_SIZE=%1%
-if "%CONDA_BLD_PATH%" == "" (
-    set "CONDA_BLD_PATH=C:\bld"
-)
 
 :: Increase pagefile size, cf. https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/155
 :: Both in the recipe and in the final package, this script is co-located with SetPageFileSize.ps1, see meta.yaml
 set ThisScriptsDirectory=%~dp0
 set EntryPointPath=%ThisScriptsDirectory%SetPageFileSize.ps1
 REM use different drive than CONDA_BLD_PATH-location for pagefile
-set PageFileDrive=
-if /i "%CONDA_BLD_PATH%" == "C:\bld" set "PageFileDrive=D:"
-if /i "%CONDA_BLD_PATH%" == "C:\bld\" set "PageFileDrive=D:"
-if /i "%CONDA_BLD_PATH%" == "C:\\bld\\" set "PageFileDrive=D:"
-if /i "%CONDA_BLD_PATH%" == "D:\bld" set "PageFileDrive=C:"
-if /i "%CONDA_BLD_PATH%" == "D:\bld\" set "PageFileDrive=C:"
-if /i "%CONDA_BLD_PATH%" == "D:\\bld\\" set "PageFileDrive=C:"
+set PageFileDrive=C:
+if /i "%CONDA_BLD_PATH:~0,2%" == "C:" (
+    if exist D:\ set "PageFileDrive=D:"
+)
 
 :: Only run if SET_PAGEFILE_SIZE is set; EntryPointPath needs to be set outside if-condition when not using EnableDelayedExpansion.
 if "%SET_PAGEFILE_SIZE%" GTR "0" (

--- a/conda_smithy/templates/create_pagefile.sh.tmpl
+++ b/conda_smithy/templates/create_pagefile.sh.tmpl
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -ex
+
+SET_PAGEFILE_SIZE=${1}
+
+[[ ${SET_PAGEFILE_SIZE} -le 0 ]] && exit
+
+SWAPFILE=/swapfile
+# If there is already a swapfile, disable it and remove it
+if swapon --show | grep -q "^${SWAPFILE}"; then
+	sudo swapoff "${SWAPFILE}" || true
+fi
+[[ -f ${SWAPFILE} ]] && sudo rm -f "${SWAPFILE}"
+
+sudo fallocate -l "${SET_PAGEFILE_SIZE}GiB" "${SWAPFILE}"
+sudo chmod 600 "${SWAPFILE}"
+sudo mkswap "${SWAPFILE}"
+sudo swapon "${SWAPFILE}"

--- a/conda_smithy/templates/create_pagefile.sh.tmpl
+++ b/conda_smithy/templates/create_pagefile.sh.tmpl
@@ -2,9 +2,9 @@
 
 set -ex
 
-SET_PAGEFILE_SIZE=${1}
+PAGEFILE_SIZE=${1}
 
-[[ ${SET_PAGEFILE_SIZE} -le 0 ]] && exit
+[[ ${PAGEFILE_SIZE} -le 0 ]] && exit
 
 SWAPFILE=/swapfile
 # If there is already a swapfile, disable it and remove it
@@ -13,7 +13,7 @@ if swapon --show | grep -q "^${SWAPFILE}"; then
 fi
 [[ -f ${SWAPFILE} ]] && sudo rm -f "${SWAPFILE}"
 
-sudo fallocate -l "${SET_PAGEFILE_SIZE}GiB" "${SWAPFILE}"
+sudo fallocate -l "${PAGEFILE_SIZE}GiB" "${SWAPFILE}"
 sudo chmod 600 "${SWAPFILE}"
 sudo mkswap "${SWAPFILE}"
 sudo swapon "${SWAPFILE}"

--- a/conda_smithy/templates/create_pagefile.sh.tmpl
+++ b/conda_smithy/templates/create_pagefile.sh.tmpl
@@ -9,7 +9,7 @@ SET_PAGEFILE_SIZE=${1}
 SWAPFILE=/swapfile
 # If there is already a swapfile, disable it and remove it
 if swapon --show | grep -q "^${SWAPFILE}"; then
-	sudo swapoff "${SWAPFILE}" || true
+    sudo swapoff "${SWAPFILE}" || true
 fi
 [[ -f ${SWAPFILE} ]] && sudo rm -f "${SWAPFILE}"
 

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -112,7 +112,7 @@ jobs:
         UPLOAD_ON_BRANCH: {{ upload_on_branch }}
 {%- endif %}
         CONDA_FORGE_DOCKER_RUN_ARGS: "{% raw %}${{ matrix.docker_run_args }}{% endraw %}"
-        SET_PAGEFILE_SIZE: {% raw %}${{ matrix.pagefile_size }}{% endraw %}
+        PAGEFILE_SIZE: {% raw %}${{ matrix.pagefile_size }}{% endraw %}
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}
@@ -135,9 +135,9 @@ jobs:
         export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         echo "::endgroup::"
-        if [[ ${SET_PAGEFILE_SIZE} -gt 0 ]]; then
+        if [[ ${PAGEFILE_SIZE} -gt 0 ]]; then
             echo "::group::Setting up swap file"
-            .scripts/create_pagefile.sh "${SET_PAGEFILE_SIZE}"
+            .scripts/create_pagefile.sh "${PAGEFILE_SIZE}"
             echo "::endgroup::"
         fi
         ./.scripts/run_docker_build.sh
@@ -215,7 +215,7 @@ jobs:
         set "flow_run_id=github_%GITHUB_RUN_ID%"
         set "remote_url=https://github.com/%GITHUB_REPOSITORY%"
         set "sha=%GITHUB_SHA%"
-        call ".scripts\create_pagefile.bat" %SET_PAGEFILE_SIZE%
+        call ".scripts\create_pagefile.bat" %PAGEFILE_SIZE%
         call ".scripts\run_win_build.bat"
       env:
         MINIFORGE_HOME: {% raw %}${{ matrix.tools_install_dir }}{% endraw %}
@@ -227,7 +227,7 @@ jobs:
 {%- if upload_on_branch %}
         UPLOAD_ON_BRANCH: {{ upload_on_branch }}
 {%- endif %}
-        SET_PAGEFILE_SIZE: {% raw %}${{ matrix.pagefile_size }}{% endraw %}
+        PAGEFILE_SIZE: {% raw %}${{ matrix.pagefile_size }}{% endraw %}
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -135,7 +135,7 @@ jobs:
         export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         echo "::endgroup::"
-        if [[ ${SET_PAGEFILE_SIZE} != 0* ]]; then
+        if [[ ${SET_PAGEFILE_SIZE} -gt 0 ]]; then
             echo "::group::Setting up swap file"
             SWAPFILE=/swapfile
             # If there is already a swapfile, disable it and remove it
@@ -144,7 +144,7 @@ jobs:
                 sudo swapoff $SWAPFILE
             fi
             [ -f "$SWAPFILE" ] && sudo rm -f $SWAPFILE
-            sudo fallocate -l "${SET_PAGEFILE_SIZE}" $SWAPFILE
+            sudo fallocate -l "${SET_PAGEFILE_SIZE}GiB" $SWAPFILE
             sudo chmod 600 $SWAPFILE
             sudo mkswap $SWAPFILE
             sudo swapon $SWAPFILE
@@ -225,7 +225,7 @@ jobs:
         set "flow_run_id=github_%GITHUB_RUN_ID%"
         set "remote_url=https://github.com/%GITHUB_REPOSITORY%"
         set "sha=%GITHUB_SHA%"
-        if "%SET_PAGEFILE_SIZE:~0,1%" NEQ "0" (
+        if "%SET_PAGEFILE_SIZE%" NEQ "0" (
             set SET_PAGEFILE=True
         )
         call ".scripts\run_win_build.bat"

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -112,7 +112,7 @@ jobs:
         UPLOAD_ON_BRANCH: {{ upload_on_branch }}
 {%- endif %}
         CONDA_FORGE_DOCKER_RUN_ARGS: "{% raw %}${{ matrix.docker_run_args }}{% endraw %}"
-        SET_PAGEFILE_SIZE: "{% raw %}${{ matrix.pagefile_size }}{% endraw %}"
+        SET_PAGEFILE_SIZE: {% raw %}${{ matrix.pagefile_size }}{% endraw %}
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}
@@ -215,7 +215,7 @@ jobs:
         set "flow_run_id=github_%GITHUB_RUN_ID%"
         set "remote_url=https://github.com/%GITHUB_REPOSITORY%"
         set "sha=%GITHUB_SHA%"
-        call ".scripts\create_pagefile.bat" "%SET_PAGEFILE_SIZE%"
+        call ".scripts\create_pagefile.bat" %SET_PAGEFILE_SIZE%
         call ".scripts\run_win_build.bat"
       env:
         MINIFORGE_HOME: {% raw %}${{ matrix.tools_install_dir }}{% endraw %}
@@ -227,7 +227,7 @@ jobs:
 {%- if upload_on_branch %}
         UPLOAD_ON_BRANCH: {{ upload_on_branch }}
 {%- endif %}
-        SET_PAGEFILE_SIZE: "{% raw %}${{ matrix.pagefile_size }}{% endraw %}"
+        SET_PAGEFILE_SIZE: {% raw %}${{ matrix.pagefile_size }}{% endraw %}
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -54,6 +54,7 @@ jobs:
             tools_install_dir: {{ data.tools_install_dir }}
             build_workspace_dir: {{ data.build_workspace_dir }}
             docker_run_args: {{ data.docker_run_args }}
+            pagefile_size: {{ data.pagefile_size }}
         {%- endfor %}
     steps:
 {%- if github_actions.free_disk_space %}
@@ -111,6 +112,7 @@ jobs:
         UPLOAD_ON_BRANCH: {{ upload_on_branch }}
 {%- endif %}
         CONDA_FORGE_DOCKER_RUN_ARGS: "{% raw %}${{ matrix.docker_run_args }}{% endraw %}"
+        SET_PAGEFILE_SIZE: "{% raw %}${{ matrix.pagefile_size }}{% endraw %}"
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}
@@ -133,6 +135,21 @@ jobs:
         export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         echo "::endgroup::"
+        if [[ ${SET_PAGEFILE_SIZE} != 0* ]]; then
+            echo "::group::Setting up swap file"
+            SWAPFILE=/swapfile
+            # If there is already a swapfile, disable it and remove it
+            if swapon --show | grep -q $SWAPFILE; then
+                echo "Disabling existing swapfile..."
+                sudo swapoff $SWAPFILE
+            fi
+            [ -f "$SWAPFILE" ] && sudo rm -f $SWAPFILE
+            sudo fallocate -l "${SET_PAGEFILE_SIZE}" $SWAPFILE
+            sudo chmod 600 $SWAPFILE
+            sudo mkswap $SWAPFILE
+            sudo swapon $SWAPFILE
+            echo "::endgroup::"
+        fi
         ./.scripts/run_docker_build.sh
 
     - name: Build on macOS
@@ -208,6 +225,9 @@ jobs:
         set "flow_run_id=github_%GITHUB_RUN_ID%"
         set "remote_url=https://github.com/%GITHUB_REPOSITORY%"
         set "sha=%GITHUB_SHA%"
+        if "%SET_PAGEFILE_SIZE:~0,1%" NEQ "0" (
+            set SET_PAGEFILE=True
+        )
         call ".scripts\run_win_build.bat"
       env:
         MINIFORGE_HOME: {% raw %}${{ matrix.tools_install_dir }}{% endraw %}
@@ -219,6 +239,7 @@ jobs:
 {%- if upload_on_branch %}
         UPLOAD_ON_BRANCH: {{ upload_on_branch }}
 {%- endif %}
+        SET_PAGEFILE_SIZE: "{% raw %}${{ matrix.pagefile_size }}{% endraw %}"
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -137,17 +137,7 @@ jobs:
         echo "::endgroup::"
         if [[ ${SET_PAGEFILE_SIZE} -gt 0 ]]; then
             echo "::group::Setting up swap file"
-            SWAPFILE=/swapfile
-            # If there is already a swapfile, disable it and remove it
-            if swapon --show | grep -q $SWAPFILE; then
-                echo "Disabling existing swapfile..."
-                sudo swapoff $SWAPFILE
-            fi
-            [ -f "$SWAPFILE" ] && sudo rm -f $SWAPFILE
-            sudo fallocate -l "${SET_PAGEFILE_SIZE}GiB" $SWAPFILE
-            sudo chmod 600 $SWAPFILE
-            sudo mkswap $SWAPFILE
-            sudo swapon $SWAPFILE
+            .scripts/create_pagefile.sh "${SET_PAGEFILE_SIZE}"
             echo "::endgroup::"
         fi
         ./.scripts/run_docker_build.sh
@@ -225,9 +215,7 @@ jobs:
         set "flow_run_id=github_%GITHUB_RUN_ID%"
         set "remote_url=https://github.com/%GITHUB_REPOSITORY%"
         set "sha=%GITHUB_SHA%"
-        if "%SET_PAGEFILE_SIZE%" NEQ "0" (
-            set SET_PAGEFILE=True
-        )
+        call ".scripts\create_pagefile.bat" "%SET_PAGEFILE_SIZE%"
         call ".scripts\run_win_build.bat"
       env:
         MINIFORGE_HOME: {% raw %}${{ matrix.tools_install_dir }}{% endraw %}

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -411,4 +411,4 @@ def fill_workflow_settings_defaults(
         }[os]
 
     if workflow_settings.get("pagefile_size") is None:
-        workflow_settings["pagefile_size"] = "0"
+        workflow_settings["pagefile_size"] = 0

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -409,3 +409,6 @@ def fill_workflow_settings_defaults(
             # TODO: switch to normalizing all paths once we're ready
             "win": rf"{tools_drive}\\bld\\",
         }[os]
+
+    if workflow_settings.get("pagefile_size") is None:
+        workflow_settings["pagefile_size"] = "0"

--- a/news/2562-pagefile-size.rst
+++ b/news/2562-pagefile-size.rst
@@ -8,7 +8,7 @@
 
 **Deprecated:**
 
-* <news item>
+* ``azure.settings_linux.swapfile_size`` and ``azure.settings_win.variables.SET_PAGEFILE`` are deprecated in favor of ``workflow_settings.pagefile_size``. (#2562)
 
 **Removed:**
 

--- a/news/2562-pagefile-size.rst
+++ b/news/2562-pagefile-size.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* ``workflow_settings.pagefile_size`` to set page file (swap file) size consistently across CI providers, on Linux and Windows. (#2562)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -3322,3 +3322,72 @@ def test_docker_run_args_azure(
         assert {entry.get("docker_run_args") for entry in matrix.values()} == {
             None if os_name != "linux" else "--cap-add SYS_ADMIN" if old or new else ""
         }
+
+
+@pytest.mark.parametrize("path", ["azure", "workflow_settings", "both"])
+@pytest.mark.parametrize("value", [0, 16])
+def test_pagefile_size_azure(py_recipe, jinja_env, caplog, path: str, value: bool):
+    forge_dir = py_recipe.recipe
+    forge_yml = Path(forge_dir, "conda-forge.yml")
+
+    with open(forge_yml, "a") as f:
+        f.write(textwrap.dedent("""\
+            provider:
+              linux_64: azure
+              osx_64: azure
+              win_64: azure
+        """))
+        if path != "workflow_settings":
+            f.write(textwrap.dedent(f"""\
+                azure:
+                  settings_linux:
+                    swapfile_size: {value}GiB
+                  settings_win:
+                    variables:
+                      SET_PAGEFILE: {'True' if value else ''}
+            """))
+        if path != "azure":
+            f.write(textwrap.dedent(f"""\
+                workflow_settings:
+                  pagefile_size: {value}
+            """))
+
+    with caplog.at_level(logging.WARNING):
+        config = configure_feedstock._load_forge_config(
+            forge_dir, "recipe/default_config.yaml"
+        )
+        if path == "both":
+            assert any(
+                "`azure.settings_linux.swapfile_size` is ignored" in record.message
+                for record in caplog.records
+            )
+            assert any(
+                "`azure.settings_win.variables.SET_PAGEFILE` is ignored"
+                in record.message
+                for record in caplog.records
+            )
+
+    configure_feedstock.render_azure(
+        jinja_env=jinja_env,
+        forge_config=config,
+        forge_dir=forge_dir,
+    )
+
+    for os_name in ("linux", "win"):
+        workflow_yml = Path(
+            forge_dir, ".azure-pipelines", f"azure-pipelines-{os_name}.yml"
+        )
+        with workflow_yml.open() as f:
+            workflow = yaml.safe_load(f)
+
+        matrix = workflow["jobs"][0]["strategy"]["matrix"]
+        assert all(entry["pagefile_size"] == value for entry in matrix.values())
+
+        # check that artifacts steps are output / not output
+        steps = workflow["jobs"][0]["steps"]
+        step_names = set(step["displayName"] for step in steps)
+        assert ("Create page file" in step_names) is (value != 0)
+
+    assert Path(forge_dir, ".scripts/create_pagefile.bat").exists() is (value != 0)
+    assert Path(forge_dir, ".scripts/SetPageFileSize.ps1").exists() is (value != 0)
+    assert Path(forge_dir, ".scripts/create_pagefile.sh").exists() is (value != 0)

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -429,9 +429,9 @@ def test_upload_on_branch_azure(upload_on_branch_recipe, jinja_env):
     ) as fp:
         content_lin = yaml.safe_load(fp)
     assert (
-        'UPLOAD_ON_BRANCH="foo-branch"' in content_lin["jobs"][0]["steps"][1]["script"]
+        'UPLOAD_ON_BRANCH="foo-branch"' in content_lin["jobs"][0]["steps"][2]["script"]
     )
-    assert "BUILD_SOURCEBRANCHNAME" in content_lin["jobs"][0]["steps"][1]["script"]
+    assert "BUILD_SOURCEBRANCHNAME" in content_lin["jobs"][0]["steps"][2]["script"]
 
 
 def test_upload_on_branch_github_actions(upload_on_branch_recipe, jinja_env):

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -429,9 +429,9 @@ def test_upload_on_branch_azure(upload_on_branch_recipe, jinja_env):
     ) as fp:
         content_lin = yaml.safe_load(fp)
     assert (
-        'UPLOAD_ON_BRANCH="foo-branch"' in content_lin["jobs"][0]["steps"][2]["script"]
+        'UPLOAD_ON_BRANCH="foo-branch"' in content_lin["jobs"][0]["steps"][1]["script"]
     )
-    assert "BUILD_SOURCEBRANCHNAME" in content_lin["jobs"][0]["steps"][2]["script"]
+    assert "BUILD_SOURCEBRANCHNAME" in content_lin["jobs"][0]["steps"][1]["script"]
 
 
 def test_upload_on_branch_github_actions(upload_on_branch_recipe, jinja_env):

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -3324,9 +3324,11 @@ def test_docker_run_args_azure(
         }
 
 
-@pytest.mark.parametrize("path", ["azure", "workflow_settings", "both"])
+@pytest.mark.parametrize("path", ["none", "azure", "workflow_settings", "both"])
 @pytest.mark.parametrize("value", [0, 16])
-def test_pagefile_size_azure(py_recipe, jinja_env, caplog, path: str, value: bool):
+def test_pagefile_size_azure(py_recipe, jinja_env, caplog, path: str, value: int):
+    if path == "none" and value != 0:
+        pytest.skip("meaningless combination")
     forge_dir = py_recipe.recipe
     forge_yml = Path(forge_dir, "conda-forge.yml")
 
@@ -3337,7 +3339,7 @@ def test_pagefile_size_azure(py_recipe, jinja_env, caplog, path: str, value: boo
               osx_64: azure
               win_64: azure
         """))
-        if path != "workflow_settings":
+        if path in ("azure", "both"):
             f.write(textwrap.dedent(f"""\
                 azure:
                   settings_linux:
@@ -3346,7 +3348,7 @@ def test_pagefile_size_azure(py_recipe, jinja_env, caplog, path: str, value: boo
                     variables:
                       SET_PAGEFILE: {'True' if value else ''}
             """))
-        if path != "azure":
+        if path in ("workflow_settings", "both"):
             f.write(textwrap.dedent(f"""\
                 workflow_settings:
                   pagefile_size: {value}
@@ -3373,6 +3375,7 @@ def test_pagefile_size_azure(py_recipe, jinja_env, caplog, path: str, value: boo
         forge_dir=forge_dir,
     )
 
+    expected = value != 0
     for os_name in ("linux", "win"):
         workflow_yml = Path(
             forge_dir, ".azure-pipelines", f"azure-pipelines-{os_name}.yml"
@@ -3386,8 +3389,49 @@ def test_pagefile_size_azure(py_recipe, jinja_env, caplog, path: str, value: boo
         # check that artifacts steps are output / not output
         steps = workflow["jobs"][0]["steps"]
         step_names = set(step["displayName"] for step in steps)
-        assert ("Create page file" in step_names) is (value != 0)
+        assert ("Create page file" in step_names) is expected
 
-    assert Path(forge_dir, ".scripts/create_pagefile.bat").exists() is (value != 0)
-    assert Path(forge_dir, ".scripts/SetPageFileSize.ps1").exists() is (value != 0)
-    assert Path(forge_dir, ".scripts/create_pagefile.sh").exists() is (value != 0)
+    assert Path(forge_dir, ".scripts/create_pagefile.bat").exists() is expected
+    assert Path(forge_dir, ".scripts/SetPageFileSize.ps1").exists() is expected
+    assert Path(forge_dir, ".scripts/create_pagefile.sh").exists() is expected
+
+
+@pytest.mark.parametrize("value", [None, 0, 16])
+def test_pagefile_size_gha(py_recipe, jinja_env, caplog, value: int | None):
+    forge_dir = py_recipe.recipe
+    forge_yml = Path(forge_dir, "conda-forge.yml")
+
+    with open(forge_yml, "a") as f:
+        f.write(textwrap.dedent("""\
+            provider:
+              linux_64: github_actions
+              osx_64: github_actions
+              win_64: github_actions
+        """))
+        if value is not None:
+            f.write(textwrap.dedent(f"""\
+                workflow_settings:
+                  pagefile_size: {value}
+            """))
+
+    config = configure_feedstock._load_forge_config(
+        forge_dir, "recipe/default_config.yaml"
+    )
+    configure_feedstock.render_github_actions(
+        jinja_env=jinja_env,
+        forge_config=config,
+        forge_dir=forge_dir,
+    )
+
+    conda_build_yml = Path(forge_dir, ".github/workflows/conda-build.yml")
+    with conda_build_yml.open() as f:
+        workflow = yaml.safe_load(f)
+
+    matrix = workflow["jobs"]["build"]["strategy"]["matrix"]["include"]
+    assert all(entry["pagefile_size"] == (value or 0) for entry in matrix)
+
+    # check that artifacts steps are output / not output
+    expected = (value or 0) != 0
+    assert Path(forge_dir, ".scripts/create_pagefile.bat").exists() is expected
+    assert Path(forge_dir, ".scripts/SetPageFileSize.ps1").exists() is expected
+    assert Path(forge_dir, ".scripts/create_pagefile.sh").exists() is expected

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4850,6 +4850,7 @@ def test_deprecated_environment_variables(tmp_path):
           settings_win:
             variables:
               MINIFORGE_HOME: D:\\Miniforge
+              SET_PAGEFILE: True
         """))
 
     lints, hints = linter.main(tmp_path, return_hints=True, conda_forge=True)
@@ -4860,6 +4861,7 @@ def test_deprecated_environment_variables(tmp_path):
         "`azure.settings_osx.variables.CONDA_BLD_PATH` is deprecated, please use `workflow_settings.build_workspace_dir` instead.",
         "`azure.settings_osx.variables.MINIFORGE_HOME` is deprecated, please use `workflow_settings.tools_install_dir` instead.",
         "`azure.settings_win.variables.MINIFORGE_HOME` is deprecated, please use `workflow_settings.tools_install_dir` instead.",
+        "`azure.settings_win.variables.SET_PAGEFILE` is deprecated, please use `workflow_settings.pagefile_size` instead.",
     }
 
     assert expected.issubset(hints)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [x] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Add a new `workflow_settings.pagefile_size` key that can be used to control page/swap file size regardless of CI provider and platform. It replicates the existing swapfile logic for Azure/Linux to GHA. For Windows, it defines `SET_PAGEFILE_SIZE` per
https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/160, along with compatibility code setting `SET_PAGEFILE` for compatibility with the current verison of `conda-forge-ci-setup`.

Closes #1971

