### PR TITLE
Unify runner images versions between Github Actions and Azure Pipelines

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -179,7 +179,7 @@ GITHUB_ACTIONS_RUNS_ON = {
     },
     "osx-arm64": {
         "os": "macos",
-        "hosted_labels": ("macos-latest",),
+        "hosted_labels": ("macos-15",),
         "self_hosted_labels": ("macOS", "arm64"),
     },
     "linux-64": {

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -199,7 +199,7 @@ GITHUB_ACTIONS_RUNS_ON = {
     },
     "win-64": {
         "os": "windows",
-        "hosted_labels": ("windows-latest",),
+        "hosted_labels": ("windows-2022",),
         "self_hosted_labels": ("windows", "x64"),
     },
     "win-arm64": {

--- a/news/2564-unify-runner-images.rst
+++ b/news/2564-unify-runner-images.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Github Actions runner images for macOS and Windows now match Azure Pipelines defaults (15 and 2022, respectively). (#2564)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -2834,7 +2834,7 @@ def test_store_build_artifacts_gha_and_azure_conditions(py_recipe, jinja_env):
         "default",
         "hosted",
         "blacksmith-8vcpu-windows-2025",
-        "windows-latest",
+        "windows-2022",
         "windows-2025",
         "namespace-profile-16cpu-on-win-64",
     ],
@@ -2873,7 +2873,7 @@ def test_tools_build_paths_gha(py_recipe, jinja_env, label: str):
         "ubuntu-latest": ("~/miniforge3", "build_artifacts"),
         "windows-11-arm": (r"C:\Miniforge", r"C:\\bld\\"),
     }
-    expected_label = "windows-latest" if label in (None, "default", "hosted") else label
+    expected_label = "windows-2022" if label in (None, "default", "hosted") else label
     if expected_label.startswith("blacksmith"):
         expected[expected_label] = (r"C:\Miniforge", r"C:\\bld\\")
     else:
@@ -3098,7 +3098,7 @@ def test_tools_build_paths_gha_override_tools_dir(py_recipe, jinja_env):
         "macos-15-intel": ("~/foo", "~/foo/conda-bld"),
         "ubuntu-latest": ("~/foo", "build_artifacts"),
         "windows-11-arm": (r"C:\foo", r"C:\\bld\\"),
-        "windows-latest": (r"C:\foo", r"C:\\bld\\"),
+        "windows-2022": (r"C:\foo", r"C:\\bld\\"),
     }
 
     matrix = workflow["jobs"]["build"]["strategy"]["matrix"]["include"]
@@ -3152,7 +3152,7 @@ def test_tools_build_paths_gha_override_both(py_recipe, jinja_env):
         "macos-15-intel": ("~/foo", "~/bar"),
         "ubuntu-latest": ("~/foo", "~/bar"),
         "windows-11-arm": (r"C:\foo", r"D:\bar"),
-        "windows-latest": (r"C:\foo", r"D:\bar"),
+        "windows-2022": (r"C:\foo", r"D:\bar"),
     }
 
     matrix = workflow["jobs"]["build"]["strategy"]["matrix"]["include"]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

- We should have the same across providers to avoid surprises. This has not been a problem so far because we only enabled Linux (which runs on Docker), but Windows is coming soon once we handle #2349, so let's get it right.
- Also closes #2563.