### PR TITLE
simplify create_pagefile.bat

### DIFF
--- a/conda_smithy/templates/create_pagefile.bat.tmpl
+++ b/conda_smithy/templates/create_pagefile.bat.tmpl
@@ -11,14 +11,13 @@ if /i "%CONDA_BLD_PATH:~0,2%" == "C:" (
     if exist D:\ set "PageFileDrive=D:"
 )
 
-:: Only run if PAGEFILE_SIZE is set; EntryPointPath needs to be set outside if-condition when not using EnableDelayedExpansion.
+:: Only run if PAGEFILE_SIZE is set
 if "%PAGEFILE_SIZE%" GTR "0" (
-    if not "%PageFileDrive%" == "" (
-        echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to %PAGEFILE_SIZE% GiB in %PageFileDrive%
-        REM Inspired by:
-        REM https://blog.danskingdom.com/allow-others-to-run-your-powershell-scripts-from-a-batch-file-they-will-love-you-for-it/
-        REM Drive-letter needs to be escaped in quotes
-        PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%EntryPointPath%' -MinimumSize "%PAGEFILE_SIZE%GB" -MaximumSize "%PAGEFILE_SIZE%GB" -DiskRoot \"%PageFileDrive%\""
-    )
+    echo CONDA_BLD_PATH=%CONDA_BLD_PATH%; Setting pagefile size to %PAGEFILE_SIZE% GiB in %PageFileDrive%
+    REM Inspired by:
+    REM https://blog.danskingdom.com/allow-others-to-run-your-powershell-scripts-from-a-batch-file-they-will-love-you-for-it/
+    REM Drive-letter needs to be escaped in quotes
+    PowerShell -NoProfile -ExecutionPolicy Bypass ^
+        -Command "& '%EntryPointPath%' -MinimumSize "%PAGEFILE_SIZE%GB" -MaximumSize "%PAGEFILE_SIZE%GB" -DiskRoot \"%PageFileDrive%\""
 )
 exit /b


### PR DESCRIPTION
Follow-up to #2562; there's no scenario where `"%PageFileDrive%" == ""` is ever true, so get rid of the condition for that; also delete a comment about not using delayed expansion, since that script _is_ using delayed expansion. Finally, break up a very long line, at least a little (the rest is a nested invocation, so leave that as-is).

CC @mgorny