### PR TITLE
more consistently order environment variables 

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -992,11 +992,11 @@ def dump_subspace_config_files(metas, root_path, platform, arch, upload, forge_c
         # remove characters in variant values that are not legal for paths everywhere
         config_name = re.sub(r"[<>:?*,\"\/\|\\]", "", config_name)
 
-        short_config_name = config_name
+        config_name_short = config_name
         conf_hash = hashlib.sha256(config_name.encode("utf-8")).hexdigest()[:8]
         # drone has a limit of 50, see https://github.com/conda-forge/conda-smithy/issues/1188
-        if len(short_config_name) >= 49:
-            short_config_name = config_name[:40] + "_h" + conf_hash
+        if len(config_name_short) >= 49:
+            config_name_short = config_name[:40] + "_h" + conf_hash
         # we need to shorten long variant files to avoid hitting maximum path limits on win.
         # GHA is pretty much the worst offender here, as it will waste a lot of characters by
         # duplicating the repo name in a way that cannot be overridden (see #2476), e.g.
@@ -1026,7 +1026,7 @@ def dump_subspace_config_files(metas, root_path, platform, arch, upload, forge_c
                 "platform": target_platform,
                 "upload": upload,
                 "config": config,
-                "short_config_name": short_config_name,
+                "config_name_short": config_name_short,
                 "build_platform": forge_config["build_platform"][
                     f"{platform}_{arch}"
                 ].replace("_", "-"),
@@ -1879,7 +1879,7 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
         for label in labels:
             if label.startswith("cirun-"):
                 # Patch Cirun runners to add some extra debug info
-                label += "--${{ github.run_id }}-" + data["short_config_name"]
+                label += "--${{ github.run_id }}-" + data["config_name_short"]
             if "gpu" in label.lower():
                 # Having 'gpu' in one label name is enough to trigger
                 # the extra docker args needed on Linux
@@ -2052,7 +2052,7 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
         config_rendered.update(workflow_settings)
         script_suffix = ".bat" if platform == "win" else ".sh"
         if config_rendered["store_build_artifacts"]:
-            config_rendered["SHORT_CONFIG"] = data["short_config_name"]
+            config_rendered["CONFIG_SHORT"] = data["config_name_short"]
             template_files.append(f".scripts/create_conda_build_artifacts{script_suffix}")
         if config_rendered["pagefile_size"] != 0 and platform in ("linux", "win"):
             template_files.append(f".scripts/create_pagefile{script_suffix}")

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -65,18 +65,18 @@ jobs:
     displayName: Configure binfmt_misc
 
   - script: |
-        export MINIFORGE_HOME=$(tools_install_dir)
+        export CI=azure
         export CONDA_BLD_PATH=$(build_workspace_dir)
         export CONDA_FORGE_DOCKER_RUN_ARGS="$(docker_run_args)"
-        export CI=azure
-        export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
-        export remote_url=$(Build.Repository.Uri)
-        export sha=$(Build.SourceVersion)
-        export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
         export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+        export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+        export MINIFORGE_HOME=$(tools_install_dir)
 {%- if upload_on_branch %}
         export UPLOAD_ON_BRANCH="{{ upload_on_branch }}"
 {%- endif %}
+        export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
+        export remote_url=$(Build.Repository.Uri)
+        export sha=$(Build.SourceVersion)
         if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
           export IS_PR_BUILD="True"
         else
@@ -91,14 +91,14 @@ jobs:
 {%- if vars.store_build_artifacts %}
 
   - script: |
-        export MINIFORGE_HOME=$(tools_install_dir)
-        export CONDA_BLD_PATH=$(build_workspace_dir)
-        export CI=azure
-        export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
-        export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
         export ARTIFACT_STAGING_DIR="$(Build.ArtifactStagingDirectory)"
         # Archive everything in CONDA_BLD_PATH except environments
         export BLD_ARTIFACT_PREFIX=conda_artifacts
+        export CI=azure
+        export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+        export CONDA_BLD_PATH=$(build_workspace_dir)
+        export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+        export MINIFORGE_HOME=$(tools_install_dir)
         if [[ "$AGENT_JOBSTATUS" == "Failed" ]]; then
           # Archive the CONDA_BLD_PATH environments only when the job fails
           export ENV_ARTIFACT_PREFIX=conda_envs

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -20,18 +20,18 @@ jobs:
     fetchDepth: {{ clone_depth }}
 {%- endif %}
   - script: |
-      export MINIFORGE_HOME=$(tools_install_dir)
-      export CONDA_BLD_PATH=$(build_workspace_dir)
       export CI=azure
-      export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
-      export remote_url=$(Build.Repository.Uri)
-      export sha=$(Build.SourceVersion)
-      export OSX_FORCE_SDK_DOWNLOAD="1"
-      export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+      export CONDA_BLD_PATH=$(build_workspace_dir)
       export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+      export MINIFORGE_HOME=$(tools_install_dir)
+      export OSX_FORCE_SDK_DOWNLOAD="1"
 {%- if upload_on_branch %}
       export UPLOAD_ON_BRANCH="{{ upload_on_branch }}"
 {%- endif %}
+      export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
+      export remote_url=$(Build.Repository.Uri)
+      export sha=$(Build.SourceVersion)
       if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
         export IS_PR_BUILD="True"
       else
@@ -46,14 +46,14 @@ jobs:
 {%- if vars.store_build_artifacts %}
 
   - script: |
-      export MINIFORGE_HOME=$(tools_install_dir)
-      export CONDA_BLD_PATH=$(build_workspace_dir)
-      export CI=azure
-      export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
-      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
       export ARTIFACT_STAGING_DIR="$(Build.ArtifactStagingDirectory)"
       # Archive everything in CONDA_BLD_PATH except environments
       export BLD_ARTIFACT_PREFIX=conda_artifacts
+      export CI=azure
+      export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+      export CONDA_BLD_PATH=$(build_workspace_dir)
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      export MINIFORGE_HOME=$(tools_install_dir)
       if [[ "$AGENT_JOBSTATUS" == "Failed" ]]; then
         # Archive the CONDA_BLD_PATH environments only when the job fails
         export ENV_ARTIFACT_PREFIX=conda_envs

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -70,32 +70,32 @@ jobs:
         call ".scripts\run_win_build.bat"
       displayName: Run Windows build
       env:
-        MINIFORGE_HOME: $(tools_install_dir)
-        CONDA_BLD_PATH: $(build_workspace_dir)
-        PYTHONUNBUFFERED: 1
-        CONFIG: $(CONFIG)
         CI: azure
-        flow_run_id: azure_$(Build.BuildNumber).$(System.JobAttempt)
-        remote_url: $(Build.Repository.Uri)
-        sha: $(Build.SourceVersion)
-        UPLOAD_PACKAGES: $(UPLOAD_PACKAGES)
-        UPLOAD_TEMP: $(UPLOAD_TEMP)
+        CONFIG: $(CONFIG)
+        CONDA_BLD_PATH: $(build_workspace_dir)
+        MINIFORGE_HOME: $(tools_install_dir)
+        PYTHONUNBUFFERED: 1
 {%- if upload_on_branch %}
         UPLOAD_ON_BRANCH: {{ upload_on_branch }}
 {%- endif %}
+        UPLOAD_PACKAGES: $(UPLOAD_PACKAGES)
+        UPLOAD_TEMP: $(UPLOAD_TEMP)
+        flow_run_id: azure_$(Build.BuildNumber).$(System.JobAttempt)
+        remote_url: $(Build.Repository.Uri)
+        sha: $(Build.SourceVersion)
 {%- for secret in secrets %}
         {{ secret }}: $({{ secret }})
 {%- endfor %}
 {%- if vars.store_build_artifacts %}
 
     - script: |
-        set MINIFORGE_HOME=$(tools_install_dir)
-        set CONDA_BLD_PATH=$(build_workspace_dir)
+        set ARTIFACT_STAGING_DIR=$(Build.ArtifactStagingDirectory
+        set BLD_ARTIFACT_PREFIX=conda_artifacts
         set CI=azure
         set CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+        set CONDA_BLD_PATH=$(build_workspace_dir)
         set FEEDSTOCK_NAME=$(build.Repository.Name)
-        set ARTIFACT_STAGING_DIR=$(Build.ArtifactStagingDirectory)
-        set BLD_ARTIFACT_PREFIX=conda_artifacts
+        set MINIFORGE_HOME=$(tools_install_dir)
         if "%AGENT_JOBSTATUS%" == "Failed" (
             set ENV_ARTIFACT_PREFIX=conda_envs
         )

--- a/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
@@ -4,10 +4,11 @@ rem INPUTS (environment variables that need to be set before calling this script
 rem
 rem CI (azure/github_actions/UNSET)
 rem CI_RUN_ID (unique identifier for the CI job run)
-rem FEEDSTOCK_NAME
+rem CONDA_BLD_PATH (path to the conda-bld directory)
 rem CONFIG (build matrix configuration string)
 rem CONFIG_SHORT (uniquely-shortened configuration string)
-rem CONDA_BLD_PATH (path to the conda-bld directory)
+rem FEEDSTOCK_NAME
+rem Optional:
 rem ARTIFACT_STAGING_DIR (use working directory if unset)
 rem BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
 rem ENV_ARTIFACT_PREFIX (prefix for the conda build environments artifact name, skip if unset)

--- a/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
@@ -6,7 +6,7 @@ rem CI (azure/github_actions/UNSET)
 rem CI_RUN_ID (unique identifier for the CI job run)
 rem FEEDSTOCK_NAME
 rem CONFIG (build matrix configuration string)
-rem SHORT_CONFIG (uniquely-shortened configuration string)
+rem CONFIG_SHORT (uniquely-shortened configuration string)
 rem CONDA_BLD_PATH (path to the conda-bld directory)
 rem ARTIFACT_STAGING_DIR (use working directory if unset)
 rem BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
@@ -33,7 +33,7 @@ if not defined ARTIFACT_STAGING_DIR (
 rem Set a unique ID for the artifact(s), specialized for this particular job run
 set ARTIFACT_UNIQUE_ID=%CI_RUN_ID%_%CONFIG%
 if not "%ARTIFACT_UNIQUE_ID%" == "%ARTIFACT_UNIQUE_ID:~0,80%" (
-    set ARTIFACT_UNIQUE_ID=%CI_RUN_ID%_%SHORT_CONFIG%
+    set ARTIFACT_UNIQUE_ID=%CI_RUN_ID%_%CONFIG_SHORT%
 )
 
 rem Make the build artifact zip

--- a/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
@@ -4,10 +4,11 @@
 #
 # CI (azure/github_actions/UNSET)
 # CI_RUN_ID (unique identifier for the CI job run)
-# FEEDSTOCK_NAME
+# CONDA_BLD_PATH (path to the conda-bld directory)
 # CONFIG (build matrix configuration string)
 # CONFIG_SHORT (uniquely-shortened configuration string)
-# CONDA_BLD_PATH (path to the conda-bld directory)
+# FEEDSTOCK_NAME
+# Optional:
 # ARTIFACT_STAGING_DIR (use working directory if unset)
 # BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
 # ENV_ARTIFACT_PREFIX (prefix for the conda build environments artifact name, skip if unset)

--- a/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
@@ -6,7 +6,7 @@
 # CI_RUN_ID (unique identifier for the CI job run)
 # FEEDSTOCK_NAME
 # CONFIG (build matrix configuration string)
-# SHORT_CONFIG (uniquely-shortened configuration string)
+# CONFIG_SHORT (uniquely-shortened configuration string)
 # CONDA_BLD_PATH (path to the conda-bld directory)
 # ARTIFACT_STAGING_DIR (use working directory if unset)
 # BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
@@ -49,7 +49,7 @@ fi
 # Set a unique ID for the artifact(s), specialized for this particular job run
 ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${CONFIG}"
 if [[ {% raw %}${#ARTIFACT_UNIQUE_ID}{% endraw %} -gt 80 ]]; then
-    ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${SHORT_CONFIG}"
+    ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${CONFIG_SHORT}"
 fi
 echo "ARTIFACT_UNIQUE_ID: $ARTIFACT_UNIQUE_ID"
 

--- a/conda_smithy/templates/drone.yml.tmpl
+++ b/conda_smithy/templates/drone.yml.tmpl
@@ -6,7 +6,7 @@
 {%- set arch_drone = arch_map.get(arch_conda, arch_conda) -%}
 ---
 kind: pipeline
-name: {{ data.short_config_name }}
+name: {{ data.config_name_short }}
 
 platform:
   os: linux

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -41,20 +41,20 @@ jobs:
         include:
         {%- for data in configs %}
           - CONFIG: {{ data.config_name }}
-            STORE_BUILD_ARTIFACTS: {{ data.store_build_artifacts is true }}
         {%- if data.store_build_artifacts %}
             CONFIG_SHORT: {{ data.config_name_short }}
         {%- endif %}
-            UPLOAD_PACKAGES: {{ data.upload }}
-            os: {{ data.gha_os }}
-            runs_on: {{ data.gha_runs_on }}
         {%- if data.build_platform.startswith("linux") %}
             DOCKER_IMAGE: {{ data.config["docker_image"][-1] }}
         {%- endif %}
-            tools_install_dir: {{ data.tools_install_dir }}
+            STORE_BUILD_ARTIFACTS: {{ data.store_build_artifacts is true }}
+            UPLOAD_PACKAGES: {{ data.upload }}
             build_workspace_dir: {{ data.build_workspace_dir }}
             docker_run_args: {{ data.docker_run_args }}
+            os: {{ data.gha_os }}
             pagefile_size: {{ data.pagefile_size }}
+            runs_on: {{ data.gha_runs_on }}
+            tools_install_dir: {{ data.tools_install_dir }}
         {%- endfor %}
     steps:
 {%- if github_actions.free_disk_space %}
@@ -102,16 +102,16 @@ jobs:
       id: build-linux
       if: matrix.os == 'ubuntu'
       env:
-        MINIFORGE_HOME: {% raw %}${{ matrix.tools_install_dir }}{% endraw %}
-        CONDA_BLD_PATH: {% raw %}${{ matrix.build_workspace_dir }}{% endraw %}
-        CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
-        UPLOAD_PACKAGES: {% raw %}${{ matrix.UPLOAD_PACKAGES }}{% endraw %}
-        DOCKER_IMAGE: {% raw %}${{ matrix.DOCKER_IMAGE }}{% endraw %}
         CI: github_actions
+        CONDA_BLD_PATH: {% raw %}${{ matrix.build_workspace_dir }}{% endraw %}
+        CONDA_FORGE_DOCKER_RUN_ARGS: {% raw %}${{ matrix.docker_run_args }}{% endraw %}
+        CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
+        MINIFORGE_HOME: {% raw %}${{ matrix.tools_install_dir }}{% endraw %}
+        DOCKER_IMAGE: {% raw %}${{ matrix.DOCKER_IMAGE }}{% endraw %}
 {%- if upload_on_branch %}
         UPLOAD_ON_BRANCH: {{ upload_on_branch }}
 {%- endif %}
-        CONDA_FORGE_DOCKER_RUN_ARGS: "{% raw %}${{ matrix.docker_run_args }}{% endraw %}"
+        UPLOAD_PACKAGES: {% raw %}${{ matrix.UPLOAD_PACKAGES }}{% endraw %}
         PAGEFILE_SIZE: {% raw %}${{ matrix.pagefile_size }}{% endraw %}
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
@@ -122,18 +122,18 @@ jobs:
           echo "::group::Configure binfmt_misc"
           docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
         fi
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
           export IS_PR_BUILD="False"
         fi
-        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
-        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         echo "::endgroup::"
         if [[ ${PAGEFILE_SIZE} -gt 0 ]]; then
             echo "::group::Setting up swap file"
@@ -146,31 +146,31 @@ jobs:
       id: build-macos
       if: matrix.os == 'macos'
       env:
-        MINIFORGE_HOME: {% raw %}${{ matrix.tools_install_dir }}{% endraw %}
+        CI: github_actions
         CONDA_BLD_PATH: {% raw %}${{ matrix.build_workspace_dir }}{% endraw %}
         CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
-        UPLOAD_PACKAGES: {% raw %}${{ matrix.UPLOAD_PACKAGES }}{% endraw %}
-        CI: github_actions
+        MINIFORGE_HOME: {% raw %}${{ matrix.tools_install_dir }}{% endraw %}
 {%- if upload_on_branch %}
         UPLOAD_ON_BRANCH: {{ upload_on_branch }}
 {%- endif %}
+        UPLOAD_PACKAGES: {% raw %}${{ matrix.UPLOAD_PACKAGES }}{% endraw %}
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}
       shell: bash
       run: |
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
         export sha="$GITHUB_SHA"
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
         if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
           export IS_PR_BUILD="True"
         else
           export IS_PR_BUILD="False"
         fi
-        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
-        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         ./.scripts/run_osx_build.sh
 
 {%- for choco_pkg in choco %}
@@ -218,16 +218,16 @@ jobs:
         call ".scripts\create_pagefile.bat" %PAGEFILE_SIZE%
         call ".scripts\run_win_build.bat"
       env:
-        MINIFORGE_HOME: {% raw %}${{ matrix.tools_install_dir }}{% endraw %}
-        CONDA_BLD_PATH: {% raw %}${{ matrix.build_workspace_dir }}{% endraw %}
-        PYTHONUNBUFFERED: 1
-        CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
         CI: github_actions
-        UPLOAD_PACKAGES: {% raw %}${{ matrix.UPLOAD_PACKAGES }}{% endraw %}
+        CONDA_BLD_PATH: {% raw %}${{ matrix.build_workspace_dir }}{% endraw %}
+        CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
+        MINIFORGE_HOME: {% raw %}${{ matrix.tools_install_dir }}{% endraw %}
+        PAGEFILE_SIZE: {% raw %}${{ matrix.pagefile_size }}{% endraw %}
+        PYTHONUNBUFFERED: 1
 {%- if upload_on_branch %}
         UPLOAD_ON_BRANCH: {{ upload_on_branch }}
 {%- endif %}
-        PAGEFILE_SIZE: {% raw %}${{ matrix.pagefile_size }}{% endraw %}
+        UPLOAD_PACKAGES: {% raw %}${{ matrix.UPLOAD_PACKAGES }}{% endraw %}
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}
@@ -262,18 +262,18 @@ jobs:
       # we do not want to trigger artefact creation if the build was cancelled
       if: {% raw %}${{ always() && steps.determine-status.outputs.status != 'cancelled' && matrix.STORE_BUILD_ARTIFACTS }}{% endraw %}
       env:
-        CONDA_BLD_PATH: {% raw %}${{ matrix.build_workspace_dir }}{% endraw %}
         CI: github_actions
+        CONDA_BLD_PATH: {% raw %}${{ matrix.build_workspace_dir }}{% endraw %}
         CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
         CONFIG_SHORT: {% raw %}${{ matrix.CONFIG_SHORT }}{% endraw %}
         JOB_STATUS: {% raw %}${{ steps.determine-status.outputs.status }}{% endraw %}
         OS: {% raw %}${{ matrix.os }}{% endraw %}
       run: |
-        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
-        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
-        export CI_RUN_ID=$GITHUB_RUN_ID
-        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
         export ARTIFACT_STAGING_DIR="$GITHUB_WORKSPACE"
+        export CI_RUN_ID=$GITHUB_RUN_ID
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
+        export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         # Archive everything in CONDA_BLD_PATH except environments
         # Archive the CONDA_BLD_PATH environments only when the job fails
         # Use different prefix for successful and failed build artifacts

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -43,7 +43,7 @@ jobs:
           - CONFIG: {{ data.config_name }}
             STORE_BUILD_ARTIFACTS: {{ data.store_build_artifacts is true }}
         {%- if data.store_build_artifacts %}
-            SHORT_CONFIG: {{ data.short_config_name }}
+            CONFIG_SHORT: {{ data.config_name_short }}
         {%- endif %}
             UPLOAD_PACKAGES: {{ data.upload }}
             os: {{ data.gha_os }}
@@ -265,7 +265,7 @@ jobs:
         CONDA_BLD_PATH: {% raw %}${{ matrix.build_workspace_dir }}{% endraw %}
         CI: github_actions
         CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
-        SHORT_CONFIG: {% raw %}${{ matrix.SHORT_CONFIG }}{% endraw %}
+        CONFIG_SHORT: {% raw %}${{ matrix.CONFIG_SHORT }}{% endraw %}
         JOB_STATUS: {% raw %}${{ steps.determine-status.outputs.status }}{% endraw %}
         OS: {% raw %}${{ matrix.os }}{% endraw %}
       run: |

--- a/news/2570-alphabetize.rst
+++ b/news/2570-alphabetize.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Environment variables in various templates have been put in alphabetical order (#2570)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -2487,7 +2487,7 @@ def test_store_build_artifacts_gha(
     matrix = workflow["jobs"]["build"]["strategy"]["matrix"]["include"]
     assert all(entry["STORE_BUILD_ARTIFACTS"] is value for entry in matrix)
     if value:
-        assert all(entry.get("SHORT_CONFIG") for entry in matrix)
+        assert all(entry.get("CONFIG_SHORT") for entry in matrix)
 
     # check that artifacts steps are output / not output
     steps = workflow["jobs"]["build"]["steps"]
@@ -2561,7 +2561,7 @@ def test_store_build_artifacts_azure(
         matrix = workflow["jobs"][0]["strategy"]["matrix"]
         assert all(entry["store_build_artifacts"] is value for entry in matrix.values())
         if value:
-            assert all(entry.get("SHORT_CONFIG") for entry in matrix.values())
+            assert all(entry.get("CONFIG_SHORT") for entry in matrix.values())
 
         # check that artifacts steps are output / not output
         steps = workflow["jobs"][0]["steps"]


### PR DESCRIPTION
We're amassing quite a few variables in the templates now, e.g.
```yaml
      env:
        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
        CONFIG: ${{ matrix.CONFIG }}
        UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
        DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
        CI: github_actions
        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.docker_run_args }}"
```
resp.
```yaml
          - CONFIG: linux_64_
            STORE_BUILD_ARTIFACTS: False
            UPLOAD_PACKAGES: True
            os: ubuntu
            runs_on: ['ubuntu-latest']
            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
            tools_install_dir: ~/miniforge3
            build_workspace_dir: build_artifacts
            docker_run_args: 
            pagefile_size: 15
```

It would be nice to order these more consistently, which is what this PR does. I separated out a preparatory commit that IMO makes sense on its own, but is helpful particularly for grouping `CONFIG` and `CONFIG_SHORT` together. I suggest to review commit-by-commit.