### PR TITLE
fix: avoid false-positive maintainer lint on transient GitHub errors

### DIFF
--- a/conda_smithy/data/linter-messages.json
+++ b/conda_smithy/data/linter-messages.json
@@ -125,7 +125,7 @@
       "identifier": "CF-008",
       "category": "CF",
       "kind": "lint",
-      "added_in": "2026.6.0",
+      "added_in": "2026.6",
       "deprecated_in": "",
       "documentation": "The recipe maintainer existence check could not be completed.\n\nThis happens when GitHub cannot be reached or returns a transient error\n(e.g. a rate limit or a server error) while checking that a maintainer\nlisted in `extra.recipe-maintainers` is a valid Github user or\n`@conda-forge/*` team. Rather than risk a false-positive (or\nfalse-negative), the lint fails and asks for the check to be retried.",
       "message": "Could not verify that recipe maintainer ${team_or}\"${maintainer}\" exists due to a transient GitHub error. Please re-run the linter by commenting `@conda-forge-admin, please lint` on this pull request.",

--- a/conda_smithy/data/linter-messages.json
+++ b/conda_smithy/data/linter-messages.json
@@ -121,6 +121,21 @@
       "path": ""
     },
     {
+      "name": "InconclusiveMaintainerCheck",
+      "identifier": "CF-008",
+      "category": "CF",
+      "kind": "lint",
+      "added_in": "2026.6.0",
+      "deprecated_in": "",
+      "documentation": "The recipe maintainer existence check could not be completed.\n\nThis happens when GitHub cannot be reached or returns a transient error\n(e.g. a rate limit or a server error) while checking that a maintainer\nlisted in `extra.recipe-maintainers` is a valid Github user or\n`@conda-forge/*` team. Rather than risk a false-positive (or\nfalse-negative), the lint fails and asks for the check to be retried.",
+      "message": "Could not verify that recipe maintainer ${team_or}\"${maintainer}\" exists due to a transient GitHub error. Please re-run the linter by commenting `@conda-forge-admin, please lint` on this pull request.",
+      "examples": [
+        "Could not verify that recipe maintainer \"some-user\" exists due to a transient GitHub error. Please re-run the linter by commenting `@conda-forge-admin, please lint` on this pull request.",
+        "Could not verify that recipe maintainer team \"@conda-forge/some-team\" exists due to a transient GitHub error. Please re-run the linter by commenting `@conda-forge-admin, please lint` on this pull request."
+      ],
+      "path": "recipe/(meta|recipe).yaml"
+    },
+    {
       "name": "NoDuplicateKeys",
       "identifier": "FC-001",
       "category": "FC",

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -1,7 +1,9 @@
 import copy
 import json
+import logging
 import os
 import sys
+import time
 from collections.abc import Mapping
 from functools import lru_cache
 from glob import glob
@@ -91,6 +93,12 @@ from conda_smithy.utils import get_yaml, render_meta_yaml
 from conda_smithy.validate_schema import validate_json_schema
 
 NEEDED_FAMILIES = ["gpl", "bsd", "mit", "apache", "psf"]
+
+LOGGER = logging.getLogger(__name__)
+
+#: HTTP statuses that indicate a transient failure (rate limit / server error)
+#: rather than a definitive answer about whether a maintainer exists.
+_TRANSIENT_STATUS = frozenset({429, 500, 502, 503, 504})
 
 
 def _get_feedstock_config(recipe_dir: Optional[str] = None) -> dict:
@@ -455,8 +463,52 @@ def _cached_gh() -> github.Github:
     return _cached_gh_with_token(os.environ["GH_TOKEN"])
 
 
-def _maintainer_exists(maintainer: str) -> bool:
-    """Check if a maintainer exists on GitHub."""
+def _head_with_retries(url: str, *, retries: int = 4) -> Optional[requests.Response]:
+    """HEAD a URL, retrying transient/rate-limit statuses with backoff.
+
+    Returns the last response received, or ``None`` if every attempt raised a
+    network error. Redirects are not followed so the status code reflects the
+    exact URL requested.
+    """
+    backoff = 1.0
+    resp = None
+    for attempt in range(retries):
+        try:
+            resp = requests.head(url, allow_redirects=False, timeout=30)
+        except requests.RequestException as exc:
+            LOGGER.warning(
+                "HEAD %s failed (attempt %d/%d): %r",
+                url,
+                attempt + 1,
+                retries,
+                exc,
+            )
+            resp = None
+        else:
+            if resp.status_code not in _TRANSIENT_STATUS:
+                return resp
+            LOGGER.warning(
+                "HEAD %s -> %d (attempt %d/%d), retrying",
+                url,
+                resp.status_code,
+                attempt + 1,
+                retries,
+            )
+        if attempt < retries - 1:
+            time.sleep(backoff)
+            backoff *= 2
+    return resp
+
+
+def _maintainer_exists(maintainer: str) -> Optional[bool]:
+    """Check if a maintainer exists on GitHub.
+
+    Returns ``True`` if the maintainer is a known GitHub user, ``False`` if they
+    are definitively absent (no such account, or the username was renamed), and
+    ``None`` if the check could not be completed due to a transient error (rate
+    limit, server error, network failure) so callers can surface a hint instead
+    of a false-positive lint.
+    """
     if "GH_TOKEN" in os.environ:
         # use a token if we have one
         gh = _cached_gh()
@@ -465,6 +517,12 @@ def _maintainer_exists(maintainer: str) -> bool:
             is_user = True
         except github.UnknownObjectException:
             is_user = False
+        except github.GithubException as exc:
+            # rate limit / server error / etc. - undetermined
+            LOGGER.warning(
+                "Could not confirm maintainer %r exists: %r", maintainer, exc
+            )
+            return None
 
         # for w/e reason, the user endpoint returns an entry for orgs
         # however the org endpoint does not return an entry for users
@@ -474,6 +532,13 @@ def _maintainer_exists(maintainer: str) -> bool:
             is_org = True
         except github.UnknownObjectException:
             is_org = False
+        except github.GithubException as exc:
+            LOGGER.warning(
+                "Could not confirm maintainer %r exists: %r", maintainer, exc
+            )
+            return None
+
+        return is_user and not is_org
     else:
         # this API request has no token and so has a restrictive rate limit
         # return (
@@ -488,18 +553,29 @@ def _maintainer_exists(maintainer: str) -> bool:
         #    orgs so we make sure it fails
         # we do not allow redirects to ensure we get the correct status code
         # for the specific URL we requested
-        req_profile = requests.head(
-            f"https://github.com/{maintainer}",
-            allow_redirects=False,
-        )
-        is_user = req_profile.status_code == 200
-        req_org = requests.head(
-            f"https://github.com/orgs/{maintainer}/teams",
-            allow_redirects=False,
-        )
+        req_profile = _head_with_retries(f"https://github.com/{maintainer}")
+        # Undetermined: network failure or a persistent rate-limit/5xx.
+        if req_profile is None or req_profile.status_code in _TRANSIENT_STATUS:
+            LOGGER.warning(
+                "Could not confirm maintainer %r exists (status=%s)",
+                maintainer,
+                None if req_profile is None else req_profile.status_code,
+            )
+            return None
+        # 200 -> exists; 404 or a 3xx redirect (renamed/invalid username) -> absent
+        if req_profile.status_code != 200:
+            return False
+        # The account exists; make sure it is a user and not an org/team.
+        req_org = _head_with_retries(f"https://github.com/orgs/{maintainer}/teams")
+        if req_org is None or req_org.status_code in _TRANSIENT_STATUS:
+            LOGGER.warning(
+                "Could not confirm maintainer %r is a user (org status=%s)",
+                maintainer,
+                None if req_org is None else req_org.status_code,
+            )
+            return None
         is_org = req_org.status_code < 400
-
-    return is_user and not is_org
+        return not is_org
 
 
 @lru_cache(maxsize=1)
@@ -512,8 +588,13 @@ def _cached_gh_team(org: str, team: str) -> github.Team.Team:
     return _cached_gh_org(org).get_team_by_slug(team)
 
 
-def _team_exists(org_team: str) -> bool:
-    """Check if a team exists on GitHub."""
+def _team_exists(org_team: str) -> Optional[bool]:
+    """Check if a team exists on GitHub.
+
+    Returns ``True`` if the team exists, ``False`` if it does not, and ``None``
+    if the check could not be completed (no token available, or a transient
+    GitHub error).
+    """
     if "GH_TOKEN" in os.environ:
         _res = org_team.split("/", 1)
         if len(_res) != 2:
@@ -523,9 +604,13 @@ def _team_exists(org_team: str) -> bool:
             _cached_gh_team(org, team)
         except github.UnknownObjectException:
             return False
+        except github.GithubException as exc:
+            LOGGER.warning("Could not confirm team %r exists: %r", org_team, exc)
+            return None
         return True
     else:
-        # we cannot check without a token
+        # we cannot check without a token, so assume it exists to avoid
+        # emitting a hint for every team on the unauthenticated linting path
         return True
 
 
@@ -569,19 +654,24 @@ def run_conda_forge_specific(
     # 2: Check that the recipe maintainers exists:
     for maintainer in maintainers:
         if "/" in maintainer:
-            if not _team_exists(maintainer):
-                lints.append(
-                    msg.cf.MaintainerMissing(
-                        maintainer=maintainer, path=recipe_fname
-                    ).as_string()
-                )
+            exists = _team_exists(maintainer)
         else:
-            if not _maintainer_exists(maintainer):
-                lints.append(
-                    msg.cf.MaintainerMissing(
-                        maintainer=maintainer, path=recipe_fname
-                    ).as_string()
-                )
+            exists = _maintainer_exists(maintainer)
+        if exists is False:
+            lints.append(
+                msg.cf.MaintainerMissing(
+                    maintainer=maintainer, path=recipe_fname
+                ).as_string()
+            )
+        elif exists is None:
+            # the existence check could not be completed (e.g. GitHub rate
+            # limit); fail the lint and ask for it to be retried rather than
+            # risk a false-positive or false-negative
+            lints.append(
+                msg.cf.InconclusiveMaintainerCheck(
+                    maintainer=maintainer, path=recipe_fname
+                ).as_string()
+            )
 
     # 3: if the recipe dir is inside the example dir
     # moved to staged-recipes directly

--- a/conda_smithy/linter/messages/conda_forge.py
+++ b/conda_smithy/linter/messages/conda_forge.py
@@ -170,7 +170,7 @@ class InconclusiveMaintainerCheck(LinterMessage):
 
     kind = "lint"
     identifier = "CF-008"
-    added_in = "2026.6.0"
+    added_in = "2026.6"
     message = (
         'Could not verify that recipe maintainer ${team_or}"${maintainer}" '
         "exists due to a transient GitHub error. Please re-run the linter by "

--- a/conda_smithy/linter/messages/conda_forge.py
+++ b/conda_smithy/linter/messages/conda_forge.py
@@ -154,3 +154,40 @@ class DeprecatedEnvironmentVariable(LinterMessage):
     message = "`${variable}` is deprecated, please use `${replacement}` instead.\n"
     variable: str
     replacement: str
+
+
+@dataclass(kw_only=True)
+class InconclusiveMaintainerCheck(LinterMessage):
+    """
+    The recipe maintainer existence check could not be completed.
+
+    This happens when GitHub cannot be reached or returns a transient error
+    (e.g. a rate limit or a server error) while checking that a maintainer
+    listed in `extra.recipe-maintainers` is a valid Github user or
+    `@conda-forge/*` team. Rather than risk a false-positive (or
+    false-negative), the lint fails and asks for the check to be retried.
+    """
+
+    kind = "lint"
+    identifier = "CF-008"
+    added_in = "2026.6.0"
+    message = (
+        'Could not verify that recipe maintainer ${team_or}"${maintainer}" '
+        "exists due to a transient GitHub error. Please re-run the linter by "
+        "commenting `@conda-forge-admin, please lint` on this pull request."
+    )
+    maintainer: str
+    path: str = "recipe/(meta|recipe).yaml"
+
+    def _render_attributes(self):
+        return {
+            "maintainer": self.maintainer,
+            "team_or": "team " if "/" in self.maintainer else "",
+        }
+
+    @classmethod
+    def examples(cls) -> list[Self]:
+        return [
+            cls(maintainer="some-user"),
+            cls(maintainer="@conda-forge/some-team"),
+        ]

--- a/news/maintainer-lint-transient.rst
+++ b/news/maintainer-lint-transient.rst
@@ -8,7 +8,7 @@
   failure (rate limit, server error, or network error) as "maintainer does not
   exist". Such checks are now retried and, if still inconclusive, the lint fails
   with a message (``CF-008``) asking for the linter to be re-run, instead of
-  producing a false-positive "does not exist" lint.
+  producing a false-positive "does not exist" lint. (#2575)
 
 **Deprecated:**
 
@@ -21,7 +21,7 @@
 **Fixed:**
 
 * Fixed false-positive ``Recipe maintainer "..." does not exist`` lints caused
-  by unauthenticated GitHub rate limiting during linting.
+  by unauthenticated GitHub rate limiting during linting. (#2575)
 
 **Security:**
 

--- a/news/maintainer-lint-transient.rst
+++ b/news/maintainer-lint-transient.rst
@@ -1,0 +1,28 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* The recipe-maintainer existence lint no longer treats a transient GitHub
+  failure (rate limit, server error, or network error) as "maintainer does not
+  exist". Such checks are now retried and, if still inconclusive, the lint fails
+  with a message (``CF-008``) asking for the linter to be re-run, instead of
+  producing a false-positive "does not exist" lint.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed false-positive ``Recipe maintainer "..." does not exist`` lints caused
+  by unauthenticated GitHub rate limiting during linting.
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4867,5 +4867,135 @@ def test_deprecated_environment_variables(tmp_path):
     assert expected.issubset(hints)
 
 
+class _FakeResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+@pytest.fixture
+def no_gh_token(monkeypatch):
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+
+@pytest.fixture
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr(linter.time, "sleep", lambda *a, **k: None)
+
+
+def _patch_head(monkeypatch, responses):
+    """Patch requests.head used by _head_with_retries.
+
+    ``responses`` maps a URL substring to either a status code (int) or an
+    exception instance to raise.
+    """
+    calls = []
+
+    def fake_head(url, **kwargs):
+        calls.append(url)
+        for key, value in responses.items():
+            if key in url:
+                if isinstance(value, Exception):
+                    raise value
+                return _FakeResponse(value)
+        raise AssertionError(f"unexpected HEAD {url}")
+
+    monkeypatch.setattr(linter.requests, "head", fake_head)
+    return calls
+
+
+def test_maintainer_exists_no_token_user_ok(monkeypatch, no_gh_token, _no_sleep):
+    _patch_head(
+        monkeypatch,
+        {"github.com/chrisburr": 200, "orgs/chrisburr/teams": 404},
+    )
+    assert linter._maintainer_exists("chrisburr") is True
+
+
+def test_maintainer_exists_no_token_missing(monkeypatch, no_gh_token, _no_sleep):
+    _patch_head(monkeypatch, {"github.com/nope": 404})
+    assert linter._maintainer_exists("nope") is False
+
+
+def test_maintainer_exists_no_token_renamed_redirect(
+    monkeypatch, no_gh_token, _no_sleep
+):
+    # a renamed account returns a 3xx redirect -> stays flagged as missing
+    _patch_head(monkeypatch, {"github.com/renamed": 301})
+    assert linter._maintainer_exists("renamed") is False
+
+
+def test_maintainer_exists_no_token_is_org(monkeypatch, no_gh_token, _no_sleep):
+    _patch_head(
+        monkeypatch,
+        {"github.com/conda-forge": 200, "orgs/conda-forge/teams": 200},
+    )
+    assert linter._maintainer_exists("conda-forge") is False
+
+
+def test_maintainer_exists_no_token_rate_limited(monkeypatch, no_gh_token, _no_sleep):
+    # a persistent 429 is undetermined -> None, and we retry
+    calls = _patch_head(monkeypatch, {"github.com/chrisburr": 429})
+    assert linter._maintainer_exists("chrisburr") is None
+    assert len(calls) > 1  # retried
+
+
+def test_maintainer_exists_no_token_network_error(monkeypatch, no_gh_token, _no_sleep):
+    _patch_head(
+        monkeypatch,
+        {"github.com/chrisburr": linter.requests.RequestException("boom")},
+    )
+    assert linter._maintainer_exists("chrisburr") is None
+
+
+def test_maintainer_exists_no_token_org_check_rate_limited(
+    monkeypatch, no_gh_token, _no_sleep
+):
+    # user resolves but the org disambiguation is rate limited -> undetermined
+    _patch_head(
+        monkeypatch,
+        {"github.com/chrisburr": 200, "orgs/chrisburr/teams": 503},
+    )
+    assert linter._maintainer_exists("chrisburr") is None
+
+
+def test_maintainer_exists_token_rate_limited(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "x")
+
+    class _FakeGH:
+        def get_user(self, login):
+            raise linter.github.GithubException(403, {"message": "rate limit"}, None)
+
+        def get_organization(self, login):
+            raise AssertionError("should not be reached")
+
+    monkeypatch.setattr(linter, "_cached_gh", lambda: _FakeGH())
+    assert linter._maintainer_exists("chrisburr") is None
+
+
+def test_run_conda_forge_specific_routes_unverified_to_lints(monkeypatch):
+    # None from the existence check fails the lint (asking for a retry),
+    # rather than reporting the maintainer as missing
+    monkeypatch.setattr(linter, "_maintainer_exists", lambda m: None)
+    monkeypatch.setattr(linter, "load_linter_toml_metdata", lambda: {})
+    meta = {"extra": {"recipe-maintainers": ["chrisburr"]}}
+    lints, hints = [], []
+    linter.run_conda_forge_specific(meta, None, lints, hints)
+    assert not any("does not exist" in lint for lint in lints)
+    assert any(
+        'Could not verify that recipe maintainer "chrisburr" exists' in lint
+        for lint in lints
+    )
+
+
+def test_run_conda_forge_specific_routes_missing_to_lints(monkeypatch):
+    monkeypatch.setattr(linter, "_maintainer_exists", lambda m: False)
+    monkeypatch.setattr(linter, "load_linter_toml_metdata", lambda: {})
+    meta = {"extra": {"recipe-maintainers": ["nope"]}}
+    lints, hints = [], []
+    linter.run_conda_forge_specific(meta, None, lints, hints)
+    assert any('Recipe maintainer "nope" does not exist' in lint for lint in lints)
+    assert not any("Could not verify" in hint for hint in hints)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [x] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [x] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
The recipe-maintainer existence check treated any non-200 response as "maintainer does not exist". On the unauthenticated linting path this meant a GitHub rate limit (429), server error (5xx), or redirect caused a false-positive lint for valid maintainers.

Make the check tri-state: retry transient statuses with backoff, keep 404 and 3xx redirects (renamed/invalid usernames) flagged, and surface a new CF-008 hint instead of a lint when the check cannot be completed.