### PR TITLE
Drop mambabuild from `--debug` workflow; document divergence of build options

### DIFF
--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -127,7 +127,7 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    {%- if conda_build_tool != "rattler-build" %}
+    {%- if conda_build_tool.startswith("conda-build") %}
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
     fi
@@ -137,7 +137,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
 
     # Drop into an interactive shell
     /bin/bash
-    {%- else %}
+    {%- elif conda_build_tool == "rattler-build" %}
     export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${FEEDSTOCK_ROOT}/build_artifacts}"
     rattler-build debug setup \
         --recipe "${RECIPE_ROOT}" \

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -134,10 +134,12 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     #   - --clobber-file vs. none
     #   - none vs. --target-platform
     {%- if conda_build_tool.startswith("conda-build") %}
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda debug \
+        "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
         ${BUILD_OUTPUT_ID:+--output-id "${BUILD_OUTPUT_ID}"} \
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
     # Drop into an interactive shell
     /bin/bash
@@ -146,9 +148,9 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     rattler-build debug setup \
         --recipe "${RECIPE_ROOT}" \
         -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --target-platform "${HOST_PLATFORM}" \
+        ${EXTRA_CB_OPTIONS:-} \
         ${BUILD_OUTPUT_ID:+--output-name "${BUILD_OUTPUT_ID}"} \
-        ${EXTRA_CB_OPTIONS:-}
+        --target-platform "${HOST_PLATFORM}"
 
     rattler-build debug shell
     {%- endif %}
@@ -160,20 +162,24 @@ else
     #   - none vs. --target-platform
     #   - --extra-meta a=b c=d vs. --extra-meta a=b --extra-meta c=d
     {%- if conda_build_tool != "rattler-build" %}
-    {{ BUILD_CMD }} "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
+    {{ BUILD_CMD }} \
+        "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        --suppress-variables \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
 
     {%- else %}
 
-    {{ BUILD_CMD }} --recipe "${RECIPE_ROOT}" \
-     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-     ${EXTRA_CB_OPTIONS:-} \
-     --target-platform "${HOST_PLATFORM}" \
-     --extra-meta flow_run_id="${flow_run_id:-}" \
-     --extra-meta remote_url="${remote_url:-}" \
-     --extra-meta sha="${sha:-}"
+    {{ BUILD_CMD }} \
+        --recipe "${RECIPE_ROOT}" \
+        -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        --target-platform "${HOST_PLATFORM}" \
+        --extra-meta flow_run_id="${flow_run_id:-}" \
+        --extra-meta remote_url="${remote_url:-}" \
+        --extra-meta sha="${sha:-}"
 
     {%- endif %}
     ( startgroup "Inspecting artifacts" ) 2> /dev/null

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -127,13 +127,17 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
+    # differences between conda-build vs. rattler-build
+    #   - 1 step (conda debug + manually open shell) vs. 2 step (rb debug {setup, shell})
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --output-id vs. --output-name
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
     {%- if conda_build_tool.startswith("conda-build") %}
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
     conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+        ${BUILD_OUTPUT_ID:+--output-id "${BUILD_OUTPUT_ID}"} \
 
     # Drop into an interactive shell
     /bin/bash
@@ -149,6 +153,12 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     rattler-build debug shell
     {%- endif %}
 else
+    # differences between conda-build vs. rattler-build
+    #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
+    #   - --suppress-variables vs. none
+    #   - --clobber-file vs. none
+    #   - none vs. --target-platform
+    #   - --extra-meta a=b c=d vs. --extra-meta a=b --extra-meta c=d
     {%- if conda_build_tool != "rattler-build" %}
     {{ BUILD_CMD }} "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -153,6 +153,9 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
         --target-platform "${HOST_PLATFORM}"
 
     rattler-build debug shell
+    {%- else %}
+    echo "Build tool {{ conda_build_tool }} is not currently supported in debug mode"
+    exit 1
     {%- endif %}
 else
     # differences between conda-build vs. rattler-build


### PR DESCRIPTION
Follow-up to #2566. I strongly doubt that mambabuild/boa support is still functional, 
https://github.com/conda-forge/conda-smithy/blob/0c86c33cd15fbca34889c35fee5cd1aaba31aeac/conda_smithy/schema.py#L45-L46
much less that it'd work by calling `conda debug`.
https://github.com/conda-forge/conda-smithy/blob/e5c3c27237a815f92a10c459a42fe6310c1345ff/conda_smithy/templates/build_steps.sh.tmpl#L134
(as opposed to `{{ BUILD_CMD }} debug`, which would at least have a theoretical chance of working).

Deprecating and removing mambabuild support can happen independently, but given that this code clearly never worked, at least we can disable it in the template for now.

It's a pity that the `--extra-meta` interface is different between conda-build and rattler-build, otherwise there'd also be a lot of common ground in
https://github.com/conda-forge/conda-smithy/blob/e5c3c27237a815f92a10c459a42fe6310c1345ff/conda_smithy/templates/build_steps.sh.tmpl#L152-L166