### PR TITLE
Fix configuring swap on Namespace Linux runners

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1888,6 +1888,7 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
 
         data["gha_runs_on"] = []
         with_gpu = False
+        on_namespace = False
         for label in labels:
             if label.startswith("cirun-"):
                 # Patch Cirun runners to add some extra debug info
@@ -1896,6 +1897,10 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
                 # Having 'gpu' in one label name is enough to trigger
                 # the extra docker args needed on Linux
                 with_gpu = True
+            if label.startswith("namespace-profile-"):
+                on_namespace = True
+                if "-on-linux-" in label:
+                    label += ";container.privileged=true;container.mount-scratch=true"
             data["gha_runs_on"].append(label)
 
         workflow_settings = get_workflow_settings(
@@ -1906,9 +1911,6 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
             "windows-2022",
             "windows-2025",
         }.intersection(data["gha_runs_on"])
-        on_namespace = any(
-            x.startswith("namespace-profile-") for x in data["gha_runs_on"]
-        )
         fill_workflow_settings_defaults(
             workflow_settings,
             "github_actions",

--- a/conda_smithy/templates/create_pagefile.sh.tmpl
+++ b/conda_smithy/templates/create_pagefile.sh.tmpl
@@ -7,6 +7,9 @@ PAGEFILE_SIZE=${1}
 [[ ${PAGEFILE_SIZE} -le 0 ]] && exit
 
 SWAPFILE=/swapfile
+if [[ ${GHA_RUNS_ON} == *namespace-profile-* ]]; then
+    SWAPFILE=/namespace/scratch/swapfile
+fi
 # If there is already a swapfile, disable it and remove it
 if swapon --show | grep -q "^${SWAPFILE}"; then
     sudo swapoff "${SWAPFILE}" || true

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -94,6 +94,7 @@ jobs:
 {%- endif %}
         UPLOAD_PACKAGES: {% raw %}${{ matrix.UPLOAD_PACKAGES }}{% endraw %}
         PAGEFILE_SIZE: {% raw %}${{ matrix.pagefile_size }}{% endraw %}
+        GHA_RUNS_ON: {% raw %}${{ join(matrix.runs_on, ' ') }}{% endraw %}
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}

--- a/news/2562-pagefile-size.rst
+++ b/news/2562-pagefile-size.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* <news item>
+* Swap file creation now works correctly on Namespace GHA runners. (#2577)
 
 **Security:**
 

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -1,5 +1,6 @@
 import copy
 import io
+import itertools
 import logging
 import os
 import re
@@ -3649,3 +3650,42 @@ def test_free_disk_space_azure(py_recipe, jinja_env, caplog, value: str, add_old
         assert ("Manage disk space" in step_names) == (value != "skip")
 
     assert Path(forge_dir, ".scripts/free_disk_space.sh").exists() == (value != "skip")
+
+
+def test_namespace_pagefile_label(py_recipe, jinja_env):
+    forge_dir = py_recipe.recipe
+    forge_yml = Path(forge_dir, "conda-forge.yml")
+    config_yml = Path(forge_dir, "recipe/default_config.yaml")
+
+    with open(forge_yml, "a") as f:
+        f.write(textwrap.dedent("""\
+            provider:
+              linux_64: github_actions
+            workflow_settings:
+              pagefile_size: 8
+        """))
+
+    with open(config_yml, "a") as f:
+        f.write(textwrap.dedent("""\
+            github_actions_labels:
+              - namespace-profile-8cpu-on-linux-64
+        """))
+
+    config = configure_feedstock._load_forge_config(
+        forge_dir, "recipe/default_config.yaml"
+    )
+    configure_feedstock.render_github_actions(
+        jinja_env=jinja_env,
+        forge_config=config,
+        forge_dir=forge_dir,
+    )
+
+    conda_build_yml = Path(forge_dir, ".github/workflows/conda-build.yml")
+    with conda_build_yml.open() as f:
+        workflow = yaml.safe_load(f)
+    matrix = workflow["jobs"]["build"]["strategy"]["matrix"]["include"]
+    labels = set(itertools.chain.from_iterable(x["runs_on"] for x in matrix))
+    assert (
+        "namespace-profile-8cpu-on-linux-64;container.privileged=true;container.mount-scratch=true"
+        in labels
+    )


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Namespace Linux runners default to using an overlay-backend filesystem that does not support swap files.  To use swap files, one needs to enable mounting scratch space using an appropriate action label.  Detect using Namespace along with enabled swap, and adjust labels and swap file path accordingly.

See https://namespace.so/docs/reference/github-actions/runner-configuration#setting-up-swap-space
Thanks to @jaimergp for figuring this out.

