### PR TITLE
set RATTLER_BUILD_{GITHUB_INTEGRATION,COLOR}, handle GITHUB_STEP_SUMMARY

### DIFF
--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -84,8 +84,6 @@ jobs:
       if: matrix.os == 'ubuntu'
       env:
         CI: github_actions
-        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
-        RATTLER_BUILD_COLOR: always
         CONDA_BLD_PATH: {% raw %}${{ matrix.build_workspace_dir }}{% endraw %}
         CONDA_FORGE_DOCKER_RUN_ARGS: {% raw %}${{ matrix.docker_run_args }}{% endraw %}
         CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
@@ -96,6 +94,8 @@ jobs:
 {%- endif %}
         UPLOAD_PACKAGES: {% raw %}${{ matrix.UPLOAD_PACKAGES }}{% endraw %}
         PAGEFILE_SIZE: {% raw %}${{ matrix.pagefile_size }}{% endraw %}
+        RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}
@@ -130,8 +130,6 @@ jobs:
       if: matrix.os == 'macos'
       env:
         CI: github_actions
-        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
-        RATTLER_BUILD_COLOR: always
         CONDA_BLD_PATH: {% raw %}${{ matrix.build_workspace_dir }}{% endraw %}
         CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
         MINIFORGE_HOME: {% raw %}${{ matrix.tools_install_dir }}{% endraw %}
@@ -139,6 +137,8 @@ jobs:
         UPLOAD_ON_BRANCH: {{ upload_on_branch }}
 {%- endif %}
         UPLOAD_PACKAGES: {% raw %}${{ matrix.UPLOAD_PACKAGES }}{% endraw %}
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
+        RATTLER_BUILD_COLOR: always
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}
@@ -204,8 +204,6 @@ jobs:
         call ".scripts\run_win_build.bat"
       env:
         CI: github_actions
-        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
-        RATTLER_BUILD_COLOR: always
         CONDA_BLD_PATH: {% raw %}${{ matrix.build_workspace_dir }}{% endraw %}
         CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
         MINIFORGE_HOME: {% raw %}${{ matrix.tools_install_dir }}{% endraw %}
@@ -215,6 +213,8 @@ jobs:
         UPLOAD_ON_BRANCH: {{ upload_on_branch }}
 {%- endif %}
         UPLOAD_PACKAGES: {% raw %}${{ matrix.UPLOAD_PACKAGES }}{% endraw %}
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
+        RATTLER_BUILD_COLOR: always
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -84,6 +84,8 @@ jobs:
       if: matrix.os == 'ubuntu'
       env:
         CI: github_actions
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
+        RATTLER_BUILD_COLOR: always
         CONDA_BLD_PATH: {% raw %}${{ matrix.build_workspace_dir }}{% endraw %}
         CONDA_FORGE_DOCKER_RUN_ARGS: {% raw %}${{ matrix.docker_run_args }}{% endraw %}
         CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
@@ -128,6 +130,8 @@ jobs:
       if: matrix.os == 'macos'
       env:
         CI: github_actions
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
+        RATTLER_BUILD_COLOR: always
         CONDA_BLD_PATH: {% raw %}${{ matrix.build_workspace_dir }}{% endraw %}
         CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
         MINIFORGE_HOME: {% raw %}${{ matrix.tools_install_dir }}{% endraw %}
@@ -200,6 +204,8 @@ jobs:
         call ".scripts\run_win_build.bat"
       env:
         CI: github_actions
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
+        RATTLER_BUILD_COLOR: always
         CONDA_BLD_PATH: {% raw %}${{ matrix.build_workspace_dir }}{% endraw %}
         CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
         MINIFORGE_HOME: {% raw %}${{ matrix.tools_install_dir }}{% endraw %}

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -162,8 +162,8 @@ jobs:
         UPLOAD_ON_BRANCH: {{ upload_on_branch }}
 {%- endif %}
         UPLOAD_PACKAGES: {% raw %}${{ matrix.UPLOAD_PACKAGES }}{% endraw %}
-        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}
@@ -236,8 +236,8 @@ jobs:
         UPLOAD_ON_BRANCH: {{ upload_on_branch }}
 {%- endif %}
         UPLOAD_PACKAGES: {% raw %}${{ matrix.UPLOAD_PACKAGES }}{% endraw %}
-        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
         RATTLER_BUILD_COLOR: always
+        RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
 {%- for secret in secrets %}
         {{ secret }}: {% raw %}${{{% endraw %} secrets.{{ secret }} {% raw %}}}{% endraw %}
 {%- endfor %}

--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -114,6 +114,8 @@ ${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
            -e GIT_BRANCH \
            -e UPLOAD_ON_BRANCH \
            -e CI \
+           -e RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION \
+           -e RATTLER_BUILD_COLOR \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
            -e BUILD_WITH_CONDA_DEBUG \

--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -122,6 +122,7 @@ ${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
            -e GIT_BRANCH \
            -e UPLOAD_ON_BRANCH \
            -e CI \
+           -e GITHUB_ACTIONS \
            -e RATTLER_BUILD_COLOR \
            -e RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION \
            -e FEEDSTOCK_NAME \

--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -96,6 +96,14 @@ if [ "${DOCKER_EXECUTABLE}" = "podman" ]; then
     fi
 fi
 
+# When running on GitHub Actions, mount the step summary file into the container
+# and point GITHUB_STEP_SUMMARY at it so that rattler-build's GitHub integration
+# can write its summary. GitHub writes the file out to the job summary after the
+# step finishes.
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} -v ${GITHUB_STEP_SUMMARY}:/home/conda/github_step_summary:rw${VOLUME_SUFFIX},delegated -e GITHUB_STEP_SUMMARY=/home/conda/github_step_summary"
+fi
+
 ( endgroup "Configure Docker" ) 2> /dev/null
 ( startgroup "Start Docker" ) 2> /dev/null
 
@@ -115,6 +123,7 @@ ${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
            -e UPLOAD_ON_BRANCH \
            -e CI \
            -e RATTLER_BUILD_COLOR \
+           -e RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
            -e BUILD_WITH_CONDA_DEBUG \

--- a/conda_smithy/templates/run_docker_build.sh.tmpl
+++ b/conda_smithy/templates/run_docker_build.sh.tmpl
@@ -114,7 +114,6 @@ ${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
            -e GIT_BRANCH \
            -e UPLOAD_ON_BRANCH \
            -e CI \
-           -e RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION \
            -e RATTLER_BUILD_COLOR \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \

--- a/news/rattler-build-github-integration.rst
+++ b/news/rattler-build-github-integration.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* Set ``RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: true`` and ``RATTLER_BUILD_COLOR: always``
+  environment variables in the generated GitHub Actions CI.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/rattler-build-github-integration.rst
+++ b/news/rattler-build-github-integration.rst
@@ -1,7 +1,9 @@
 **Added:**
 
 * Set ``RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: true`` and ``RATTLER_BUILD_COLOR: always``
-  environment variables in the generated GitHub Actions CI.
+  environment variables in the generated GitHub Actions CI. For Linux builds, the
+  ``$GITHUB_STEP_SUMMARY`` file is mounted into the build container so that
+  rattler-build's GitHub integration can write its summary.
 
 **Changed:**
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

the github logs will then look more readable because they contain colored brackets for each output.
this also means that the raw logs might look a bit scuffed with ansi codes. if you think this can be an issue in some feedstocks, wdyt about adding a configuration flag to `conda-forge.yml`?

example: tested in https://github.com/conda-forge/file-feedstock/pull/12: https://github.com/conda-forge/file-feedstock/actions/runs/27337004480?pr=12
<details>
<summary>Details</summary>

<img width="1272" height="1438" alt="image" src="https://github.com/user-attachments/assets/2b036a9e-b3f1-4d54-a62d-8580a3ee40df" />

<img width="1313" height="1008" alt="image" src="https://github.com/user-attachments/assets/aeb235ae-2b06-43d5-9f71-8f454cc7755f" />

</details>