### PR TITLE
Add hint: remove python_min redefinitions that match the global pinning default

### DIFF
--- a/conda_smithy/data/linter-messages.json
+++ b/conda_smithy/data/linter-messages.json
@@ -841,11 +841,13 @@
       "identifier": "R-052",
       "category": "R",
       "kind": "hint",
-      "added_in": "2026.6",
+      "added_in": "2026.7",
       "deprecated_in": "",
-      "documentation": "conda-forge's global pinning already provides the `python_min` variable,\nso recipes should not redefine it to the same value. Only override\n`python_min` when the package needs a higher floor than the global\ndefault.",
-      "message": "The recipe sets `python_min` to ${value}, which is identical to the default provided by conda-forge's global pinning. Remove the redefinition; it is redundant and unintentionally overrides platforms where the global default differs. Only set `python_min` when the package needs a higher floor than the global default.",
-      "examples": [],
+      "documentation": "conda-forge's global pinning already provides the `python_min` variable,\nso recipes should not redefine it to the same (or a lower) value. Doing so\nis redundant and unintentionally overrides platforms where the global\ndefault differs. Only override `python_min` when the package needs a\nhigher floor than the global default.",
+      "message": "The recipe sets `python_min` to ${value}, which is equal or lower than the default provided by conda-forge's global pinning. Please remove the redefinition.",
+      "examples": [
+        "The recipe sets `python_min` to 3.9, which is equal or lower than the default provided by conda-forge's global pinning. Please remove the redefinition."
+      ],
       "path": "recipe/(meta|recipe).yaml"
     },
     {

--- a/conda_smithy/data/linter-messages.json
+++ b/conda_smithy/data/linter-messages.json
@@ -789,6 +789,18 @@
       "path": "recipe/(meta|recipe).yaml"
     },
     {
+      "name": "RedundantPythonMin",
+      "identifier": "R-052",
+      "category": "R",
+      "kind": "hint",
+      "added_in": "2026.6",
+      "deprecated_in": "",
+      "documentation": "conda-forge's global pinning already provides the `python_min` variable,\nso recipes should not redefine it to the same value. Only override\n`python_min` when the package needs a higher floor than the global\ndefault.",
+      "message": "The recipe sets `python_min` to ${value}, which is identical to the default provided by conda-forge's global pinning. Remove the redefinition; it is redundant and unintentionally overrides platforms where the global default differs. Only set `python_min` when the package needs a higher floor than the global default.",
+      "examples": [],
+      "path": "recipe/(meta|recipe).yaml"
+    },
+    {
       "name": "FormattedSelectors",
       "identifier": "R0-001",
       "category": "R0",

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -36,6 +36,7 @@ from conda_smithy.linter.hints import (
     hint_pip_no_build_backend,
     hint_pip_usage,
     hint_rattler_build_bld_bat,
+    hint_redundant_python_min,
     hint_shellcheck_usage,
     hint_sources_should_not_mention_pypi_io_but_pypi_org,
     hint_space_separated_specs,
@@ -793,6 +794,15 @@ def run_conda_forge_specific(
             hints,
             recipe_version=recipe_version,
         )
+
+        # 11b: redefining python_min to the global pinning default is redundant
+        if "hint_redundant_python_min" not in lints_to_skip:
+            hint_redundant_python_min(
+                meta,
+                recipe_text,
+                recipe_version,
+                hints,
+            )
 
         # 12: ensure is_abi3 is boolean
         lint_recipe_is_abi3_bool(

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -89,7 +89,7 @@ from conda_smithy.linter.utils import (
     flatten_v1_if_else,
     get_all_test_requirements,
     get_section,
-    load_linter_toml_metdata,
+    load_linter_toml_metadata,
 )
 from conda_smithy.utils import get_yaml, render_meta_yaml
 from conda_smithy.validate_schema import validate_json_schema
@@ -709,7 +709,7 @@ def run_conda_forge_specific(
             else:
                 run_reqs += _req
 
-    specific_hints = (load_linter_toml_metdata() or {}).get("hints", {})
+    specific_hints = (load_linter_toml_metadata() or {}).get("hints", {})
     all_reqs = build_reqs + host_reqs + run_reqs
     if recipe_version == 1:
         all_reqs = flatten_v1_if_else(all_reqs)

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -16,6 +16,7 @@ from conda_smithy.linter.utils import (
     find_local_config_file,
     flatten_v1_if_else,
     get_all_test_requirements,
+    get_global_pinning_python_min,
     is_selector_line,
 )
 from conda_smithy.utils import get_yaml
@@ -359,6 +360,25 @@ def hint_noarch_python_use_python_min(
 
     if recommendations:
         hints.append(msg.r.PythonMinPin(recommendations=recommendations).as_string())
+
+
+def hint_redundant_python_min(meta, recipe_text, recipe_version, hints):
+    if recipe_version == 1:
+        context = meta.get("context")
+        declared = context.get("python_min") if isinstance(context, Mapping) else None
+    else:
+        match = re.search(
+            r"""{%\s*set\s+python_min\s*=\s*["']([^"']+)["']""",
+            recipe_text or "",
+        )
+        declared = match.group(1) if match else None
+
+    if declared is None:
+        return
+
+    global_python_min = get_global_pinning_python_min()
+    if global_python_min is not None and str(declared) == global_python_min:
+        hints.append(msg.r.RedundantPythonMin(value=global_python_min).as_string())
 
 
 def hint_space_separated_specs(

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -377,7 +377,7 @@ def hint_redundant_python_min(meta, recipe_text, recipe_version, hints):
         return
 
     global_python_min = get_global_pinning_python_min()
-    if global_python_min is not None and str(declared) == global_python_min:
+    if global_python_min is not None and Version(str(declared)) <= Version(global_python_min):
         hints.append(msg.r.RedundantPythonMin(value=global_python_min).as_string())
 
 

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -9,6 +9,8 @@ from collections.abc import Generator, Mapping
 from glob import glob
 from typing import Any
 
+from conda.models.version import VersionOrder
+
 from conda_smithy.linter import conda_recipe_v1_linter
 from conda_smithy.linter import messages as msg
 from conda_smithy.linter.utils import (
@@ -377,8 +379,10 @@ def hint_redundant_python_min(meta, recipe_text, recipe_version, hints):
         return
 
     global_python_min = get_global_pinning_python_min()
-    if global_python_min is not None and Version(str(declared)) <= Version(global_python_min):
-        hints.append(msg.r.RedundantPythonMin(value=global_python_min).as_string())
+    if global_python_min is not None and VersionOrder(str(declared)) <= VersionOrder(
+        global_python_min
+    ):
+        hints.append(msg.r.RedundantPythonMin(value=str(declared)).as_string())
 
 
 def hint_space_separated_specs(

--- a/conda_smithy/linter/messages/recipe.py
+++ b/conda_smithy/linter/messages/recipe.py
@@ -1041,22 +1041,25 @@ class DuplicateRecipes(LinterMessage, _AnyRecipeMessage):
 class RedundantPythonMin(LinterMessage, _AnyRecipeMessage):
     """
     conda-forge's global pinning already provides the `python_min` variable,
-    so recipes should not redefine it to the same value. Only override
-    `python_min` when the package needs a higher floor than the global
-    default.
+    so recipes should not redefine it to the same (or a lower) value. Doing so
+    is redundant and unintentionally overrides platforms where the global
+    default differs. Only override `python_min` when the package needs a
+    higher floor than the global default.
     """
 
     kind = "hint"
     identifier = "R-052"
-    added_in = "2026.6"
+    added_in = "2026.7"
     message = (
-        "The recipe sets `python_min` to ${value}, which is identical to "
-        "the default provided by conda-forge's global pinning. Remove the "
-        "redefinition; it is redundant and unintentionally overrides "
-        "platforms where the global default differs. Only set `python_min` "
-        "when the package needs a higher floor than the global default."
+        "The recipe sets `python_min` to ${value}, which is equal or lower "
+        "than the default provided by conda-forge's global pinning. Please "
+        "remove the redefinition."
     )
     value: str
+
+    @classmethod
+    def examples(cls) -> list[Self]:
+        return [cls(value="3.9")]
 
 
 # endregion

--- a/conda_smithy/linter/messages/recipe.py
+++ b/conda_smithy/linter/messages/recipe.py
@@ -1037,6 +1037,28 @@ class DuplicateRecipes(LinterMessage, _AnyRecipeMessage):
     )
 
 
+@dataclass(kw_only=True)
+class RedundantPythonMin(LinterMessage, _AnyRecipeMessage):
+    """
+    conda-forge's global pinning already provides the `python_min` variable,
+    so recipes should not redefine it to the same value. Only override
+    `python_min` when the package needs a higher floor than the global
+    default.
+    """
+
+    kind = "hint"
+    identifier = "R-052"
+    added_in = "2026.6"
+    message = (
+        "The recipe sets `python_min` to ${value}, which is identical to "
+        "the default provided by conda-forge's global pinning. Remove the "
+        "redefinition; it is redundant and unintentionally overrides "
+        "platforms where the global default differs. Only set `python_min` "
+        "when the package needs a higher floor than the global default."
+    )
+    value: str
+
+
 # endregion
 # region Recipe v0
 

--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -254,7 +254,7 @@ def load_linter_toml_metadata():
 
 @deprecated(
     "2026.7",
-    "2027.1",
+    "2026.9",
     addendum="Use `load_linter_toml_metadata` instead.",
 )
 def load_linter_toml_metdata_internal(time_salt=None):
@@ -264,7 +264,7 @@ def load_linter_toml_metdata_internal(time_salt=None):
 # BW compat for the (misspelled) public alias
 deprecated.constant(
     "2026.7",
-    "2027.1",
+    "2026.9",
     "load_linter_toml_metdata",
     load_linter_toml_metadata,
     addendum="Use `load_linter_toml_metadata` instead.",

--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -20,6 +20,7 @@ from rattler_build_conda_compat.recipe_sources import get_all_sources
 from requests.exceptions import Timeout
 
 from conda_smithy.linter import messages as msg
+from conda_smithy.utils import get_yaml
 
 FIELDS = copy.deepcopy(_CONDA_BUILD_FIELDS)
 
@@ -217,29 +218,54 @@ def _lint_package_version(version: Optional[str]) -> Optional[str]:
         return msg.r.InvalidVersion(version=ver, error=str(e)).as_string()
 
 
+PINNING_FEEDSTOCK_RAW = (
+    "https://raw.githubusercontent.com/conda-forge/conda-forge-pinning-feedstock/main"
+)
+
+
+# cache size should be >= number of urls in use; old epochs are never needed again
+@lru_cache(maxsize=5)
+def _try_fetch_url_content(url: str, epoch_hour: int) -> Optional[str]:
+    """private helper for _try_fetch_url_content_cached"""
+    try:
+        payload = requests.get(url, timeout=5)
+    except Timeout:
+        return None
+    if payload.status_code != 200:
+        # too bad, but not important enough to throw an error;
+        # linter will rerun on the next commit anyway
+        return None
+    return payload.content.decode("utf-8")
+
+
+def _try_fetch_url_content_cached(url: str) -> Optional[str]:
+    """self-limited to update only once per hour"""
+    epoch_hour = int(time.time() / 3600)  # time.time() is in seconds
+    return _try_fetch_url_content(url, epoch_hour)
+
+
 def load_linter_toml_metadata():
-    # ensure we refresh the cache every hour
-    ttl = 3600
-    time_salt = int(time.time() / ttl)
-    return load_linter_toml_metdata_internal(time_salt)
+    url = f"{PINNING_FEEDSTOCK_RAW}/recipe/linter_hints/hints.toml"
+    if (hints_toml_str := _try_fetch_url_content_cached(url)) is None:
+        return None
+    return tomllib.loads(hints_toml_str)
 
 
 load_linter_toml_metdata = load_linter_toml_metadata  # BW Compat
 
 
-@lru_cache(maxsize=1)
-def load_linter_toml_metdata_internal(time_salt):
-    hints_toml_url = "https://raw.githubusercontent.com/conda-forge/conda-forge-pinning-feedstock/main/recipe/linter_hints/hints.toml"
-    try:
-        hints_toml_req = requests.get(hints_toml_url, timeout=5)
-    except Timeout:
+def get_global_pinning_python_min() -> Optional[str]:
+    """The default `python_min` from conda-forge's global pinning, as a
+    string, or None if it cannot be fetched."""
+    url = f"{PINNING_FEEDSTOCK_RAW}/recipe/conda_build_config.yaml"
+    if (pinning_yaml := _try_fetch_url_content_cached(url)) is None:
         return None
-    if hints_toml_req.status_code != 200:
-        # too bad, but not important enough to throw an error;
-        # linter will rerun on the next commit anyway
-        return None
-    hints_toml_str = hints_toml_req.content.decode("utf-8")
-    return tomllib.loads(hints_toml_str)
+    python_min = get_yaml().load(pinning_yaml).get("python_min")
+    if isinstance(python_min, Sequence) and not isinstance(python_min, str):
+        # the first entry is the default; later entries are platform
+        # exceptions gated by selector comments (e.g. win-arm64)
+        python_min = python_min[0] if python_min else None
+    return str(python_min) if python_min is not None else None
 
 
 def flatten_v1_if_else(requirements: list[str | dict] | str) -> list[str]:

--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -19,6 +19,7 @@ from rattler_build_conda_compat import loader as rattler_loader
 from rattler_build_conda_compat.recipe_sources import get_all_sources
 from requests.exceptions import Timeout
 
+from conda_smithy.deprecations import deprecated
 from conda_smithy.linter import messages as msg
 from conda_smithy.utils import get_yaml
 
@@ -251,7 +252,23 @@ def load_linter_toml_metadata():
     return tomllib.loads(hints_toml_str)
 
 
-load_linter_toml_metdata = load_linter_toml_metadata  # BW Compat
+@deprecated(
+    "2026.7",
+    "2027.1",
+    addendum="Use `load_linter_toml_metadata` instead.",
+)
+def load_linter_toml_metdata_internal(time_salt=None):
+    return load_linter_toml_metadata()
+
+
+# BW compat for the (misspelled) public alias
+deprecated.constant(
+    "2026.7",
+    "2027.1",
+    "load_linter_toml_metdata",
+    load_linter_toml_metadata,
+    addendum="Use `load_linter_toml_metadata` instead.",
+)
 
 
 def get_global_pinning_python_min() -> Optional[str]:

--- a/news/redundant-python-min.rst
+++ b/news/redundant-python-min.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* New hint ``R-051``: recipes that redefine ``python_min`` (via ``context`` in v1 recipes or ``{% set %}`` in v0 recipes) to the same value as conda-forge's global pinning default are hinted to remove the redundant override. The global default is fetched from the pinning feedstock with the same cached, fail-quiet pattern used for ``hints.toml``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/redundant-python-min.rst
+++ b/news/redundant-python-min.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* New hint ``R-051``: recipes that redefine ``python_min`` (via ``context`` in v1 recipes or ``{% set %}`` in v0 recipes) to the same value as conda-forge's global pinning default are hinted to remove the redundant override. The global default is fetched from the pinning feedstock with the same cached, fail-quiet pattern used for ``hints.toml``.
+* New hint ``R-052``: recipes that redefine ``python_min`` (via ``context`` in v1 recipes or ``{% set %}`` in v0 recipes) to the same value as (or a lower value than) conda-forge's global pinning default are hinted to remove the redundant override. The global default is fetched from the pinning feedstock with the same cached, fail-quiet pattern used for ``hints.toml``.
 
 **Changed:**
 

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4228,6 +4228,106 @@ def test_lint_recipe_v1_python_min_in_python_version(text):
         )
 
 
+@pytest.mark.parametrize(
+    "recipe_name,text,global_python_min,expected_hint",
+    [
+        # v1: redefining python_min to the global default -> hint
+        (
+            "recipe.yaml",
+            textwrap.dedent("""
+                context:
+                  python_min: "3.10"
+
+                package:
+                  name: mypackage
+                  version: 1.0.0
+                """),
+            "3.10",
+            True,
+        ),
+        # v1: overriding to a higher floor -> no hint
+        (
+            "recipe.yaml",
+            textwrap.dedent("""
+                context:
+                  python_min: "3.12"
+
+                package:
+                  name: mypackage
+                  version: 1.0.0
+                """),
+            "3.10",
+            False,
+        ),
+        # v1: no python_min in context -> no hint
+        (
+            "recipe.yaml",
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+                  version: 1.0.0
+                """),
+            "3.10",
+            False,
+        ),
+        # v1: pinning not fetchable -> no hint
+        (
+            "recipe.yaml",
+            textwrap.dedent("""
+                context:
+                  python_min: "3.10"
+
+                package:
+                  name: mypackage
+                  version: 1.0.0
+                """),
+            None,
+            False,
+        ),
+        # v0: jinja set matching the global default -> hint
+        (
+            "meta.yaml",
+            textwrap.dedent("""
+                {% set python_min = "3.10" %}
+
+                package:
+                  name: mypackage
+                  version: 1.0.0
+                """),
+            "3.10",
+            True,
+        ),
+        # v0: jinja set with a higher floor -> no hint
+        (
+            "meta.yaml",
+            textwrap.dedent("""
+                {% set python_min = "3.12" %}
+
+                package:
+                  name: mypackage
+                  version: 1.0.0
+                """),
+            "3.10",
+            False,
+        ),
+    ],
+    ids=(f"recipe-{i}" for i in count(1)),
+)
+def test_lint_recipe_hint_redundant_python_min(
+    recipe_name, text, global_python_min, expected_hint, monkeypatch
+):
+    monkeypatch.setattr(
+        "conda_smithy.linter.hints.get_global_pinning_python_min",
+        lambda: global_python_min,
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, recipe_name), "w") as f:
+            f.write(text)
+        _, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
+        has_hint = any("Remove the redefinition" in h for h in hints)
+        assert has_hint == expected_hint, hints
+
+
 def test_lint_recipe_v1_comment_selectors():
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:
@@ -4754,14 +4854,14 @@ tests:
 outputs:
   - package:
       name: foo
-{textwrap.indent(midpart, '    ')}\
+{textwrap.indent(midpart, "    ")}\
 """
 
     recipe = f"""\
 context:
   version: "1.0"
 
-{'recipe' if outputs else 'package'}:
+{"recipe" if outputs else "package"}:
   name: foo
   version: ${{{{ version }}}}
 

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4260,6 +4260,20 @@ def test_lint_recipe_v1_python_min_in_python_version(text):
             "3.10",
             False,
         ),
+        # v1: redefining to a lower floor than the default -> hint
+        (
+            "recipe.yaml",
+            textwrap.dedent("""
+                context:
+                  python_min: "3.9"
+
+                package:
+                  name: mypackage
+                  version: 1.0.0
+                """),
+            "3.10",
+            True,
+        ),
         # v1: no python_min in context -> no hint
         (
             "recipe.yaml",
@@ -4325,7 +4339,7 @@ def test_lint_recipe_hint_redundant_python_min(
         with open(os.path.join(tmpdir, recipe_name), "w") as f:
             f.write(text)
         _, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
-        has_hint = any("Remove the redefinition" in h for h in hints)
+        has_hint = any("remove the redefinition" in h for h in hints)
         assert has_hint == expected_hint, hints
 
 
@@ -5089,7 +5103,7 @@ def test_run_conda_forge_specific_routes_unverified_to_lints(monkeypatch):
     # None from the existence check fails the lint (asking for a retry),
     # rather than reporting the maintainer as missing
     monkeypatch.setattr(linter, "_maintainer_exists", lambda m: None)
-    monkeypatch.setattr(linter, "load_linter_toml_metdata", lambda: {})
+    monkeypatch.setattr(linter, "load_linter_toml_metadata", lambda: {})
     meta = {"extra": {"recipe-maintainers": ["chrisburr"]}}
     lints, hints = [], []
     linter.run_conda_forge_specific(meta, None, lints, hints)
@@ -5102,7 +5116,7 @@ def test_run_conda_forge_specific_routes_unverified_to_lints(monkeypatch):
 
 def test_run_conda_forge_specific_routes_missing_to_lints(monkeypatch):
     monkeypatch.setattr(linter, "_maintainer_exists", lambda m: False)
-    monkeypatch.setattr(linter, "load_linter_toml_metdata", lambda: {})
+    monkeypatch.setattr(linter, "load_linter_toml_metadata", lambda: {})
     meta = {"extra": {"recipe-maintainers": ["nope"]}}
     lints, hints = [], []
     linter.run_conda_forge_specific(meta, None, lints, hints)
@@ -5111,7 +5125,7 @@ def test_run_conda_forge_specific_routes_missing_to_lints(monkeypatch):
 
 
 def test_run_conda_forge_specific_missing_linter_hints_table(monkeypatch):
-    monkeypatch.setattr(linter, "load_linter_toml_metdata", lambda: {})
+    monkeypatch.setattr(linter, "load_linter_toml_metadata", lambda: {})
     meta = {
         "package": {"name": "foo"},
         "requirements": {"run": ["python"]},


### PR DESCRIPTION
### Description

Adds hint `R-051`: when a recipe redefines `python_min` to the same value as conda-forge's global pinning default, suggest removing the redundant override. Covers both formats:

- v1: `context.python_min`
- v0: `{% set python_min = "..." %}`

Per CFEP-25 the global pinning already provides `python_min`; redefining it to the same value is noise reviewers have to verify, and it silently overrides platforms where the default differs (e.g. win-arm64 uses a different floor). Overriding to a *higher* floor is intentional and not hinted.

The default value is fetched from the pinning feedstock's `conda_build_config.yaml` using the same cached, fail-quiet pattern as `hints.toml` (5s timeout, hourly cache, hint silently skipped if unreachable). Skippable via `linter.skip: [hint_redundant_python_min]`.

Includes tests (fetch mocked), news entry, and regenerated `linter-messages.json`.

Related: #2580 (another `python_min` hygiene hint).

### Checklist

* [x] Added a `news` entry
