### PR TITLE
lint against duplicate recipes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,3 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./coverage.lcov
-          # TODO: revert as soon as feasible; coveralls has an extended outage
-          #       and is recommending this work-around for the time being, see
-          #       https://status.coveralls.io/incidents/pdbt7vdzlvpj
-          fail-on-error: false

--- a/conda_smithy/data/linter-messages.json
+++ b/conda_smithy/data/linter-messages.json
@@ -777,6 +777,18 @@
       "path": "recipe/(meta|recipe).yaml"
     },
     {
+      "name": "DuplicateRecipes",
+      "identifier": "R-051",
+      "category": "R",
+      "kind": "lint",
+      "added_in": "2026.6",
+      "deprecated_in": "",
+      "documentation": "If recipe folder contains both meta.yaml and recipe.yaml",
+      "message": "Recipe folder contains both `meta.yaml` and `recipe.yaml`. Only one recipe file at a time is allowed.",
+      "examples": [],
+      "path": "recipe/(meta|recipe).yaml"
+    },
+    {
       "name": "FormattedSelectors",
       "identifier": "R0-001",
       "category": "R0",

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -160,10 +160,17 @@ def lintify_meta_yaml(
     feedstock_config_keys = _get_feedstock_config(recipe_dir)
     lints_to_skip = feedstock_config_keys.get("linter", {}).get("skip", [])
 
-    # If the recipe_dir exists (no guarantee within this function) , we can
-    # find the meta.yaml within it.
-    recipe_name = "meta.yaml" if recipe_version == 0 else "recipe.yaml"
-    recipe_fname = os.path.join(recipe_dir or "", recipe_name)
+    # If the recipe_dir exists (no guarantee within this function),
+    # find the recipe(s) within it.
+    recipe_dir = recipe_dir or ""
+    recipe_fname_v0 = os.path.join(recipe_dir, "meta.yaml")
+    recipe_fname_v1 = os.path.join(recipe_dir, "recipe.yaml")
+    recipe_fname = recipe_fname_v0 if recipe_version == 0 else recipe_fname_v1
+
+    # irrespective of the expected recipe_version, lint if both recipe types are present
+    if os.path.exists(recipe_fname_v0) and os.path.exists(recipe_fname_v1):
+        lints.append(msg.r.DuplicateRecipes().as_string())
+        return lints, hints
 
     if recipe_version == 1:
         schema_version = meta.get("schema_version", 1)

--- a/conda_smithy/linter/messages/recipe.py
+++ b/conda_smithy/linter/messages/recipe.py
@@ -1022,6 +1022,21 @@ class UsePyPIOrg(LinterMessage, _AnyRecipeMessage):
     )
 
 
+@dataclass(kw_only=True)
+class DuplicateRecipes(LinterMessage, _AnyRecipeMessage):
+    """
+    If recipe folder contains both meta.yaml and recipe.yaml
+    """
+
+    kind = "lint"
+    identifier = "R-051"
+    added_in = "2026.6"
+    message = (
+        "Recipe folder contains both `meta.yaml` and `recipe.yaml`. "
+        "Only one recipe file at a time is allowed."
+    )
+
+
 # endregion
 # region Recipe v0
 

--- a/news/duplicate_recipe.rst
+++ b/news/duplicate_recipe.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* The linter will now complain if both `meta.yaml` as well as `recipe.yaml` are found in the recipe folder (#2583)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -493,6 +493,18 @@ def test_cbc_osx_lints_variants_yaml(
             assert any(lint.startswith(exp_lint) for lint in lints)
 
 
+def test_duplicated_recipes():
+    recipe_content = "package:\n  name: foo"
+    with tmp_directory() as recipe_dir:
+        recipe_dir = Path(recipe_dir)
+        recipe_dir.joinpath("recipe.yaml").write_text(recipe_content)
+        recipe_dir.joinpath("meta.yaml").write_text(recipe_content)
+
+        # run the linter
+        lints = linter.main(recipe_dir)
+        assert any(lint.startswith("Recipe folder contains both") for lint in lints)
+
+
 @pytest.mark.parametrize("recipe_version", [0, 1])
 def test_duplicated_recipe_configs(recipe_version):
     recipe_content = "package:\n  name: foo"


### PR DESCRIPTION
Follow-up to #2473, where we added a lint about duplicate configuration files (ef3e9123ce98902e4736b6acc54aa59839f7dbac). I was surprised to find that we don't have the same lint for duplicate recipe files.

As another follow-up from that PR, revert the `fail-on-error: false` for coveralls (ea1897ffe91d9f22e514fc64a01254a39d374132)