### PR TITLE
Implement `workflow_settings.resize_partitions`

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2631,6 +2631,23 @@ def _read_forge_config(forge_dir, forge_yml=None):
                 }
             )
 
+    if "resize_win_partitions" in file_config.get("github_actions", {}):
+        if "resize_partitions" in file_config.get("workflow_settings", {}):
+            logger.warning(
+                "`github_actions.resize_win_partitions` is ignored when "
+                "`workflow_settings.resize_partitions` is set",
+            )
+            del config["github_actions"]["resize_win_partitions"]
+        else:
+            # Convert old keys to new settings.
+            config["workflow_settings"]["resize_partitions"].append(
+                {
+                    "provider": "github_actions",
+                    "os": "win",
+                    "value": config["github_actions"]["resize_win_partitions"],
+                }
+            )
+
     # check for conda-smithy 2.x matrix which we can't auto-migrate
     # to conda_build_config
     if file_config.get("matrix") and not os.path.exists(

--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -1149,7 +1149,7 @@
             }
           ],
           "default": [],
-          "description": "Free up disk space before building.\nTakes one of the following values:\n\n- `no` not to clean anything (the default)\n- `quick` to clean a subset of components that should yield\n  a quick space gain\n- `max` for the most significant space gain\n\nOn all platforms, `quick` removes a number of unnecessary system\ntools. On Linux, it additionally uninstall a few large system\npackages.\n\nThe `max` option additionally prunes unnecessary Docker images\non Linux.\n\nThe extent of cleanup may change in the future. However, changes\nwill only propagate through rerendering.\n\nPlease note that on Windows only C:\\ drive is cleaned up, so\nusing cleanup is only beneficial if this drive is used for\n`tools_install_dir`, `build_workspace_dir` or the page file.",
+          "description": "Free up disk space before building.\nTakes one of the following values:\n\n- `skip`: does not do anything (the default)\n- `quick`: cleans a subset of components that balances space gained\n  against the time necessary to do so\n- `max`: takes longer, but achieves more significant space gain\n\nOn all platforms, `quick` removes a number of unnecessary system\ntools. On Linux, it additionally uninstall a few large system\npackages.\n\nThe `max` option additionally prunes unnecessary Docker images\non Linux.\n\nThe extent of cleanup may change in the future. However, changes\nwill only propagate through rerendering.\n\nPlease note that on Windows only `C:\\` drive is cleaned up, so\nusing cleanup is only beneficial if this drive is used for\n`tools_install_dir`, `build_workspace_dir` or the page file.",
           "title": "Free Disk Space"
         },
         "resize_partitions": {
@@ -1171,7 +1171,7 @@
             }
           ],
           "default": [],
-          "description": "Whether to resize partitions to use all available space,\nCurrently only supported on Windows GitHub Actions.",
+          "description": "Whether to resize partitions to use all available space. Currently\nonly supported for certain providers on GitHub Actions for Windows.",
           "title": "Resize Partitions"
         }
       },
@@ -2102,7 +2102,7 @@
           "type": "null"
         }
       ],
-      "description": "Settings in this block are used to control how `conda smithy` lints\nAn example of the such configuration is:\n\n```yaml\nlinter:\n    skip:\n        - lint_noarch_selectors\n```"
+      "description": "Settings in this block are used to control how `conda smithy` lints.\nAn example of the such configuration is:\n\n```yaml\nlinter:\n    skip:\n        - lint_noarch_selectors\n```"
     },
     "conda_build_tool": {
       "anyOf": [

--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -732,7 +732,8 @@
             }
           ],
           "default": false,
-          "description": "Whether to resize partitions to use all space on Windows",
+          "deprecated": true,
+          "description": "Deprecated. Use `workflow_settings.resize_partitions` instead.\nWhether to resize partitions to use all space on Windows",
           "title": "Resize Win Partitions"
         },
         "self_hosted": {

--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -1150,6 +1150,28 @@
           "default": [],
           "description": "Free up disk space before building.\nTakes one of the following values:\n\n- `no` not to clean anything (the default)\n- `quick` to clean a subset of components that should yield\n  a quick space gain\n- `max` for the most significant space gain\n\nOn all platforms, `quick` removes a number of unnecessary system\ntools. On Linux, it additionally uninstall a few large system\npackages.\n\nThe `max` option additionally prunes unnecessary Docker images\non Linux.\n\nThe extent of cleanup may change in the future. However, changes\nwill only propagate through rerendering.\n\nPlease note that on Windows only C:\\ drive is cleaned up, so\nusing cleanup is only beneficial if this drive is used for\n`tools_install_dir`, `build_workspace_dir` or the page file.",
           "title": "Free Disk Space"
+        },
+        "resize_partitions": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "items": {
+                "$ref": "#/$defs/ConditionalValue__class__bool__"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/Nullable"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": [],
+          "description": "Whether to resize partitions to use all available space,\nCurrently only supported on Windows GitHub Actions.",
+          "title": "Resize Partitions"
         }
       },
       "title": "WorkflowSettings",

--- a/conda_smithy/data/conda-forge.yml
+++ b/conda_smithy/data/conda-forge.yml
@@ -148,5 +148,6 @@ workflow_settings:
   build_workspace_dir: []
   free_disk_space: []
   pagefile_size: []
+  resize_partitions: []
   store_build_artifacts: []
   tools_install_dir: []

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -566,10 +566,10 @@ class WorkflowSettings(BaseModel):
         Free up disk space before building.
         Takes one of the following values:
 
-        - `no` not to clean anything (the default)
-        - `quick` to clean a subset of components that should yield
-          a quick space gain
-        - `max` for the most significant space gain
+        - `skip`: does not do anything (the default)
+        - `quick`: cleans a subset of components that balances space gained
+          against the time necessary to do so
+        - `max`: takes longer, but achieves more significant space gain
 
         On all platforms, `quick` removes a number of unnecessary system
         tools. On Linux, it additionally uninstall a few large system
@@ -581,7 +581,7 @@ class WorkflowSettings(BaseModel):
         The extent of cleanup may change in the future. However, changes
         will only propagate through rerendering.
 
-        Please note that on Windows only C:\ drive is cleaned up, so
+        Please note that on Windows only `C:\` drive is cleaned up, so
         using cleanup is only beneficial if this drive is used for
         `tools_install_dir`, `build_workspace_dir` or the page file.
         """),
@@ -595,8 +595,8 @@ class WorkflowSettings(BaseModel):
         ]
     ] = Field(
         description=cleandoc(r"""
-        Whether to resize partitions to use all available space,
-        Currently only supported on Windows GitHub Actions.
+        Whether to resize partitions to use all available space. Currently
+        only supported for certain providers on GitHub Actions for Windows.
         """),
         default=[],
     )
@@ -636,7 +636,7 @@ class ConfigModel(BaseModel):
     linter: Optional[LinterConfig] = Field(
         default_factory=LinterConfig,
         description=cleandoc("""
-        Settings in this block are used to control how `conda smithy` lints
+        Settings in this block are used to control how `conda smithy` lints.
         An example of the such configuration is:
 
         ```yaml

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -583,6 +583,20 @@ class WorkflowSettings(BaseModel):
         """),
     )
 
+    resize_partitions: Optional[
+        Union[
+            bool,
+            list[conditional_value(bool, False)],
+            Nullable,
+        ]
+    ] = Field(
+        description=cleandoc(r"""
+        Whether to resize partitions to use all available space,
+        Currently only supported on Windows GitHub Actions.
+        """),
+        default=[],
+    )
+
 
 class ConfigModel(BaseModel):
     """

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -298,8 +298,12 @@ class GithubActionsConfig(BaseModel):
     )
 
     resize_win_partitions: Optional[bool] = Field(
-        description="Whether to resize partitions to use all space on Windows",
+        description=cleandoc("""
+        Deprecated. Use `workflow_settings.resize_partitions` instead.
+        Whether to resize partitions to use all space on Windows
+        """),
         default=False,
+        deprecated=True,
     )
 
     self_hosted: Optional[bool] = Field(

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -16,6 +16,9 @@
   {%- if data.gha_os == "windows" and data.pagefile_size > 0 %}
     {%- set vars.create_pagefile_win = True %}
   {%- endif %}
+  {%- if data.gha_os == "windows" and data.resize_partitions %}
+    {%- set vars.resize_win_partitions = True %}
+  {%- endif %}
 {%- endfor %}
 
 name: Build conda package
@@ -63,6 +66,7 @@ jobs:
             free_disk_space: {{ data.free_disk_space }}
             os: {{ data.gha_os }}
             pagefile_size: {{ data.pagefile_size }}
+            resize_partitions: {{ data.resize_partitions }}
             runs_on: {{ data.gha_runs_on }}
             tools_install_dir: {{ data.tools_install_dir }}
         {%- endfor %}
@@ -185,11 +189,11 @@ jobs:
       run: |
         choco install {{ choco_pkg }} -fdv -y --debug
 {% endfor %}
-{%- if github_actions.resize_win_partitions %}
+{%- if vars.resize_win_partitions %}
 
     # https://github.com/aktech/cirun-azure-resize-disk
     - name: Resize all partitions to maximum
-      if: matrix.os == 'windows'
+      if: matrix.os == 'windows' && matrix.resize_partitions
       shell: pwsh
       run: |
         Write-Output "=== RESIZING PARTITIONS ==="

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -410,7 +410,11 @@ def fill_workflow_settings_defaults(
             "win": rf"{tools_drive}\\bld\\",
         }[os]
 
-    if workflow_settings.get("pagefile_size") is None:
-        workflow_settings["pagefile_size"] = 0
-    if workflow_settings.get("free_disk_space") is None:
-        workflow_settings["free_disk_space"] = "skip"
+    simple_defaults = {
+        "pagefile_size": 0,
+        "free_disk_space": "skip",
+        "resize_partitions": False,
+    }
+    for k, v in simple_defaults.items():
+        if workflow_settings.get(k) is None:
+            workflow_settings[k] = v

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -372,6 +372,13 @@ def get_workflow_settings(
                 f"workflows: {win_path}"
             )
 
+    if data["resize_partitions"]:
+        if os != "win" or provider != "github_actions":
+            raise ValueError(
+                "`workflow_settings.resize_partitions` is only valid for GHA/Windows "
+                f"(enabled for {provider=} / {os=})"
+            )
+
     return data
 
 

--- a/news/2584-resize-partitions.rst
+++ b/news/2584-resize-partitions.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* ``workflow_settings.resize_partitions`` to control resizing partitions across CI providers. (#2584)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/2584-resize-partitions.rst
+++ b/news/2584-resize-partitions.rst
@@ -8,7 +8,7 @@
 
 **Deprecated:**
 
-* <news item>
+* ``github_actions.resize_win_partitions`` was deprecated in favor of ``workflow_settings.resize_partitions``. (#2584)
 
 **Removed:**
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Convert `github_actions.resize_win_partitions` into a more generic `workflow_settings.resize_partitions`. However, for now it's only doing anything on Windows GHA, and it's unclear to me if any other CI provider will ever feature reusable free space.