### PR TITLE
fix: update deps, emulate feedstock CI env, fix testing paths

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,11 +76,11 @@ jobs:
 
         # export CONDA_BUILD=1
         # export CONDA_BUILD_STATE=TEST
-        # export RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION=true
+        # export RATTLER_BUILD_COLOR=always
       - name: run tests
         run: |
           rm -rf conda_smithy
-          export RATTLER_BUILD_COLOR=always
+          export RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION=true
           pytest -vvsx tests --cov conda_smithy --cov-report lcov --cov-report term-missing
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,10 +76,10 @@ jobs:
 
         # export CONDA_BUILD=1
         # export CONDA_BUILD_STATE=TEST
+        # export RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION=true
       - name: run tests
         run: |
           rm -rf conda_smithy
-          export RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION=true
           export RATTLER_BUILD_COLOR=always
           pytest -vvsx tests --cov conda_smithy --cov-report lcov --cov-report term-missing
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
           export CONDA_BUILD_STATE=TEST
           export RATTLER_BUILD_COLOR=always
           export RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION=true
-          pytest -vvsx tests --cov conda_smithy --cov-report lcov --cov-report term-missing
+          pytest tests --cov conda_smithy --cov-report lcov --cov-report term-missing
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
           create-args: >-
             coverage
             coveralls
+            conda-forge-tick>=2026.0
 
       - name: install conda-smithy
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,8 @@ jobs:
           micromamba-version: 1.5.12-0
           cache-environment: true
           create-args: >-
-            python=3.12
             coverage
             coveralls
-            conda-forge-tick>=2026.0
 
       - name: install conda-smithy
         run: |
@@ -74,9 +72,14 @@ jobs:
           test -f sdist-content/conda_smithy-*/conda_smithy/templates/github-actions.yml.tmpl
           rm -r sdist-content/
 
+      # we remove the local package and set some env vars to emulate the smithy feedstock
+      # CI env in the hopes that we catch errors here.
       - name: run tests
         run: |
           rm -rf conda_smithy
+          export CONDA_BUILD=1
+          export CONDA_BUILD_STATE=TEST
+          export RATTLER_BUILD_COLOR=always
           export RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION=true
           pytest -vvsx tests --cov conda_smithy --cov-report lcov --cov-report term-missing
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,12 +74,12 @@ jobs:
           test -f sdist-content/conda_smithy-*/conda_smithy/templates/github-actions.yml.tmpl
           rm -r sdist-content/
 
+        # export CONDA_BUILD=1
+        # export CONDA_BUILD_STATE=TEST
       - name: run tests
         run: |
           rm -rf conda_smithy
-          export CONDA_BUILD=1
           export RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION=true
-          export CONDA_BUILD_STATE=TEST
           export RATTLER_BUILD_COLOR=always
           pytest -vvsx tests --cov conda_smithy --cov-report lcov --cov-report term-missing
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
           popd
           pip uninstall conda-smithy --yes
 
-          python -m pip install -v --no-build-isolation -e .
+          python -m pip install -v --no-build-isolation .
 
       - name: test data and templates files in sdist
         run: |
@@ -76,6 +76,7 @@ jobs:
 
       - name: run tests
         run: |
+          rm -rf conda_smithy
           pytest tests --cov conda_smithy --cov-report lcov --cov-report term-missing
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,11 @@ jobs:
       - name: run tests
         run: |
           rm -rf conda_smithy
-          pytest tests --cov conda_smithy --cov-report lcov --cov-report term-missing
+          export CONDA_BUILD=1
+          export RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION=true
+          export CONDA_BUILD_STATE=TEST
+          export RATTLER_BUILD_COLOR=always
+          pytest -vvsx tests --cov conda_smithy --cov-report lcov --cov-report term-missing
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,10 @@ jobs:
           micromamba-version: 1.5.12-0
           cache-environment: true
           create-args: >-
-            python=3.11
+            python=3.12
             coverage
             coveralls
-            conda-forge-tick
+            conda-forge-tick>=2026.0
 
       - name: install conda-smithy
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,9 +74,6 @@ jobs:
           test -f sdist-content/conda_smithy-*/conda_smithy/templates/github-actions.yml.tmpl
           rm -r sdist-content/
 
-        # export CONDA_BUILD=1
-        # export CONDA_BUILD_STATE=TEST
-        # export RATTLER_BUILD_COLOR=always
       - name: run tests
         run: |
           rm -rf conda_smithy

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,6 @@ dependencies:
   # # Part of some optional lint tests
   - conda-recipe-manager>=0.9
   - conda-souschef
-  - conda-forge-tick>=2026.0
   # Runtime dependencies
   - conda>=22.11.1
   - conda-build>=26.3.0

--- a/environment.yml
+++ b/environment.yml
@@ -39,6 +39,7 @@ dependencies:
   - pixi>=0.59.0
   - jsonschema
   - exceptiongroup
-  # py-rattler's API subject to change, pin to minor
+  # rattler's APIs are subject to change, pin to minor versions
   - py-rattler>=0.22,<0.23
   - rattler-build-conda-compat>=1.4.15,<2.0.0a0
+  - rattler-build>=0.66.0,<0.67.0a0

--- a/environment.yml
+++ b/environment.yml
@@ -17,8 +17,8 @@ dependencies:
   - conda-recipe-manager>=0.9
   - conda-souschef
   # Runtime dependencies
-  - conda>=4.2
-  - conda-build>=25.3.1
+  - conda>=22.11.1
+  - conda-build>=26.3.0
   - conda-package-handling>=1.9.0
   - jinja2
   - requests

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   # # Part of some optional lint tests
   - conda-recipe-manager>=0.9
   - conda-souschef
+  - conda-forge-tick>=2026.0
   # Runtime dependencies
   - conda>=22.11.1
   - conda-build>=26.3.0
@@ -41,4 +42,4 @@ dependencies:
   - exceptiongroup
   # py-rattler's API subject to change, pin to minor
   - py-rattler>=0.22,<0.23
-  - rattler-build-conda-compat>=1.4.12,<2.0.0a0
+  - rattler-build-conda-compat>=1.4.15,<2.0.0a0

--- a/news/update-ci-2588.rst
+++ b/news/update-ci-2588.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Updated the testing CI configuration and dependencies to match that of the feedstock. (#2588)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed testing bugs where paths to files in the package were computed assuming a development
+  installation layout. (#2588)
+
+**Security:**
+
+* <news item>

--- a/news/update-ci-2588.rst
+++ b/news/update-ci-2588.rst
@@ -5,6 +5,7 @@
 **Changed:**
 
 * Updated the testing CI configuration and dependencies to match that of the feedstock. (#2588)
+* Added a pin on ``rattler-build`` to the minor version to help avoid breakages. (#2588)
 
 **Deprecated:**
 

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -2223,7 +2223,7 @@ def test_github_actions_pins():
     pkg_root = Path(conda_smithy.__file__).parent
     github_actions_template = pkg_root / "templates" / "github-actions.yml.tmpl"
     dependabot_inventory = (
-        Path(__file__)
+        Path(__file__).parent
         / ".."
         / ".github"
         / "workflows"

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -2221,11 +2221,13 @@ def test_github_actions_pins():
     make this pass.
     """
     repo_root = Path(conda_smithy.__file__).parents[1]
-    github_actions_template = (
-        repo_root / "templates" / "github-actions.yml.tmpl"
-    )
+    github_actions_template = repo_root / "templates" / "github-actions.yml.tmpl"
     dependabot_inventory = (
-        Path(__file__) / ".." / ".github" / "workflows" / "_proxy-file-for-dependabot-tests.yml"
+        Path(__file__)
+        / ".."
+        / ".github"
+        / "workflows"
+        / "_proxy-file-for-dependabot-tests.yml"
     )
 
     def get_uses(path):

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -15,6 +15,7 @@ import yaml
 from conftest import ConfigYAML
 from rattler_build_conda_compat.loader import parse_recipe_config_file
 
+import conda_smithy
 from conda_smithy import configure_feedstock
 from conda_smithy.configure_feedstock import (
     DEFAULT_PROVIDER,
@@ -2219,12 +2220,12 @@ def test_github_actions_pins():
     If Dependabot opens a PR against the proxy, just copy the new pins to the template to
     make this pass.
     """
-    repo_root = Path(__file__).parents[1]
+    repo_root = Path(conda_smithy.__file__).parents[1]
     github_actions_template = (
-        repo_root / "conda_smithy" / "templates" / "github-actions.yml.tmpl"
+        repo_root / "templates" / "github-actions.yml.tmpl"
     )
     dependabot_inventory = (
-        repo_root / ".github" / "workflows" / "_proxy-file-for-dependabot-tests.yml"
+        Path(__file__) / ".." / ".github" / "workflows" / "_proxy-file-for-dependabot-tests.yml"
     )
 
     def get_uses(path):

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -2220,8 +2220,8 @@ def test_github_actions_pins():
     If Dependabot opens a PR against the proxy, just copy the new pins to the template to
     make this pass.
     """
-    repo_root = Path(conda_smithy.__file__).parents[1]
-    github_actions_template = repo_root / "templates" / "github-actions.yml.tmpl"
+    pkg_root = Path(conda_smithy.__file__).parent
+    github_actions_template = pkg_root / "templates" / "github-actions.yml.tmpl"
     dependabot_inventory = (
         Path(__file__)
         / ".."

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -59,8 +59,7 @@ def test_schema_no_empty_properties_for_bot():
     """
     with (
         Path(conda_smithy.__file__)
-        .parents[1]
-        .joinpath("data/conda-forge.json")
+        .parent.joinpath("data/conda-forge.json")
         .open("r") as f
     ):
         schema = json.load(f)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+import conda_smithy
 from conda_smithy.schema import ConfigModel
 from conda_smithy.utils import get_yaml
 from conda_smithy.validate_schema import (
@@ -57,9 +58,9 @@ def test_schema_no_empty_properties_for_bot():
     is not in the properties object in this case.
     """
     with (
-        Path(__file__)
+        Path(conda_smithy.__file__)
         .parents[1]
-        .joinpath("conda_smithy/data/conda-forge.json")
+        .joinpath("data/conda-forge.json")
         .open("r") as f
     ):
         schema = json.load(f)


### PR DESCRIPTION
Towards finding out what's going on with: #2587

This matches the current [state](https://github.com/conda-forge/conda-smithy-feedstock/blob/cfed8476a22f44e86d5c5806e297458a97303b51/recipe/meta.yaml#L35-L36) of conda-smithy-feedstock, where we're seeing failures (likely due to some environmental differences): https://github.com/conda-forge/conda-smithy-feedstock/pull/391

closes #2587 