### PR TITLE
stop depending on implicit mutation of lints/hints

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -178,19 +178,19 @@ def lintify_meta_yaml(
             lints.append(f"Unsupported recipe.yaml schema version {schema_version}")
             return lints, hints
 
-    sources_section = get_section(meta, "source", lints, recipe_version)
-    build_section = get_section(meta, "build", lints, recipe_version)
-    requirements_section = get_section(meta, "requirements", lints, recipe_version)
+    sources_section, lints = get_section(meta, "source", lints, recipe_version)
+    build_section, lints = get_section(meta, "build", lints, recipe_version)
+    requirements_section, lints = get_section(meta, "requirements", lints, recipe_version)
     build_requirements = requirements_section.get("build", [])
     run_reqs = requirements_section.get("run", [])
     if recipe_version == 1:
-        test_section = get_section(meta, "tests", lints, recipe_version)
+        test_section, lints = get_section(meta, "tests", lints, recipe_version)
     else:
-        test_section = get_section(meta, "test", lints, recipe_version)
-    about_section = get_section(meta, "about", lints, recipe_version)
-    extra_section = get_section(meta, "extra", lints, recipe_version)
-    package_section = get_section(meta, "package", lints, recipe_version)
-    outputs_section = get_section(meta, "outputs", lints, recipe_version)
+        test_section, lints = get_section(meta, "test", lints, recipe_version)
+    about_section, lints = get_section(meta, "about", lints, recipe_version)
+    extra_section, lints = get_section(meta, "extra", lints, recipe_version)
+    package_section, lints = get_section(meta, "package", lints, recipe_version)
+    outputs_section, lints = get_section(meta, "outputs", lints, recipe_version)
 
     recipe_dirname = os.path.basename(recipe_dir) if recipe_dir else "recipe"
     is_staged_recipes = recipe_dirname != "recipe"
@@ -214,20 +214,20 @@ def lintify_meta_yaml(
         major_sections.remove(section)
 
     # 1: Top level keys in recipe file should have a specific order.
-    lint_section_order(major_sections, lints, recipe_version)
+    lints = lint_section_order(major_sections, lints, recipe_version)
 
     # 2: The about section should have a home, license and summary.
-    lint_about_contents(about_section, lints, recipe_version)
+    lints = lint_about_contents(about_section, lints, recipe_version)
 
     # 3a: The recipe should have some maintainers.
     # 3b: Maintainers should be a list
-    lint_recipe_maintainers(extra_section, lints)
+    lints = lint_recipe_maintainers(extra_section, lints)
 
     # 3c: feedstock-name should not end with "-feedstock"
-    lint_feedstock_name_not_end_with_feedstock(extra_section, lints)
+    lints = lint_feedstock_name_not_end_with_feedstock(extra_section, lints)
 
     # 4: The recipe should have some tests.
-    lint_recipe_have_tests(
+    lints, hints = lint_recipe_have_tests(
         recipe_dir,
         test_section,
         outputs_section,
@@ -237,31 +237,31 @@ def lintify_meta_yaml(
     )
 
     # 5: License cannot be 'unknown.'
-    lint_license_cannot_be_unknown(about_section, lints)
+    lints = lint_license_cannot_be_unknown(about_section, lints)
 
     # 6: Selectors should be in a tidy form.
     if recipe_version == 0:
         # v1 does not have selectors in comments form
-        lint_selectors_should_be_in_tidy_form(recipe_fname, lints, hints)
+        lints, hints = lint_selectors_should_be_in_tidy_form(recipe_fname, lints, hints)
 
     # 6a: Comment-style selectors must not be used in v1 recipes.
     if recipe_version == 1:
-        lint_no_comment_selectors(recipe_fname, lints, hints)
+        lints, hints = lint_no_comment_selectors(recipe_fname, lints, hints)
 
     # 7: The build section should have a build number.
-    lint_build_section_should_have_a_number(build_section, lints)
+    lints = lint_build_section_should_have_a_number(build_section, lints)
 
     # 8: The build section should be before the run section in requirements.
-    lint_build_section_should_be_before_run(requirements_section, lints)
+    lints = lint_build_section_should_be_before_run(requirements_section, lints)
 
     # 9: Files downloaded should have a hash.
-    lint_sources_should_have_hash(sources_section, lints)
+    lints = lint_sources_should_have_hash(sources_section, lints)
 
     # 10: License should not include the word 'license'.
-    lint_license_should_not_have_license(about_section, lints)
+    lints = lint_license_should_not_have_license(about_section, lints)
 
     # 11: There should be one empty line at the end of the file.
-    lint_should_be_empty_line(recipe_fname, lints)
+    lints = lint_should_be_empty_line(recipe_fname, lints)
 
     # 12: License family must be valid (conda-build checks for that)
     # we skip it for v1 builds as it will validate it
@@ -274,22 +274,22 @@ def lintify_meta_yaml(
 
     # 12a: License family must be valid (conda-build checks for that)
     license = about_section.get("license", "").lower()
-    lint_license_family_should_be_valid(
+    lints = lint_license_family_should_be_valid(
         about_section, license, NEEDED_FAMILIES, lints, recipe_version
     )
 
     # 13: Check that the recipe name is valid
     if recipe_version == 1:
-        recipe_name = conda_recipe_v1_linter.lint_recipe_name(meta, lints)
+        recipe_name, lints = conda_recipe_v1_linter.lint_recipe_name(meta, lints)
     else:
-        recipe_name = lint_recipe_name(
+        recipe_name, lints = lint_recipe_name(
             package_section,
             lints,
         )
 
     # 14: Run conda-forge specific lints
     if conda_forge:
-        run_conda_forge_specific(
+        lints, hints = run_conda_forge_specific(
             meta,
             recipe_dir,
             lints,
@@ -299,15 +299,15 @@ def lintify_meta_yaml(
         )
 
     # 15: Check if we are using legacy patterns
-    lint_usage_of_legacy_patterns(requirements_section, lints)
+    lints = lint_usage_of_legacy_patterns(requirements_section, lints)
 
     # 16: Subheaders should be in the allowed subheadings
     if recipe_version == 0:
-        lint_subheaders(major_sections, meta, lints)
+        lints = lint_subheaders(major_sections, meta, lints)
 
     # 17: Validate noarch
     noarch_value = build_section.get("noarch")
-    lint_noarch(noarch_value, lints)
+    lints = lint_noarch(noarch_value, lints)
 
     # Interlude: load recipe config
     recipe_config_keys = _get_recipe_config_keys(recipe_dir)
@@ -317,7 +317,7 @@ def lintify_meta_yaml(
     if "lint_noarch_selectors" not in lints_to_skip:
         if recipe_version == 1:
             raw_requirements_section = meta.get("requirements", {})
-            lint_recipe_v1_noarch_and_runtime_dependencies(
+            lints = lint_recipe_v1_noarch_and_runtime_dependencies(
                 noarch_value,
                 raw_requirements_section,
                 build_section,
@@ -325,7 +325,7 @@ def lintify_meta_yaml(
                 lints,
             )
         else:
-            lint_noarch_and_runtime_dependencies(
+            lints = lint_noarch_and_runtime_dependencies(
                 noarch_value,
                 recipe_fname,
                 feedstock_config_keys,
@@ -335,23 +335,23 @@ def lintify_meta_yaml(
 
     # 19: check version
     if recipe_version == 1:
-        conda_recipe_v1_linter.lint_package_version(meta, lints)
+        lints = conda_recipe_v1_linter.lint_package_version(meta, lints)
     else:
-        lint_package_version(package_section, lints)
+        lints = lint_package_version(package_section, lints)
 
     # 20: Jinja2 variable definitions should be nice.
-    lint_jinja_variables_definitions(recipe_fname, lints)
+    lints = lint_jinja_variables_definitions(recipe_fname, lints)
 
     # 21: Legacy usage of compilers
-    lint_legacy_usage_of_compilers(build_requirements, lints)
+    lints = lint_legacy_usage_of_compilers(build_requirements, lints)
 
     # 22: Single space in pinned requirements
-    lint_single_space_in_pinned_requirements(
+    lints = lint_single_space_in_pinned_requirements(
         requirements_section, lints, recipe_version
     )
 
     # 23: non noarch builds shouldn't use version constraints on python and r-base
-    lint_non_noarch_builds(
+    lints = lint_non_noarch_builds(
         requirements_section,
         outputs_section,
         build_section,
@@ -361,17 +361,17 @@ def lintify_meta_yaml(
     )
 
     # 24: jinja2 variable references should be {{<one space>var<one space>}}
-    lint_jinja_var_references(recipe_fname, hints, recipe_version=recipe_version)
+    hints = lint_jinja_var_references(recipe_fname, hints, recipe_version=recipe_version)
 
     # 25: require a lower bound on python version
-    lint_require_lower_bound_on_python_version(
+    lints = lint_require_lower_bound_on_python_version(
         run_reqs, outputs_section, noarch_value, lints
     )
 
     # 26: pin_subpackage is for subpackages and pin_compatible is for
     # non-subpackages of the recipe. Contact @carterbox for troubleshooting
     # this lint.
-    lint_pin_subpackages(
+    lints = lint_pin_subpackages(
         meta,
         outputs_section,
         package_section,
@@ -380,15 +380,15 @@ def lintify_meta_yaml(
     )
 
     # 27: Check usage of whl files as a source
-    lint_check_usage_of_whls(recipe_fname, noarch_value, lints, hints)
+    lints, hints = lint_check_usage_of_whls(recipe_fname, noarch_value, lints, hints)
 
     # 28: Check that Rust licenses are bundled.
-    lint_rust_licenses_are_bundled(
+    lints = lint_rust_licenses_are_bundled(
         recipe_name, build_requirements, lints, recipe_version=recipe_version
     )
 
     # 29: Check that go licenses are bundled.
-    lint_go_licenses_are_bundled(
+    lints = lint_go_licenses_are_bundled(
         recipe_name, build_requirements, lints, recipe_version=recipe_version
     )
 
@@ -399,7 +399,7 @@ def lintify_meta_yaml(
     # 31: stdlib-related lints
     if "lint_stdlib" not in lints_to_skip:
         for config_fn in recipe_config_keys.keys():
-            lint_stdlib(
+            lints = lint_stdlib(
                 meta,
                 requirements_section,
                 recipe_dir,
@@ -410,15 +410,15 @@ def lintify_meta_yaml(
             )
 
     # 32: floats should be quoted
-    lint_floats_quoted(meta, lints, recipe_version=recipe_version)
+    lints = lint_floats_quoted(meta, lints, recipe_version=recipe_version)
 
     # hints
     # 1: suggest pip
-    hint_pip_usage(build_section, hints)
+    hints = hint_pip_usage(build_section, hints)
 
     # 2: suggest python noarch (skip on feedstocks)
     raw_requirements_section = meta.get("requirements", {})
-    hint_suggest_noarch(
+    hints = hint_suggest_noarch(
         noarch_value,
         build_requirements,
         raw_requirements_section,
@@ -430,18 +430,18 @@ def lintify_meta_yaml(
     )
 
     # 3: suggest fixing all recipe/*.sh shellcheck findings
-    hint_shellcheck_usage(recipe_dir, hints, feedstock_config=feedstock_config_keys)
+    hints = hint_shellcheck_usage(recipe_dir, hints, feedstock_config=feedstock_config_keys)
 
     # 4: Check for SPDX
-    hint_check_spdx(about_section, hints)
+    hints = hint_check_spdx(about_section, hints)
 
     # 5: hint pypi.io -> pypi.org
-    hint_sources_should_not_mention_pypi_io_but_pypi_org(sources_section, hints)
+    hints = hint_sources_should_not_mention_pypi_io_but_pypi_org(sources_section, hints)
 
     # 6: warn of `name =version=build` specs, suggest `name version build`
     # see https://github.com/conda/conda-build/issues/5571#issuecomment-2604505922
     if recipe_version == 0:
-        hint_space_separated_specs(
+        hints = hint_space_separated_specs(
             requirements_section,
             test_section,
             outputs_section,
@@ -450,10 +450,10 @@ def lintify_meta_yaml(
 
     # 7. check for obsolete os_version
     if "hint_os_version" not in lints_to_skip:
-        hint_os_version(feedstock_config_keys, hints)
+        hints = hint_os_version(feedstock_config_keys, hints)
 
     # 8. check for bld.bat with rattler-build
-    hint_rattler_build_bld_bat(recipe_dir, hints, recipe_version)
+    hints = hint_rattler_build_bld_bat(recipe_dir, hints, recipe_version)
 
     return lints, hints
 
@@ -634,16 +634,16 @@ def run_conda_forge_specific(
     lints_to_skip = feedstock_config.get("linter", {}).get("skip", [])
 
     # Retrieve sections from meta
-    package_section = get_section(meta, "package", lints, recipe_version=recipe_version)
-    extra_section = get_section(meta, "extra", lints, recipe_version=recipe_version)
-    requirements_section = get_section(
+    package_section, lints = get_section(meta, "package", lints, recipe_version=recipe_version)
+    extra_section, lints = get_section(meta, "extra", lints, recipe_version=recipe_version)
+    requirements_section, lints = get_section(
         meta, "requirements", lints, recipe_version=recipe_version
     )
-    outputs_section = get_section(meta, "outputs", lints, recipe_version=recipe_version)
+    outputs_section, lints = get_section(meta, "outputs", lints, recipe_version=recipe_version)
 
-    build_section = get_section(meta, "build", lints, recipe_version)
+    build_section, lints = get_section(meta, "build", lints, recipe_version)
     noarch_value = build_section.get("noarch")
-    test_reqs = get_all_test_requirements(meta, lints, recipe_version)
+    test_reqs, lints = get_all_test_requirements(meta, lints, recipe_version)
 
     # Fetch list of recipe maintainers
     maintainers = extra_section.get("recipe-maintainers", [])
@@ -772,7 +772,7 @@ def run_conda_forge_specific(
 
     # 10: check for proper noarch python syntax
     if "hint_python_min" not in lints_to_skip:
-        hint_noarch_python_use_python_min(
+        hints = hint_noarch_python_use_python_min(
             requirements_section.get("host") or [],
             requirements_section.get("run") or [],
             test_reqs,
@@ -787,7 +787,7 @@ def run_conda_forge_specific(
             recipe_text = fh.read()
 
         # 11: ensure we can parse the recipe
-        lint_recipe_is_parsable(
+        lints, hints = lint_recipe_is_parsable(
             recipe_text,
             lints,
             hints,
@@ -795,7 +795,7 @@ def run_conda_forge_specific(
         )
 
         # 12: ensure is_abi3 is boolean
-        lint_recipe_is_abi3_bool(
+        lints = lint_recipe_is_abi3_bool(
             recipe_text,
             lints,
         )
@@ -829,13 +829,14 @@ def run_conda_forge_specific(
         )
 
     # 16: Check for requirements overriding dependency pins
-    hint_dependency_pins(
+    hints = hint_dependency_pins(
         requirements_section, outputs_section, ci_support_files, hints, recipe_version
     )
 
     # 17: Check for deprecated conda-forge.yml variables (that cannot be caught
     # via the schema)
-    hint_deprecated_environment_variables(feedstock_config, hints)
+    hints = hint_deprecated_environment_variables(feedstock_config, hints)
+    return lints, hints
 
 
 def _format_validation_msg(error: jsonschema.ValidationError):
@@ -943,20 +944,20 @@ def main(recipe_dir, conda_forge=False, return_hints=False, feedstock_dir=None):
     # see https://github.com/prefix-dev/rattler-build-conda-compat/issues/88
     validation_errors, validation_hints = lintify_forge_yaml(recipe_dir=recipe_dir)
 
-    results, hints = lintify_meta_yaml(
+    lints, hints = lintify_meta_yaml(
         meta,
         recipe_dir,
         conda_forge,
         recipe_version=recipe_version,
     )
 
-    results.extend([_format_validation_msg(err) for err in validation_errors])
+    lints.extend([_format_validation_msg(err) for err in validation_errors])
     hints.extend(validation_hints)
 
     if return_hints:
-        return results, hints
+        return lints, hints
     else:
-        return results
+        return lints
 
 
 if __name__ == "__main__":

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -180,7 +180,9 @@ def lintify_meta_yaml(
 
     sources_section, lints = get_section(meta, "source", lints, recipe_version)
     build_section, lints = get_section(meta, "build", lints, recipe_version)
-    requirements_section, lints = get_section(meta, "requirements", lints, recipe_version)
+    requirements_section, lints = get_section(
+        meta, "requirements", lints, recipe_version
+    )
     build_requirements = requirements_section.get("build", [])
     run_reqs = requirements_section.get("run", [])
     if recipe_version == 1:
@@ -361,7 +363,9 @@ def lintify_meta_yaml(
     )
 
     # 24: jinja2 variable references should be {{<one space>var<one space>}}
-    hints = lint_jinja_var_references(recipe_fname, hints, recipe_version=recipe_version)
+    hints = lint_jinja_var_references(
+        recipe_fname, hints, recipe_version=recipe_version
+    )
 
     # 25: require a lower bound on python version
     lints = lint_require_lower_bound_on_python_version(
@@ -430,7 +434,9 @@ def lintify_meta_yaml(
     )
 
     # 3: suggest fixing all recipe/*.sh shellcheck findings
-    hints = hint_shellcheck_usage(recipe_dir, hints, feedstock_config=feedstock_config_keys)
+    hints = hint_shellcheck_usage(
+        recipe_dir, hints, feedstock_config=feedstock_config_keys
+    )
 
     # 4: Check for SPDX
     hints = hint_check_spdx(about_section, hints)
@@ -634,12 +640,18 @@ def run_conda_forge_specific(
     lints_to_skip = feedstock_config.get("linter", {}).get("skip", [])
 
     # Retrieve sections from meta
-    package_section, lints = get_section(meta, "package", lints, recipe_version=recipe_version)
-    extra_section, lints = get_section(meta, "extra", lints, recipe_version=recipe_version)
+    package_section, lints = get_section(
+        meta, "package", lints, recipe_version=recipe_version
+    )
+    extra_section, lints = get_section(
+        meta, "extra", lints, recipe_version=recipe_version
+    )
     requirements_section, lints = get_section(
         meta, "requirements", lints, recipe_version=recipe_version
     )
-    outputs_section, lints = get_section(meta, "outputs", lints, recipe_version=recipe_version)
+    outputs_section, lints = get_section(
+        meta, "outputs", lints, recipe_version=recipe_version
+    )
 
     build_section, lints = get_section(meta, "build", lints, recipe_version)
     noarch_value = build_section.get("noarch")

--- a/conda_smithy/linter/conda_recipe_v1_linter.py
+++ b/conda_smithy/linter/conda_recipe_v1_linter.py
@@ -79,6 +79,7 @@ def lint_recipe_tests(
 
     lints.extend(tests_lints)
     hints.extend(tests_hints)
+    return lints, hints
 
 
 def hint_noarch_usage(
@@ -110,6 +111,7 @@ def hint_noarch_usage(
 
         if no_arch_possible:
             hints.append(HINT_NO_ARCH)
+    return hints
 
 
 def get_recipe_name(recipe_content: RecipeWithContext) -> str:
@@ -140,13 +142,13 @@ def lint_recipe_name(
     # from conda_build_config.yaml.
     # https://github.com/conda-forge/conda-smithy/issues/2224
     if "${{" in name:
-        return None
+        return None, lints
 
     lint_msg = _lint_recipe_name(name)
     if lint_msg:
         lints.append(lint_msg)
 
-    return name
+    return name, lints
 
 
 def lint_package_version(
@@ -159,6 +161,7 @@ def lint_package_version(
 
     if lint_msg:
         lints.append(lint_msg)
+    return lints
 
 
 def lint_usage_of_selectors_for_noarch(
@@ -206,3 +209,4 @@ def lint_usage_of_selectors_for_noarch(
         lints.append(
             msg.r.NoarchSelectorsV1(noarch=noarch_value, skips=True).as_string()
         )
+    return lints

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -29,6 +29,7 @@ def hint_pip_usage(build_section, hints):
         for script in scripts:
             if "python setup.py install" in script:
                 hints.append(msg.r.UsePip().as_string())
+    return hints
 
 
 def hint_sources_should_not_mention_pypi_io_but_pypi_org(
@@ -45,6 +46,7 @@ def hint_sources_should_not_mention_pypi_io_but_pypi_org(
         sources = [source] if isinstance(source, str) else source
         if any(s.startswith("https://pypi.io/") for s in sources):
             hints.append(msg.r.UsePyPIOrg().as_string())
+    return hints
 
 
 def hint_suggest_noarch(
@@ -90,6 +92,7 @@ def hint_suggest_noarch(
                             break
                 if no_arch_possible:
                     hints.append(msg.r.SuggestNoarch().as_string())
+    return hints
 
 
 def hint_shellcheck_usage(recipe_dir, hints, feedstock_config=None):
@@ -98,7 +101,7 @@ def hint_shellcheck_usage(recipe_dir, hints, feedstock_config=None):
     if recipe_dir:
         shell_scripts = glob(os.path.join(recipe_dir, "*.sh"))
         if not shell_scripts:
-            return
+            return hints
         if feedstock_config is None:
             forge_yaml = find_local_config_file(recipe_dir, "conda-forge.yml")
             if forge_yaml:
@@ -146,6 +149,7 @@ def hint_shellcheck_usage(recipe_dir, hints, feedstock_config=None):
             elif p.returncode != 0:
                 # Something went wrong.
                 hints.append(msg.r.ScriptShellcheckFailure().as_string())
+    return hints
 
 
 def hint_check_spdx(about_section, hints):
@@ -190,6 +194,7 @@ def hint_check_spdx(about_section, hints):
         hints.append(msg.r.LicenseSPDX().as_string())
     if set(parsed_exceptions) - expected_exceptions:
         hints.append(msg.r.InvalidLicenseException().as_string())
+    return hints
 
 
 def hint_pip_no_build_backend(host_or_build_section, package_name, hints):
@@ -202,7 +207,7 @@ def hint_pip_no_build_backend(host_or_build_section, package_name, hints):
         "pdm-backend",
         "setuptools",
     ]:
-        return
+        return hints
 
     if host_or_build_section and any(
         req.split(" ")[0] == "pip" for req in host_or_build_section
@@ -225,6 +230,7 @@ def hint_pip_no_build_backend(host_or_build_section, package_name, hints):
             hints.append(
                 msg.r.PythonBuildBackendHost(package_name=package_name).as_string()
             )
+    return hints
 
 
 def _hint_noarch_python_use_python_min_inner(
@@ -339,7 +345,8 @@ def hint_noarch_python_use_python_min(
                 _hint_noarch_python_use_python_min_inner(
                     output_host_reqs or [],
                     output_run_reqs or [],
-                    get_all_test_requirements(output, [], recipe_version),
+                    # we're ignoring possible lints (in the second argument)
+                    get_all_test_requirements(output, [], recipe_version)[0],
                     output.get("build", {}).get("noarch"),
                     recipe_version,
                     output.get("package", {}).get("name", f"<output {output_num}"),
@@ -359,6 +366,7 @@ def hint_noarch_python_use_python_min(
 
     if recommendations:
         hints.append(msg.r.PythonMinPin(recommendations=recommendations).as_string())
+    return hints
 
 
 def hint_space_separated_specs(
@@ -398,6 +406,7 @@ def hint_space_separated_specs(
         hints.append(
             msg.r.SpaceSeparatedSpecs(output=output, bad_specs=requirements).as_string()
         )
+    return hints
 
 
 def _ensure_spec_space_separated(spec: str) -> bool:
@@ -439,7 +448,7 @@ def _ensure_spec_space_separated(spec: str) -> bool:
 def hint_os_version(
     forge_yaml: dict[str, Any],
     hints: list[str],
-) -> None:
+) -> list[str]:
     default_os_version = "alma9"
     obsolete_os_versions = ("cos7", "alma8", "ubi8")
     matches = {
@@ -453,6 +462,7 @@ def hint_os_version(
                 platforms=matches, default=default_os_version
             ).as_string()
         )
+    return hints
 
 
 def hint_rattler_build_bld_bat(
@@ -466,16 +476,17 @@ def hint_rattler_build_bld_bat(
     Having bld.bat present when using rattler-build is likely a mistake.
     """
     if not recipe_dir:
-        return
+        return hints
 
     # Check if this is a recipe version 1 (rattler-build)
     if recipe_version != 1:
-        return
+        return hints
 
     # Check if bld.bat exists in the recipe directory
     bld_bat_path = os.path.join(recipe_dir, "bld.bat")
     if os.path.exists(bld_bat_path):
         hints.append(msg.r.RattlerBldBat().as_string())
+    return hints
 
 
 def _check_pin_overridden(
@@ -531,7 +542,7 @@ def hint_dependency_pins(
     """Hint for dependencies that override pinning"""
 
     if not ci_support_files:
-        return
+        return hints
 
     potential_pins = set()
     for pin_file in ci_support_files:
@@ -563,6 +574,7 @@ def hint_dependency_pins(
                 output=output, bad_specs=requirements
             ).as_string()
         )
+    return hints
 
 
 def hint_deprecated_environment_variables(
@@ -588,3 +600,4 @@ def hint_deprecated_environment_variables(
                     replacement=deprecated_variables[deprecated_variable],
                 ).as_string()
             )
+    return hints

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -6,7 +6,7 @@ import os
 import re
 import tempfile
 from collections.abc import Sequence
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, Tuple
 
 from conda.models.version import VersionOrder
 from rattler_build_conda_compat.jinja.jinja import render_recipe_with_context
@@ -52,6 +52,7 @@ def lint_section_order(
 
     if major_sections != section_order_sorted:
         lints.append(msg.r.SectionOrder(order=section_order_sorted).as_string())
+    return lints
 
 
 def lint_about_contents(about_section, lints, recipe_version: int = 0):
@@ -64,12 +65,14 @@ def lint_about_contents(about_section, lints, recipe_version: int = 0):
         # if the section doesn't exist, or is just empty, lint it.
         if not about_section.get(about_item, ""):
             lints.append(msg.r.MissingAboutItem(item=about_item).as_string())
+    return lints
 
 
 def lint_feedstock_name_not_end_with_feedstock(extra_section, lints):
     feedstock_name = extra_section.get("feedstock-name", "")
     if feedstock_name and feedstock_name.endswith("-feedstock"):
         lints.append(msg.r.ExtraFeedstockNameSuffix().as_string())
+    return lints
 
 
 def lint_recipe_maintainers(extra_section, lints):
@@ -80,6 +83,7 @@ def lint_recipe_maintainers(extra_section, lints):
         and not isinstance(extra_section.get("recipe-maintainers", []), str)
     ):
         lints.append(msg.r.MaintainersMustBeList().as_string())
+    return lints
 
 
 def lint_recipe_have_tests(
@@ -91,10 +95,10 @@ def lint_recipe_have_tests(
     recipe_version: int = 0,
 ):
     if recipe_version == 1:
-        conda_recipe_v1_linter.lint_recipe_tests(
+        lints, hints = conda_recipe_v1_linter.lint_recipe_tests(
             recipe_dir, test_section, outputs_section, lints, hints
         )
-        return
+        return lints, hints
 
     if not any(key in TEST_KEYS for key in test_section):
         a_test_file_exists = recipe_dir is not None and any(
@@ -106,7 +110,7 @@ def lint_recipe_have_tests(
             no_test_hints = []
             if outputs_section:
                 for out in outputs_section:
-                    test_out = get_section(out, "test", lints)
+                    test_out, lints = get_section(out, "test", lints)
                     if any(key in TEST_KEYS for key in test_out):
                         has_outputs_test = True
                     elif test_out.get("script", "").endswith((".bat", ".sh")):
@@ -122,12 +126,14 @@ def lint_recipe_have_tests(
                 hints.extend(no_test_hints)
             else:
                 lints.append(msg.r.RequiredTests().as_string())
+    return lints, hints
 
 
 def lint_license_cannot_be_unknown(about_section, lints):
     license = about_section.get("license", "").lower()
     if "unknown" == license.strip():
         lints.append(msg.r.UnknownLicense().as_string())
+    return lints
 
 
 def lint_selectors_should_be_in_tidy_form(recipe_fname, lints, hints):
@@ -164,6 +170,7 @@ def lint_selectors_should_be_in_tidy_form(recipe_fname, lints, hints):
         lints.append(
             msg.r.OldPythonSelectorsLint(lines=py_selector_lines_lint).as_string()
         )
+    return lints, hints
 
 
 def lint_no_comment_selectors(recipe_fname, lints, hints):
@@ -174,11 +181,13 @@ def lint_no_comment_selectors(recipe_fname, lints, hints):
                 bad_lines.append(line_number)
     if bad_lines:
         lints.append(msg.r.NoCommentSelectors(lines=bad_lines).as_string())
+    return lints, hints
 
 
 def lint_build_section_should_have_a_number(build_section, lints):
     if build_section.get("number", None) is None:
         lints.append(msg.r.BuildNumberMissing().as_string())
+    return lints
 
 
 def lint_build_section_should_be_before_run(requirements_section, lints):
@@ -190,6 +199,7 @@ def lint_build_section_should_be_before_run(requirements_section, lints):
                 expected=REQUIREMENTS_ORDER, seen=seen_requirements
             ).as_string()
         )
+    return lints
 
 
 def lint_sources_should_have_hash(
@@ -200,6 +210,7 @@ def lint_sources_should_have_hash(
             {"sha1", "sha256", "md5"} & set(source_section.keys())
         ):
             lints.append(msg.r.SourceHash().as_string())
+    return lints
 
 
 def lint_license_should_not_have_license(about_section, lints):
@@ -211,6 +222,7 @@ def lint_license_should_not_have_license(about_section, lints):
         and "-license" not in license.lower()
     ):
         lints.append(msg.r.LicenseFieldMentionsLicense().as_string())
+    return lints
 
 
 def lint_should_be_empty_line(meta_fname, lints):
@@ -226,6 +238,7 @@ def lint_should_be_empty_line(meta_fname, lints):
             )
         elif end_empty_lines_count < 1:
             lints.append(msg.r.TooFewEmptyLines().as_string())
+    return lints
 
 
 def lint_license_family_should_be_valid(
@@ -234,7 +247,7 @@ def lint_license_family_should_be_valid(
     needed_families: list[str],
     lints: list[str],
     recipe_version: int = 0,
-) -> None:
+) -> list[str]:
     license_file = about_section.get("license_file", None)
     if not license_file:
         if recipe_version == 1:
@@ -243,23 +256,25 @@ def lint_license_family_should_be_valid(
             license_family = about_section.get("license_family", license).lower()
             if any(f for f in needed_families if f in license_family):
                 lints.append(msg.r.LicenseFamily().as_string())
+    return lints
 
 
 def lint_recipe_name(
     package_section: dict[str, Any],
     lints: list[str],
-) -> str:
+) -> Tuple[str, list[str]]:
     recipe_name = package_section.get("name", "").strip()
     lint_msg = _lint_recipe_name(recipe_name)
     if lint_msg:
         lints.append(lint_msg)
-    return recipe_name
+    return recipe_name, lints
 
 
 def lint_usage_of_legacy_patterns(requirements_section, lints):
     build_reqs = requirements_section.get("build", None)
     if build_reqs and ("numpy x.x" in build_reqs):
         lints.append(msg.r.PinnedNumpy().as_string())
+    return lints
 
 
 def lint_subheaders(major_sections, meta, lints):
@@ -267,7 +282,8 @@ def lint_subheaders(major_sections, meta, lints):
         expected_subsections = FIELDS.get(section, [])
         if not expected_subsections:
             continue
-        for subsection in get_section(meta, section, lints):
+        # we're ignoring extra lints from get_section here
+        for subsection in get_section(meta, section, lints)[0]:
             if (
                 section != "source"
                 and section != "outputs"
@@ -286,12 +302,14 @@ def lint_subheaders(major_sections, meta, lints):
                                 section=section, subsection=source_subsection
                             ).as_string()
                         )
+    return lints
 
 
 def lint_noarch(noarch_value: Optional[str], lints):
     if noarch_value is not None:
         if noarch_value not in msg.r.NoarchValue.valid:
             lints.append(msg.r.NoarchValue(given=noarch_value).as_string())
+    return lints
 
 
 def lint_recipe_v1_noarch_and_runtime_dependencies(
@@ -300,15 +318,16 @@ def lint_recipe_v1_noarch_and_runtime_dependencies(
     build_section: dict[str, Any],
     noarch_platforms: bool,
     lints: list[str],
-) -> None:
+) -> list[str]:
     if noarch_value:
-        conda_recipe_v1_linter.lint_usage_of_selectors_for_noarch(
+        lints = conda_recipe_v1_linter.lint_usage_of_selectors_for_noarch(
             noarch_value,
             raw_requirements_section,
             build_section,
             noarch_platforms,
             lints,
         )
+    return lints
 
 
 def lint_noarch_and_runtime_dependencies(
@@ -320,7 +339,7 @@ def lint_noarch_and_runtime_dependencies(
     for skips with selectors, and for packages with selectors.
     """
     if noarch_value is None or not os.path.exists(meta_fname):
-        return
+        return lints
     noarch_platforms = len(forge_yaml.get("noarch_platforms", [])) > 1
     with open(meta_fname, encoding="utf-8") as fh:
         in_runreqs = False
@@ -357,6 +376,7 @@ def lint_noarch_and_runtime_dependencies(
                         ).as_string()
                     )
                     break
+    return lints
 
 
 def lint_package_version(package_section, lints):
@@ -364,6 +384,7 @@ def lint_package_version(package_section, lints):
     lint_msg = _lint_package_version(str(version) if version is not None else None)
     if lint_msg:
         lints.append(lint_msg)
+    return lints
 
 
 def lint_jinja_variables_definitions(meta_fname, lints):
@@ -379,11 +400,13 @@ def lint_jinja_variables_definitions(meta_fname, lints):
                     bad_lines.append(line_number)
         if bad_jinja:
             lints.append(msg.r.JinjaDefinitions(lines=bad_lines).as_string())
+    return lints
 
 
 def lint_legacy_usage_of_compilers(build_reqs, lints):
     if build_reqs and ("toolchain" in build_reqs):
         lints.append(msg.r.LegacyToolchain().as_string())
+    return lints
 
 
 def lint_single_space_in_pinned_requirements(
@@ -470,6 +493,7 @@ def lint_single_space_in_pinned_requirements(
                     ).as_string()
                 )
                 continue
+    return lints
 
 
 def lint_non_noarch_builds(
@@ -507,6 +531,7 @@ def lint_non_noarch_builds(
                         lints.append(
                             msg.r.LanguageHostRunUnpinned(language=language).as_string()
                         )
+    return lints
 
 
 def lint_jinja_var_references(meta_fname, hints, recipe_version: int = 0):
@@ -530,6 +555,7 @@ def lint_jinja_var_references(meta_fname, hints, recipe_version: int = 0):
                     recipe_version=recipe_version, lines=bad_lines
                 ).as_string()
             )
+    return hints
 
 
 def lint_require_lower_bound_on_python_version(
@@ -541,6 +567,7 @@ def lint_require_lower_bound_on_python_version(
                 break
         else:
             lints.append(msg.r.PythonLowerBound().as_string())
+    return lints
 
 
 def lint_pin_subpackages(
@@ -622,6 +649,7 @@ def lint_pin_subpackages(
     check_pins_build_and_requirements(meta)
     for out in outputs_section:
         check_pins_build_and_requirements(out)
+    return lints
 
 
 def lint_check_usage_of_whls(meta_fname, noarch_value, lints, hints):
@@ -653,6 +681,7 @@ def lint_check_usage_of_whls(meta_fname, noarch_value, lints, hints):
                 lints.append(
                     msg.r.PureWheelsNotAllowed(urls=pure_python_wheel_urls).as_string()
                 )
+    return lints, hints
 
 
 def lint_rust_licenses_are_bundled(
@@ -662,11 +691,11 @@ def lint_rust_licenses_are_bundled(
     recipe_version: int = 0,
 ):
     if not build_reqs:
-        return
+        return lints
 
     if recipe_name == "cargo-bundle-licenses":
         # cargo-bundle-licenses itself bundles its own licenses
-        return
+        return lints
 
     if recipe_version == 1:
         has_rust = "${{ compiler('rust') }}" in build_reqs
@@ -675,6 +704,7 @@ def lint_rust_licenses_are_bundled(
 
     if has_rust and "cargo-bundle-licenses" not in build_reqs:
         lints.append(msg.r.RustLicenses().as_string())
+    return lints
 
 
 def lint_go_licenses_are_bundled(
@@ -684,7 +714,7 @@ def lint_go_licenses_are_bundled(
     recipe_version: int = 0,
 ):
     if not build_reqs:
-        return
+        return lints
 
     if recipe_version == 1:
         has_go = "${{ compiler('go') }}" in build_reqs
@@ -694,13 +724,14 @@ def lint_go_licenses_are_bundled(
     if has_go:
         if "go-licenses" not in [*build_reqs, recipe_name]:
             lints.append(msg.r.GoLicenses().as_string())
+    return lints
 
 
 def lint_osx_pins(recipe_dir, recipe_config_filename, lints, recipe_version):
     cbc_osx = {}
     if recipe_dir is None or recipe_config_filename is None:
         # nothing left to do
-        return
+        return lints
 
     recipe_config_file = os.path.join(recipe_dir, recipe_config_filename)
 
@@ -750,7 +781,7 @@ def lint_osx_pins(recipe_dir, recipe_config_filename, lints, recipe_version):
     cbc_osx = dict(filter(lambda item: item[1] is not None, cbc_osx.items()))
     if not cbc_osx:
         # nothing left to do
-        return
+        return lints
 
     if "MACOSX_DEPLOYMENT_TARGET" in cbc_osx:
         lints.append(
@@ -808,6 +839,7 @@ def lint_osx_pins(recipe_dir, recipe_config_filename, lints, recipe_version):
         ):
             if sdk_lint not in lints:
                 lints.append(sdk_lint)
+    return lints
 
 
 def lint_stdlib(
@@ -834,7 +866,7 @@ def lint_stdlib(
             r"^\${{ compiler\('(m2w64_)?(c|cxx|fortran|rust|go-cgo)"
         )
 
-    outputs = get_section(meta, "outputs", lints, recipe_version)
+    outputs, lints = get_section(meta, "outputs", lints, recipe_version)
     output_reqs = [x.get("requirements", {}) for x in outputs]
 
     # deal with cb2 recipes (no build/host/run distinction)
@@ -890,6 +922,7 @@ def lint_stdlib(
     to_check = all_run_reqs_flat + all_contraints_flat
     if any(req.startswith("__osx >") for req in to_check):
         msg.r.StdlibMacOS(recipe_version=recipe_version).append_if_absent(lints)
+    return lints
 
 
 def lint_recipe_is_parsable(
@@ -984,6 +1017,7 @@ def lint_recipe_is_parsable(
             for parser_name, pv in parse_results.items():
                 if pv is False:
                     hints.append(msg.r.NotParsableHint(parser=parser_name).as_string())
+    return lints, hints
 
 
 IS_AB3_BOOL_RE = re.compile(r"is_abi3\s*(==|!=)\s*('|\")(true|false)('|\")")
@@ -992,29 +1026,32 @@ IS_AB3_BOOL_RE = re.compile(r"is_abi3\s*(==|!=)\s*('|\")(true|false)('|\")")
 def lint_recipe_is_abi3_bool(
     recipe_text: str,
     lints: list[str],
-) -> None:
+) -> list[str]:
     if IS_AB3_BOOL_RE.search(recipe_text):
         lints.append(msg.r.PythonIsAbi3Bool().as_string())
+    return lints
 
 
 def lint_floats_quoted(
     meta: dict,
     lints: list[str],
     recipe_version: int,
-) -> None:
-    def process_recursively(key: str, value: Any) -> None:
+) -> list[str]:
+    def process_recursively(key: str, value: Any, local_lints: list[str]) -> list[str]:
         if isinstance(value, dict):
             for subkey, subvalue in value.items():
-                process_recursively(f"{key}.{subkey}", subvalue)
+                local_lints = process_recursively(f"{key}.{subkey}", subvalue, local_lints)
         elif isinstance(value, list):
             for i, subvalue in enumerate(value):
-                process_recursively(f"{key}[{i}]", subvalue)
+                local_lints = process_recursively(f"{key}[{i}]", subvalue, local_lints.copy())
         elif isinstance(value, float):
-            lints.append(
+            local_lints.append(
                 msg.r.VersionParsedAsFloat(
                     key=key, value=value, recipe_version=recipe_version
                 ).as_string()
             )
+        return local_lints
 
     for key, value in meta.items():
-        process_recursively(key, value)
+        lints = process_recursively(key, value, lints)
+    return lints

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -1040,10 +1040,14 @@ def lint_floats_quoted(
     def process_recursively(key: str, value: Any, local_lints: list[str]) -> list[str]:
         if isinstance(value, dict):
             for subkey, subvalue in value.items():
-                local_lints = process_recursively(f"{key}.{subkey}", subvalue, local_lints)
+                local_lints = process_recursively(
+                    f"{key}.{subkey}", subvalue, local_lints
+                )
         elif isinstance(value, list):
             for i, subvalue in enumerate(value):
-                local_lints = process_recursively(f"{key}[{i}]", subvalue, local_lints.copy())
+                local_lints = process_recursively(
+                    f"{key}[{i}]", subvalue, local_lints.copy()
+                )
         elif isinstance(value, float):
             local_lints.append(
                 msg.r.VersionParsedAsFloat(

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -6,7 +6,7 @@ import os
 import re
 import tempfile
 from collections.abc import Sequence
-from typing import Any, Literal, Optional, Tuple
+from typing import Any, Literal, Optional
 
 from conda.models.version import VersionOrder
 from rattler_build_conda_compat.jinja.jinja import render_recipe_with_context
@@ -262,7 +262,7 @@ def lint_license_family_should_be_valid(
 def lint_recipe_name(
     package_section: dict[str, Any],
     lints: list[str],
-) -> Tuple[str, list[str]]:
+) -> tuple[str, list[str]]:
     recipe_name = package_section.get("name", "").strip()
     lint_msg = _lint_recipe_name(recipe_name)
     if lint_msg:

--- a/conda_smithy/linter/utils.py
+++ b/conda_smithy/linter/utils.py
@@ -77,15 +77,18 @@ VALID_PYTHON_BUILD_BACKENDS = [
 
 def get_section(parent, name, lints, recipe_version: int = 0):
     if recipe_version == 0:
+        # returns lints already
         return get_meta_section(parent, name, lints)
     elif recipe_version == 1:
-        return get_recipe_v1_section(parent, name)
+        # this function does not return any lints itself
+        return get_recipe_v1_section(parent, name), lints
     else:
         raise ValueError(f"Unknown recipe version: {recipe_version}")
 
 
 def get_meta_section(parent, name, lints):
     if name == "source":
+        # get_list_section already return lints
         return get_list_section(parent, name, lints, allow_single=True)
     elif name == "outputs":
         return get_list_section(parent, name, lints)
@@ -97,7 +100,7 @@ def get_meta_section(parent, name, lints):
             f"got a {type(section).__name__}."
         )
         section = {}
-    return section
+    return section, lints
 
 
 def get_recipe_v1_section(meta, name) -> Union[dict, list[dict]]:
@@ -115,9 +118,9 @@ def get_recipe_v1_section(meta, name) -> Union[dict, list[dict]]:
 def get_list_section(parent, name, lints, allow_single=False):
     section = parent.get(name, [])
     if allow_single and isinstance(section, Mapping):
-        return [section]
+        return [section], lints
     elif isinstance(section, Sequence) and not isinstance(section, str):
-        return section
+        return section, lints
     else:
         msg = 'The "{}" section was expected to be a {}list, but got a {}.{}.'.format(
             name,
@@ -126,7 +129,7 @@ def get_list_section(parent, name, lints, allow_single=False):
             type(section).__name__,
         )
         lints.append(msg)
-        return [{}]
+        return [{}], lints
 
 
 def find_local_config_file(recipe_dir: str, filename: str) -> Optional[str]:
@@ -265,7 +268,7 @@ def get_all_test_requirements(
     meta: dict, lints: list[str], recipe_version: int
 ) -> list[str]:
     if recipe_version == 1:
-        test_section = get_section(meta, "tests", lints, recipe_version)
+        test_section, lints = get_section(meta, "tests", lints, recipe_version)
         test_reqs = []
         for test_element in test_section:
             test_reqs += (test_element.get("requirements") or {}).get("run") or []
@@ -281,9 +284,9 @@ def get_all_test_requirements(
                 else:
                     test_reqs.append("python")
     else:
-        test_section = get_section(meta, "test", lints, recipe_version)
+        test_section, lints = get_section(meta, "test", lints, recipe_version)
         test_reqs = test_section.get("requires") or []
-    return test_reqs
+    return test_reqs, lints
 
 
 def get_version_independent(


### PR DESCRIPTION
To me, code like

https://github.com/conda-forge/conda-smithy/blob/c771d9b52815e29bf5f52bebf502c085b3d62147/conda_smithy/lint_recipe.py#L251-L264

is a major code smell, because there's no indication (besides the meta-context of "we're collecting lints") that `lints` is being mutated from call to call. Same for `hints`. 

In this PR, I'm suggesting to switch away from implicit mutation, towards explicit passing of these quantities. This makes the code much easier to reason about (IMO).