### PR TITLE
don't pin rattler-build

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -39,7 +39,6 @@ dependencies:
   - pixi>=0.59.0
   - jsonschema
   - exceptiongroup
-  # rattler's APIs are subject to change, pin to minor versions
+  # py-rattler's APIs are subject to change, pin to minor versions
   - py-rattler>=0.22,<0.23
   - rattler-build-conda-compat>=1.4.15,<2.0.0a0
-  - rattler-build>=0.66.0,<0.67.0a0


### PR DESCRIPTION
Follow-up to #2588 
> I don't think we need the rattler-build pin? We're only interacting with that through `py-rattler`? At least, as long as py-rattler controls its constraints correctly, I don't think we need this.
> 
> I'd prefer not to have this constraint, because it didn't break anything yet (AFAICT), and it'd be one more fast-moving thing to keep in sync

