### PR TITLE
avoid mis-identifying ambient folders as recipe for linter test

### DIFF
--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -97,7 +97,7 @@ def lint_recipe_have_tests(
         return
 
     if not any(key in TEST_KEYS for key in test_section):
-        a_test_file_exists = recipe_dir is not None and any(
+        a_test_file_exists = bool(recipe_dir) and any(
             os.path.exists(os.path.join(recipe_dir, test_file))
             for test_file in TEST_FILES
         )


### PR DESCRIPTION
Fix for https://github.com/conda-forge/conda-smithy-feedstock/pull/391

The issue was that in
https://github.com/conda-forge/conda-smithy/blob/203988551ec4763994085355d232d01118504483/conda_smithy/linter/lints.py#L100-L103
`recipe_dir = ''` would pass the `recipe_dir is not None` check, and then `os.path.exists(os.path.join(recipe_dir, test_file))` would actually evaluate to true if any test files (`run_test.py` [etc.](https://github.com/conda-forge/conda-smithy/blob/203988551ec4763994085355d232d01118504483/conda_smithy/linter/utils.py#L48)) would be found. When building the package on the feedstock, this might be true for the conda-build generated test root folder.

The solution is to also avoid `recipe_dir = ''` for considering `a_test_file_exists`.

PS. No idea what changed that this error did not appear earlier already. It's unrelated to recent linter changes AFAICT.