### PR TITLE
Use `pixi exec` for non-build tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,3 @@ oryx-build-commands.txt
 
 # rattler-build workspace
 output/
-

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ conda_smithy/_version.py
 
 venv
 oryx-build-commands.txt
+
+# rattler-build workspace
+output/
+

--- a/conda_smithy/templates/pixi.toml.tmpl
+++ b/conda_smithy/templates/pixi.toml.tmpl
@@ -53,12 +53,12 @@ cmd = "inspect_artifacts --recipe-dir {{ recipe_dir }} -m .ci_support/{{ variant
 description = "List contents of {{ feedstock_name }} packages built for variant {{ variant }}"
 {%- endfor %}
 
-{%- set _feature_platforms = platforms | select("in", shellcheck_platforms) -%}
-{%- if (shellcheck is defined) and shellcheck.enabled and _feature_platforms -%}
-{%- set with_shellcheck = " --with shellcheck" -%}
-{%- else -%}
-{%- set with_shellcheck = "" -%}
-{%- endif -%}
+{%- set _feature_platforms = platforms | select("in", shellcheck_platforms) %}
+{%- if (shellcheck is defined) and shellcheck.enabled and _feature_platforms %}
+{%- set with_shellcheck = " --with shellcheck" %}
+{%- else %}
+{%- set with_shellcheck = "" %}
+{%- endif %}
 
 [feature.smithy]
 [feature.smithy.tasks.build-locally]

--- a/conda_smithy/templates/pixi.toml.tmpl
+++ b/conda_smithy/templates/pixi.toml.tmpl
@@ -12,6 +12,27 @@ channels = ["conda-forge"]
 platforms = {{ platforms | tojson }}
 requires-pixi = ">={{ pixi_version }}"
 
+{%- set _feature_platforms = platforms | select("in", shellcheck_platforms) %}
+{%- if (shellcheck is defined) and shellcheck.enabled and _feature_platforms %}
+{%- set with_shellcheck = " --with shellcheck" %}
+{%- else %}
+{%- set with_shellcheck = "" %}
+{%- endif %}
+
+[tasks.build-locally]
+cmd = "pixi exec --force-reinstall --list='^python$' python ./build-locally.py"
+description = "Build packages locally using the same setup scripts used in conda-forge's CI"
+[tasks.smithy]
+cmd = "pixi exec --force-reinstall --list='^conda-smithy$' conda-smithy"
+description = "Run conda-smithy. Pass necessary arguments."
+[tasks.rerender]
+cmd = "pixi exec --force-reinstall --list='^conda-smithy$' conda-smithy rerender"
+description = "Rerender the feedstock."
+
+[tasks.lint]
+cmd = "pixi exec{{ with_shellcheck }} --list='^conda-smithy$' conda-smithy lint --conda-forge {{ recipe_dir }}"
+description = "Lint the feedstock recipe"
+
 [feature.build.dependencies]
 {%- for spec_name, spec_constraints in build_tool_deps_dict | dictsort %}
 {{ spec_name }} = "{{ spec_constraints }}"
@@ -53,32 +74,7 @@ cmd = "inspect_artifacts --recipe-dir {{ recipe_dir }} -m .ci_support/{{ variant
 description = "List contents of {{ feedstock_name }} packages built for variant {{ variant }}"
 {%- endfor %}
 
-{%- set _feature_platforms = platforms | select("in", shellcheck_platforms) %}
-{%- if (shellcheck is defined) and shellcheck.enabled and _feature_platforms %}
-{%- set with_shellcheck = " --with shellcheck" %}
-{%- else %}
-{%- set with_shellcheck = "" %}
-{%- endif %}
-
-[feature.smithy]
-{#- --force-reinstall tries to update everything but only relinks the changed packages #}
-[feature.smithy.tasks.build-locally]
-cmd = "pixi exec --force-reinstall --list=python python ./build-locally.py"
-description = "Build packages locally using the same setup scripts used in conda-forge's CI"
-[feature.smithy.tasks.smithy]
-cmd = "pixi exec --force-reinstall --list=conda-smithy conda-smithy"
-description = "Run conda-smithy. Pass necessary arguments."
-[feature.smithy.tasks.rerender]
-cmd = "pixi exec --force-reinstall --list=conda-smithy conda-smithy rerender"
-description = "Rerender the feedstock."
-
-[feature.smithy.tasks.lint]
-cmd = "pixi exec{{ with_shellcheck }} conda-smithy lint --conda-forge {{ recipe_dir }}"
-description = "Lint the feedstock recipe"
-
 [environments]
-build = {features = ["build"], no-default-feature = true}
-smithy = {features = ["smithy"], no-default-feature = true}
-
-# This is a copy of default, to be enabled by build_steps.sh during Docker builds
-# __PLATFORM_SPECIFIC_ENV__ = {features = ["build"], no-default-feature = true}
+build = ["build"]
+# This is a copy of 'build', to be enabled by build_steps.sh during Docker builds
+# __PLATFORM_SPECIFIC_ENV__ = ["build"]

--- a/conda_smithy/templates/pixi.toml.tmpl
+++ b/conda_smithy/templates/pixi.toml.tmpl
@@ -62,13 +62,13 @@ description = "List contents of {{ feedstock_name }} packages built for variant 
 
 [feature.smithy]
 [feature.smithy.tasks.build-locally]
-cmd = "pixi exec python ./build-locally.py"
+cmd = "pixi exec --list=python python ./build-locally.py"
 description = "Build packages locally using the same setup scripts used in conda-forge's CI"
 [feature.smithy.tasks.smithy]
-cmd = "pixi exec conda-smithy"
+cmd = "pixi exec --list=conda-smithy conda-smithy"
 description = "Run conda-smithy. Pass necessary arguments."
 [feature.smithy.tasks.rerender]
-cmd = "pixi exec conda-smithy rerender"
+cmd = "pixi exec --list=conda-smithy conda-smithy rerender"
 description = "Rerender the feedstock."
 
 [feature.smithy.tasks.lint]

--- a/conda_smithy/templates/pixi.toml.tmpl
+++ b/conda_smithy/templates/pixi.toml.tmpl
@@ -61,14 +61,15 @@ description = "List contents of {{ feedstock_name }} packages built for variant 
 {%- endif %}
 
 [feature.smithy]
+{#- --force-reinstall tries to update everything but only relinks the changed packages #}
 [feature.smithy.tasks.build-locally]
-cmd = "pixi exec --list=python python ./build-locally.py"
+cmd = "pixi exec --force-reinstall --list=python python ./build-locally.py"
 description = "Build packages locally using the same setup scripts used in conda-forge's CI"
 [feature.smithy.tasks.smithy]
-cmd = "pixi exec --list=conda-smithy conda-smithy"
+cmd = "pixi exec --force-reinstall --list=conda-smithy conda-smithy"
 description = "Run conda-smithy. Pass necessary arguments."
 [feature.smithy.tasks.rerender]
-cmd = "pixi exec --list=conda-smithy conda-smithy rerender"
+cmd = "pixi exec --force-reinstall --list=conda-smithy conda-smithy rerender"
 description = "Rerender the feedstock."
 
 [feature.smithy.tasks.lint]

--- a/conda_smithy/templates/pixi.toml.tmpl
+++ b/conda_smithy/templates/pixi.toml.tmpl
@@ -12,71 +12,69 @@ channels = ["conda-forge"]
 platforms = {{ platforms | tojson }}
 requires-pixi = ">={{ pixi_version }}"
 
-[dependencies]
+[feature.build.dependencies]
 {%- for spec_name, spec_constraints in build_tool_deps_dict | dictsort %}
 {{ spec_name }} = "{{ spec_constraints }}"
 {%- endfor %}
 
-[tasks.inspect-all]
+[feature.build.tasks.inspect-all]
 cmd = "inspect_artifacts --all-packages"
 description = "List contents of all packages found in {{ conda_build_tool }} build directory."
 {%- if conda_build_tool != "rattler-build" %}
-[tasks.build]
+[feature.build.tasks.build]
 cmd = "{{ conda_build_tool }} build {{ recipe_dir }}"
 description = "Build {{ feedstock_name }} directly (without setup scripts), no particular variant specified"
-[tasks.debug]
+[feature.build.tasks.debug]
 cmd = "{{ conda_build_tool }} debug {{ recipe_dir }}"
 description = "Debug {{ feedstock_name }} directly (without setup scripts), no particular variant specified"
 {%- else %}
-[tasks.build]
+[feature.build.tasks.build]
 cmd = "{{ conda_build_tool }} build --recipe {{ recipe_dir }}"
 description = "Build {{ feedstock_name }} directly (without setup scripts), no particular variant specified"
 {%- endif %}
 {%- for variant in variants | sort %}
 {%- if conda_build_tool != "rattler-build" %}
-[tasks."build-{{ variant }}"]
+[feature.build.tasks."build-{{ variant }}"]
 cmd = "{{ conda_build_tool }} build {{ recipe_dir }} -m .ci_support/{{ variant }}.yaml --suppress-variables --clobber-file .ci_support/clobber_{{ variant }}.yaml"
 description = "Build {{ feedstock_name }} with variant {{ variant }} directly (without setup scripts)"
-[tasks."debug-{{ variant }}"]
+[feature.build.tasks."debug-{{ variant }}"]
 cmd = "{{ conda_build_tool }} debug {{ recipe_dir }} -m .ci_support/{{ variant }}.yaml"
 description = "Debug {{ feedstock_name }} with variant {{ variant }} directly (without setup scripts)"
 {%- else %}
-[tasks."build-{{ variant }}"]
+[feature.build.tasks."build-{{ variant }}"]
 cmd = "{{ conda_build_tool }} build --recipe {{ recipe_dir }} -m .ci_support/{{ variant }}.yaml"
 description = "Build {{ feedstock_name }} with variant {{ variant }} directly (without setup scripts)"
 {%- endif %}
-[tasks."inspect-{{ variant }}"]
+[feature.build.tasks."inspect-{{ variant }}"]
 cmd = "inspect_artifacts --recipe-dir {{ recipe_dir }} -m .ci_support/{{ variant }}.yaml"
 description = "List contents of {{ feedstock_name }} packages built for variant {{ variant }}"
 {%- endfor %}
 
-[feature.smithy.dependencies]
-conda-smithy = "*"
-[feature.smithy.tasks.build-locally]
-cmd = "python ./build-locally.py"
-description = "Build packages locally using the same setup scripts used in conda-forge's CI"
-[feature.smithy.tasks.smithy]
-cmd = "conda-smithy"
-description = "Run conda-smithy. Pass necessary arguments."
-[feature.smithy.tasks.rerender]
-cmd = "conda-smithy rerender"
-description = "Rerender the feedstock."
-[feature.smithy.tasks.lint]
-cmd = "conda-smithy lint --conda-forge {{ recipe_dir }}"
-description = "Lint the feedstock recipe"
-
-{% set _smithy_features = ["smithy"] -%}
-
 {%- set _feature_platforms = platforms | select("in", shellcheck_platforms) -%}
 {%- if (shellcheck is defined) and shellcheck.enabled and _feature_platforms -%}
-{%- set _smithy_features = _smithy_features + ["shellcheck"] -%}
-[feature.shellcheck]
-dependencies.shellcheck = "*"
-platforms = {{ _feature_platforms | sort | tojson }}
+{%- set with_shellcheck = " --with shellcheck" -%}
+{%- else -%}
+{%- set with_shellcheck = "" -%}
+{%- endif -%}
 
-{% endif -%}
+[feature.smithy]
+[feature.smithy.tasks.build-locally]
+cmd = "pixi exec python ./build-locally.py"
+description = "Build packages locally using the same setup scripts used in conda-forge's CI"
+[feature.smithy.tasks.smithy]
+cmd = "pixi exec conda-smithy"
+description = "Run conda-smithy. Pass necessary arguments."
+[feature.smithy.tasks.rerender]
+cmd = "pixi exec conda-smithy rerender"
+description = "Rerender the feedstock."
+
+[feature.smithy.tasks.lint]
+cmd = "pixi exec{{ with_shellcheck }} conda-smithy lint --conda-forge {{ recipe_dir }}"
+description = "Lint the feedstock recipe"
+
 [environments]
-smithy = {{ _smithy_features | sort | tojson }}
+build = {features = ["build"], no-default-feature = true}
+smithy = {features = ["smithy"], no-default-feature = true}
 
 # This is a copy of default, to be enabled by build_steps.sh during Docker builds
-# __PLATFORM_SPECIFIC_ENV__ = []
+# __PLATFORM_SPECIFIC_ENV__ = {features = ["build"], no-default-feature = true}

--- a/conda_smithy/templates/pixi.toml.tmpl
+++ b/conda_smithy/templates/pixi.toml.tmpl
@@ -44,6 +44,9 @@ description = "Debug {{ feedstock_name }} with variant {{ variant }} directly (w
 [feature.build.tasks."build-{{ variant }}"]
 cmd = "{{ conda_build_tool }} build --recipe {{ recipe_dir }} -m .ci_support/{{ variant }}.yaml"
 description = "Build {{ feedstock_name }} with variant {{ variant }} directly (without setup scripts)"
+[feature.build.tasks."debug-{{ variant }}"]
+cmd = "{{ conda_build_tool }} debug setup --recipe {{ recipe_dir }} -m .ci_support/{{ variant }}.yaml"
+description = "Build {{ feedstock_name }} with variant {{ variant }} directly (without setup scripts)"
 {%- endif %}
 [feature.build.tasks."inspect-{{ variant }}"]
 cmd = "inspect_artifacts --recipe-dir {{ recipe_dir }} -m .ci_support/{{ variant }}.yaml"

--- a/news/rattler-build-tasks-exec.rst
+++ b/news/rattler-build-tasks-exec.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Debug tasks for rattler-build in Pixi-enabled feedstocks. (#2598)
+
+**Changed:**
+
+* Non-build ``pixi.toml`` tasks now rely on ``pixi exec`` instead of a workspace environment. (#2598)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -2307,14 +2307,8 @@ def test_render_pixi(
         assert (
             "win-64" in platforms
         ), "expected an aliased platform in pixi workspace platforms"
-        shellcheck_platforms = pixi["feature"]["shellcheck"]["platforms"]
-        smithy_env = pixi["environments"]["smithy"]
-        assert shellcheck_platforms, "`shellcheck` should be enabled on _some_ platform"
-        assert (
-            platform_without_shellcheck not in shellcheck_platforms
-        ), f"`shellcheck` should not be enabled for {platform_without_shellcheck}"
-
-        assert "shellcheck" in smithy_env, "`smithy` env should have `shellcheck`"
+        cmd = pixi["feature"]["smithy"]["tasks"]["lint"]["cmd"]
+        assert "--with shellcheck" in cmd, "`smithy` commands should have `shellcheck`"
 
 
 def test_configure_feedstock_rattler_build_conda_compat_round_trip():

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -2307,7 +2307,7 @@ def test_render_pixi(
         assert (
             "win-64" in platforms
         ), "expected an aliased platform in pixi workspace platforms"
-        cmd = pixi["feature"]["smithy"]["tasks"]["lint"]["cmd"]
+        cmd = pixi["tasks"]["lint"]["cmd"]
         assert "--with shellcheck" in cmd, "`smithy` commands should have `shellcheck`"
 
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Idea suggested by @chrisburr in [#general > how is conda-smithy kept up-to-date in Pixi lock file?](https://conda-forge.zulipchat.com/#narrow/channel/457337-general/topic/how.20is.20conda-smithy.20kept.20up-to-date.20in.20Pixi.20lock.20file.3F/with/603281721)