### PR TITLE
fix: Use the feedstock name instead of meta.name to register feedstocks where the package name is dependent on a variant

### DIFF
--- a/conda_smithy/cli.py
+++ b/conda_smithy/cli.py
@@ -145,8 +145,9 @@ class Init(Subcommand):
             RATTLER_BUILD if isinstance(meta, RattlerMetaData) else None
         )
 
+        feedstock_name = get_feedstock_name_from_meta(meta)
         feedstock_directory = args.feedstock_directory.format(
-            package=argparse.Namespace(name=meta.name())
+            package=argparse.Namespace(name=feedstock_name)
         )
         msg = f"Initial feedstock commit with conda-smithy {__version__}."
 

--- a/news/feedstock-name-init.rst
+++ b/news/feedstock-name-init.rst
@@ -1,4 +1,3 @@
 **Fixed:**
 
 * Use the feedstock name instead of ``meta.name`` to register feedstocks where the package name is dependent on a variant.
-

--- a/news/feedstock-name-init.rst
+++ b/news/feedstock-name-init.rst
@@ -1,3 +1,3 @@
 **Fixed:**
 
-* Use the feedstock name instead of ``meta.name`` to register feedstocks where the package name is dependent on a variant.
+* Use the feedstock name instead of ``meta.name`` to register feedstocks where the package name is dependent on a variant. (#2600)

--- a/news/feedstock-name-init.rst
+++ b/news/feedstock-name-init.rst
@@ -1,0 +1,4 @@
+**Fixed:**
+
+* Use the feedstock name instead of ``meta.name`` to register feedstocks where the package name is dependent on a variant.
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,6 +244,36 @@ def py_recipe(config_yaml: ConfigYAML):
 
 
 @pytest.fixture(scope="function")
+def go_compiler_recipe(config_yaml: ConfigYAML):
+    with open(
+        os.path.join(config_yaml.workdir, "recipe", config_yaml.recipe_name),
+        "w",
+    ) as fh:
+        recipe_path = os.path.abspath(
+            os.path.join(
+                __file__,
+                "../",
+                "recipes",
+                "go_compiler_recipe",
+                config_yaml.recipe_name,
+            )
+        )
+
+        content = Path(recipe_path).read_text()
+        fh.write(content)
+
+    return RecipeConfigPair(
+        str(config_yaml.workdir),
+        _load_forge_config(
+            config_yaml.workdir,
+            exclusive_config_file=os.path.join(
+                config_yaml.workdir, "recipe", "default_config.yaml"
+            ),
+        ),
+    )
+
+
+@pytest.fixture(scope="function")
 def py_abi3_recipe(config_yaml: ConfigYAML):
     with open(
         os.path.join(config_yaml.workdir, "recipe", config_yaml.recipe_name),

--- a/tests/recipes/go_compiler_recipe/meta.yaml
+++ b/tests/recipes/go_compiler_recipe/meta.yaml
@@ -1,0 +1,10 @@
+package:
+  name: go-compiler
+  version: 1.26.4
+build:
+  number: 0
+about:
+  home: https://conda-forge.org
+  summary: test
+extra:
+  feedstock-name: go-compiler

--- a/tests/recipes/go_compiler_recipe/recipe.yaml
+++ b/tests/recipes/go_compiler_recipe/recipe.yaml
@@ -1,0 +1,15 @@
+context:
+  version: "1.26.4"
+  go_variant_str: "cgo"
+package:
+  name: go-${{ go_variant_str }}-compiler
+  version: ${{ version }}
+build:
+  number: 0
+about:
+  license: BSD-3-Clause
+  license_file: LICENSE.txt
+  summary: test
+  homepage: https://conda-forge.org
+extra:
+  feedstock-name: go-compiler

--- a/tests/recipes/py_recipe/meta.yaml
+++ b/tests/recipes/py_recipe/meta.yaml
@@ -10,3 +10,5 @@ requirements:
         - python
 about:
     home: home
+
+extra: {}

--- a/tests/recipes/py_recipe/recipe.yaml
+++ b/tests/recipes/py_recipe/recipe.yaml
@@ -10,3 +10,4 @@ requirements:
         - python
     run:
         - python
+extra: {}

--- a/tests/recipes/skip_rerenders_ok/meta.yaml
+++ b/tests/recipes/skip_rerenders_ok/meta.yaml
@@ -9,3 +9,5 @@ build:
   skip: true  # [mpi == "nompi" and double == "yes"]
 
 about: {}
+
+extra: {}

--- a/tests/recipes/variant_mismatches/meta.yaml
+++ b/tests/recipes/variant_mismatches/meta.yaml
@@ -6,3 +6,5 @@ build:
   skip: true  # [not linux64 or a != b]
 
 about: {}
+
+extra: {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -351,8 +351,6 @@ def test_init_with_feedstock_name(go_compiler_recipe):
     Regression test: When the package name depends on a variant but the recipe
     has a feedstock-name in extra, the Init command should use the feedstock
     name (not meta.name()) to create the feedstock directory.
-
-    See https://github.com/conda-forge/staged-recipes/recipes/go-compiler/recipe.yaml
     """
     parser = argparse.ArgumentParser()
     subparser = parser.add_subparsers()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -357,9 +357,7 @@ def test_init_with_feedstock_name(go_compiler_recipe):
     init_obj = cli.Init(subparser)
 
     recipe = go_compiler_recipe.recipe
-    feedstock_dir_template = os.path.join(
-        recipe, "{package.name}-feedstock"
-    )
+    feedstock_dir_template = os.path.join(recipe, "{package.name}-feedstock")
     args = InitArgs(
         recipe_directory=os.path.join(recipe, "recipe"),
         feedstock_directory=feedstock_dir_template,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -346,6 +346,35 @@ def test_render_variant_mismatches(testing_workdir):
         assert data["a"] == data["b"]
 
 
+def test_init_with_feedstock_name(go_compiler_recipe):
+    """
+    Regression test: When the package name depends on a variant but the recipe
+    has a feedstock-name in extra, the Init command should use the feedstock
+    name (not meta.name()) to create the feedstock directory.
+
+    See https://github.com/conda-forge/staged-recipes/recipes/go-compiler/recipe.yaml
+    """
+    parser = argparse.ArgumentParser()
+    subparser = parser.add_subparsers()
+    init_obj = cli.Init(subparser)
+
+    recipe = go_compiler_recipe.recipe
+    feedstock_dir_template = os.path.join(
+        recipe, "{package.name}-feedstock"
+    )
+    args = InitArgs(
+        recipe_directory=os.path.join(recipe, "recipe"),
+        feedstock_directory=feedstock_dir_template,
+        temporary_directory=os.path.join(recipe, "temp"),
+    )
+    init_obj(args)
+
+    # The feedstock directory should use the feedstock-name from extra,
+    # not the package name (which depends on go_variant_str)
+    destination = os.path.join(recipe, "go-compiler-feedstock")
+    assert os.path.isdir(destination)
+
+
 def test_render_skipped_variants(testing_workdir):
     """
     Regression test for https://github.com/conda-forge/conda-smithy/issues/1617


### PR DESCRIPTION
Feedstock creation for `go-compiler` currently fails with a conda-smithy issue as the name contains a variant variable. 

```
Making feedstock for go-compiler
Traceback (most recent call last):
  File "/home/runner/Miniforge3/bin/conda-smithy", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/runner/Miniforge3/lib/python3.13/site-packages/conda_smithy/cli.py", line 774, in main
    args.subcommand_func(args)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/runner/Miniforge3/lib/python3.13/site-packages/conda_smithy/cli.py", line 149, in __call__
    package=argparse.Namespace(name=meta.name())
                                    ~~~~~~~~~^^
  File "/home/runner/Miniforge3/lib/python3.13/site-packages/rattler_build_conda_compat/render.py", line 139, in name
    check_bad_chrs(name, "package/name")
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/Miniforge3/lib/python3.13/site-packages/conda_build/metadata.py", line 834, in check_bad_chrs
    raise CondaBuildUserError(
        f"Bad character(s) ({''.join(sorted(invalid))}) in {field}: {value}."
    )
conda_build.exceptions.CondaBuildUserError: Bad character(s) ( $) in package/name: go-${{ go_variant_str }}-compiler.
```

The recipe contains a `feedstock-name` which should be used instead.

See also: https://github.com/conda-forge/admin-requests/actions/runs/27467405766/job/81192070603

AI-Disclaimer: The fix is manually written, but DeepSeek-V4 helped with writing a unit test.