### PR TITLE
Move Windows to GHA by default (and other small platform fixes)

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -89,7 +89,7 @@ SERVICE_FEEDSTOCKS = [
     # this one is used for testing
     "cf-autotick-bot-test-package-feedstock",
     # Add more via undocumented env var
-    *os.environ.get("CONDA_SMITHY_SERVICE_FEEDSTOCKS", "").split(",")
+    *os.environ.get("CONDA_SMITHY_SERVICE_FEEDSTOCKS", "").split(","),
 ]
 
 # Cache lifetime in seconds, default 15min

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -74,7 +74,7 @@ logger = logging.getLogger(__name__)
 
 # feedstocks listed here are allowed to use GHA on
 # conda-forge
-# this should solve issues where other CI proviers have too many
+# this should solve issues where other CI providers have too many
 # jobs and we need to change something via CI
 SERVICE_FEEDSTOCKS = [
     "conda-forge-pinning-feedstock",
@@ -88,9 +88,9 @@ SERVICE_FEEDSTOCKS = [
     "conda-forge-feedstock-ops-feedstock",
     # this one is used for testing
     "cf-autotick-bot-test-package-feedstock",
+    # Add more via undocumented env var
+    *os.environ.get("CONDA_SMITHY_SERVICE_FEEDSTOCKS", "").split(",")
 ]
-if "CONDA_SMITHY_SERVICE_FEEDSTOCKS" in os.environ:
-    SERVICE_FEEDSTOCKS += os.environ["CONDA_SMITHY_SERVICE_FEEDSTOCKS"].split(",")
 
 # Cache lifetime in seconds, default 15min
 CONDA_FORGE_PINNING_LIFETIME = int(
@@ -129,7 +129,7 @@ ALL_PLATFORMS = (
     "win_64",
     "win_arm64",
 )
-# These are enabled by default
+# These are enabled by default on all feedstocks
 DEFAULT_PLATFORMS = (
     "linux_64",
     "osx_64",
@@ -139,7 +139,7 @@ DEFAULT_PLATFORMS = (
 DEFAULT_PROVIDER = "github_actions"
 DEFAULT_PROVIDERS = {
     "linux_64": "github_actions",
-    "linux_aarch64": "github_actions",  # emulated
+    "linux_aarch64": "github_actions",
     "linux_ppc64le": "github_actions",  # emulated
     "linux_s390x": "github_actions",  # emulated
     "osx_64": "azure",

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -144,8 +144,8 @@ DEFAULT_PROVIDERS = {
     "linux_s390x": "github_actions",  # emulated
     "osx_64": "azure",
     "osx_arm64": "azure",
-    "win_64": "azure",
-    "win_arm64": "azure",  # emulated
+    "win_64": "github_actions",
+    "win_arm64": "github_actions",
 }
 
 NATIVE_CI_PROVIDER = {

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -108,7 +108,7 @@ CONDA_FORGE_SHELLCHECK_PLATFORMS = [
 ]
 
 CONDA_FORGE_ALIAS_PLATFORMS = {
-    "win": {"win-64"},
+    "win": {"win-64", "win-arm64"},
     "linux": {"linux-64", "linux-aarch64", "linux-ppc64le"},
     "osx": {"osx-64", "osx-arm64"},
 }

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -150,7 +150,7 @@ DEFAULT_PROVIDERS = {
 
 NATIVE_CI_PROVIDER = {
     "linux_64": "github_actions",
-    "linux_aarch64": "travis",
+    "linux_aarch64": "github_actions",
     "linux_ppc64le": "travis",
     "linux_s390x": "travis",
     "osx_64": "azure",

--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -2023,7 +2023,7 @@
               "type": "null"
             }
           ],
-          "default": "azure",
+          "default": "github_actions",
           "title": "Win 64"
         },
         "win_arm64": {
@@ -2201,7 +2201,7 @@
           "type": "null"
         }
       ],
-      "description": "This is a mapping from the target platform to the build platform for the\npackage to be built. For example, the following builds a `osx-64` package\non the `linux-64` build platform using cross-compiling.\n\n```yaml\nbuild_platform:\n    osx_64: linux_64\n```\n\nLeaving this field empty implicitly requests to build a package natively. i.e.\n\n```yaml\nbuild_platform:\n    linux_64: linux_64\n    linux_ppc64le: linux_ppc64le\n    linux_aarch64: linux_aarch64\n    osx_64: osx_64\n    osx_arm64: osx_arm64\n    win_64: win_64\n```"
+      "description": "This is a mapping from the target platform to the build platform for the\npackage to be built. For example, the following builds a `osx-64` package\non the `linux-64` build platform using cross-compiling.\n\n```yaml\nbuild_platform:\n    osx_64: linux_64\n```\n\nLeaving this field empty implicitly requests to build a package natively. i.e.\n\n```yaml\nbuild_platform:\n    linux_64: linux_64\n    linux_ppc64le: linux_ppc64le\n    linux_aarch64: linux_aarch64\n    osx_64: osx_64\n    osx_arm64: osx_arm64\n    win_64: win_64\n    win_arm64: win_arm64\n```"
     },
     "channel_priority": {
       "anyOf": [
@@ -2295,7 +2295,7 @@
           "type": "null"
         }
       ],
-      "description": "The `provider` field is a mapping from build platform (not target platform)\nto CI service. It determines which service handles each build platform.\nIf a desired build platform is not available with a selected provider\n(either natively or with emulation), the build will be disabled.\nUse the `build_platform` field to manually specify cross-compilation when\nno providers offer a desired build platform.\n\nThe following are available as supported build platforms:\n\n* `linux_64`\n* `osx_64`\n* `win_64`\n* `linux_aarch64`\n* `linux_ppc64le`\n* `linux_s390x`\n* `linux_armv7l`\n\nThe following CI services are available:\n\n* `azure`\n* `circle`\n* `travis`\n* `appveyor`\n* `None` or `False` to disable a build platform.\n* `default` to choose an appropriate CI (only if available)\n* `native` to choose an appropriate CI for native compiling (only if available)\n* `emulated` to choose an appropriate CI for compiling inside an emulation\n  of the target platform (only if available)\n\nFor example, making explicit that linux_64 & osx_64 build on azure (by default),\nand switching win_64 to Appveyor:\n\n```yaml\nprovider:\n    linux_64: azure\n    osx_64: azure\n    win_64: appveyor\n```\n\nCurrently, x86_64 platforms are enabled, but other build platforms are\ndisabled by default. i.e. an empty provider entry is equivalent to the\nfollowing:\n\n```yaml\nprovider:\n    linux_64: azure\n    osx_64: azure\n    win_64: azure\n    linux_ppc64le: None\n    linux_aarch64: None\n```\n\nTo enable `linux_ppc64le` and `linux_aarch64` add the following:\n\n```yaml\nprovider:\n    linux_ppc64le: default\n    linux_aarch64: default\n```"
+      "description": "The `provider` field is a mapping from build platform (not target platform)\nto CI service. It determines which service handles each build platform.\nIf a desired build platform is not available with a selected provider\n(either natively or with emulation), the build will be disabled.\nUse the `build_platform` field to manually specify cross-compilation when\nno providers offer a desired build platform.\n\nThe following are available as supported build platforms:\n\n* `linux_64`\n* `osx_64`\n* `osx_arm64`\n* `win_64`\n* `win_arm64`\n* `linux_aarch64`\n* `linux_ppc64le`\n* `linux_s390x`\n* `linux_armv7l`\n\nThe following CI services are available:\n\n* `azure`\n* `github_actions`\n* `circle`\n* `travis`\n* `appveyor`\n* `None` or `False` to disable a build platform.\n* `default` to choose an appropriate CI (only if available)\n* `native` to choose an appropriate CI for native compiling (only if available)\n* `emulated` to choose an appropriate CI for compiling inside an emulation\n  of the target platform (only if available)\n\nFor example, making explicit that linux_64 & osx_64 build on azure (by default),\nand switching win_64 to Appveyor:\n\n```yaml\nprovider:\n    linux_64: azure\n    osx_64: azure\n    win_64: appveyor\n```\n\nCurrently, x86_64 platforms are enabled, but other build platforms are\ndisabled by default. i.e. an empty provider entry is equivalent to the\nfollowing:\n\n```yaml\nprovider:\n    linux_64: azure\n    osx_64: azure\n    win_64: azure\n    linux_ppc64le: None\n    linux_aarch64: None\n```\n\nTo enable `linux_ppc64le` and `linux_aarch64` add the following:\n\n```yaml\nprovider:\n    linux_ppc64le: default\n    linux_aarch64: default\n```"
     },
     "package": {
       "anyOf": [

--- a/conda_smithy/data/conda-forge.yml
+++ b/conda_smithy/data/conda-forge.yml
@@ -128,7 +128,7 @@ provider:
   wasi_wasm32: null
   win: null
   win_32: null
-  win_64: azure
+  win_64: github_actions
   win_arm64: null
   zos_z: null
 recipe_dir: recipe

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -734,6 +734,7 @@ class ConfigModel(BaseModel):
             osx_64: osx_64
             osx_arm64: osx_arm64
             win_64: win_64
+            win_arm64: win_arm64
         ```
         """),
     )
@@ -854,7 +855,9 @@ class ConfigModel(BaseModel):
 
         * `linux_64`
         * `osx_64`
+        * `osx_arm64`
         * `win_64`
+        * `win_arm64`
         * `linux_aarch64`
         * `linux_ppc64le`
         * `linux_s390x`
@@ -863,6 +866,7 @@ class ConfigModel(BaseModel):
         The following CI services are available:
 
         * `azure`
+        * `github_actions`
         * `circle`
         * `travis`
         * `appveyor`

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -10,7 +10,7 @@ from inspect import cleandoc
 from typing import Annotated, Any, Literal, Optional, Union
 
 import yaml
-from conda.base.constants import KNOWN_SUBDIRS
+from conda.base.constants import PLATFORMS
 from pydantic import BaseModel, ConfigDict, Field, WithJsonSchema, create_model
 
 # use relative imports to ensure that we don't pick up the data paths from
@@ -420,7 +420,7 @@ class PlatformsAliases(StrEnum):
 
 
 def get_subdirs():
-    return [subdir.replace("-", "_") for subdir in KNOWN_SUBDIRS if "-" in subdir]
+    return [platform.replace("-", "_") for platform in PLATFORMS]
 
 
 Platforms = StrEnum("Platforms", get_subdirs())

--- a/news/2601-gha-windows.rst
+++ b/news/2601-gha-windows.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Github Actions is now the default platform for Windows builds. (#2601)
+* Github Actions is now the default platform for native Linux ARM builds. (#2601)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [X] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

With https://github.com/conda-forge/conda-smithy/issues/2349 closed, we have feature parity between Azure and GHA, so we can switch to GHA on Windows too (including `arm64`!).