### PR TITLE
Correct an erroneous default value causing `AttributeError` from `conda-smithy recipe-lint --conda-forge`

### DIFF
--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -708,7 +708,7 @@ def run_conda_forge_specific(
             else:
                 run_reqs += _req
 
-    specific_hints = (load_linter_toml_metdata() or {}).get("hints", [])
+    specific_hints = (load_linter_toml_metdata() or {}).get("hints", {})
     all_reqs = build_reqs + host_reqs + run_reqs
     if recipe_version == 1:
         all_reqs = flatten_v1_if_else(all_reqs)

--- a/news/2611-linter-hints-default.rst
+++ b/news/2611-linter-hints-default.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed ``run_conda_forge_specific`` failing when linter metadata omits the
+  ``hints`` table. (#2611)
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -5009,6 +5009,20 @@ def test_run_conda_forge_specific_routes_missing_to_lints(monkeypatch):
     assert not any("Could not verify" in hint for hint in hints)
 
 
+def test_run_conda_forge_specific_missing_linter_hints_table(monkeypatch):
+    monkeypatch.setattr(linter, "load_linter_toml_metdata", lambda: {})
+    meta = {
+        "package": {"name": "foo"},
+        "requirements": {"run": ["python"]},
+    }
+    lints, hints = [], []
+
+    linter.run_conda_forge_specific(meta, None, lints, hints)
+
+    assert lints == []
+    assert hints == []
+
+
 def test_invalid_workflow_settings(tmp_path):
     cfyml = tmp_path / "conda-forge.yml"
     recipe_dir = tmp_path / "recipe"


### PR DESCRIPTION
When investigating why https://github.com/conda-forge/conda-forge-webservices/actions/runs/28789787848/job/85365251296 had failed, I saw this in the workflow run log:
``` 
2026-07-06 11:58:34,690 ERROR    conda_forge_feedstock_ops.lint || Error linting recipe /tmp/tmpwnofsgqw/cf_feedstock_ops_dir/recipe/meta.yaml
Traceback (most recent call last):
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.12/site-packages/conda_forge_feedstock_ops/lint.py", line 110, in _lint_local
    _lints, _hints = conda_smithy.lint_recipe.main(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.12/site-packages/conda_smithy/lint_recipe.py", line 946, in main
    results, hints = lintify_meta_yaml(
                     ^^^^^^^^^^^^^^^^^^
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.12/site-packages/conda_smithy/lint_recipe.py", line 292, in lintify_meta_yaml
    run_conda_forge_specific(
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.12/site-packages/conda_smithy/lint_recipe.py", line 717, in run_conda_forge_specific
    dep_hint = specific_hints.get(dep)
               ^^^^^^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'get'
```

This looks like a straightforward bug whereby a `get` defaults to `[]` when it should default to `{}`: https://github.com/conda-forge/conda-smithy/blob/40c2b59a878f6461689cb3d5f9c4c438ec6ce57c/conda_smithy/lint_recipe.py#L711-L718

Accordingly:
- Make `specific_hints` default to a dictionary, since `specific_hints.get` is called later.
- Add a regression test.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [x] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [x] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
