### PR TITLE
Fix v1 stdlib lint not firing for double-quoted `compiler()` calls

### DIFF
--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -835,7 +835,7 @@ def lint_stdlib(
         )
     else:
         pat_compiler_stub = re.compile(
-            r"^\${{ compiler\('(m2w64_)?(c|cxx|fortran|rust|go-cgo)"
+            r"^\${{ compiler\(['\"](m2w64_)?(c|cxx|fortran|rust|go-cgo)"
         )
 
     outputs = get_section(meta, "outputs", lints, recipe_version)

--- a/news/stdlib-lint-double-quotes-2572.rst
+++ b/news/stdlib-lint-double-quotes-2572.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed the v1 recipe ``stdlib`` lint not firing when ``${{ compiler(...) }}`` used double quotes instead of single quotes. (#2572)
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -123,7 +123,8 @@ def test_m2w64_stdlib_legal():
         "go-nocgo",
     ],
 )
-def test_v1_stdlib_hint(comp_lang):
+@pytest.mark.parametrize("quote", ["'", '"'])
+def test_v1_stdlib_hint(comp_lang, quote):
     expected_message = "This recipe is using a compiler"
 
     with tmp_directory() as recipe_dir:
@@ -133,7 +134,7 @@ def test_v1_stdlib_hint(comp_lang):
                 requirements:
                   build:
                     # since we're in an f-string: double up braces (2->4)
-                    - ${{{{ compiler('{comp_lang}') }}}}
+                    - ${{{{ compiler({quote}{comp_lang}{quote}) }}}}
                 """)
         Path(recipe_dir).joinpath("conda-forge.yml").write_text(
             "conda_build_tool: rattler-build"


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [x] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [x] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Fixes #2572 

## Problem

The `lint_stdlib` check is supposed to flag a v1 recipe that uses a compiler (e.g. `${{ compiler("c") }}`) without also declaring the matching C stdlib (`${{ stdlib("c") }}`). It detects compiler usage via the `pat_compiler_stub` regex, which for v1 recipes was:

```python
r"^\${{ compiler\('(m2w64_)?(c|cxx|fortran|rust|go-cgo)"
```

This only matches a **single-quoted** argument (`compiler('c')`). Recipes that use **double quotes** (`compiler("c")`) - a perfectly valid and common style, e.g. [openimageio-feedstock#138](https://github.com/conda-forge/openimageio-feedstock/pull/138) - were never detected as using a compiler at all, so the stdlib check was silently skipped. This let a recipe merge without `${{ stdlib("c") }}`, which in turn caused [openimageio-feedstock#150](https://github.com/conda-forge/openimageio-feedstock/issues/150).

The sibling `stdlib_regex` a few lines below already handled both quote styles (`['\"]`) - the compiler-detection regex was just never updated to match.

## Fix

Update `pat_compiler_stub` to accept either quote character:

```python
r"^\${{ compiler\(['\"](m2w64_)?(c|cxx|fortran|rust|go-cgo)"
```

## Testing

Parametrized `test_v1_stdlib_hint` over both `'` and `"` quote styles. Confirmed the new double-quote cases fail against the old regex and pass with the fix; the full stdlib/compiler test suite (29 tests) passes.

In addition to this the recipe from [openimageio-feedstock#138](https://github.com/conda-forge/openimageio-feedstock/pull/138) now fails with this PR (which is the expectation),

```sh
(py313) 1:58:21:~/conda-smithy % conda smithy recipe-lint ../recipe-dir
../recipe-dir has some lint:
  This recipe is using a compiler, which now requires adding a build dependence on `${{ stdlib("c") }}` as well. Note that this rule applies to each output of the recipe using a compiler. For further details, please see https://github.com/conda-forge/conda-forge.github.io/issues/2102.
```
