### PR TITLE
Add hint: python version-independent (abi3) recipes should test latest Python

### DIFF
--- a/conda_smithy/data/linter-messages.json
+++ b/conda_smithy/data/linter-messages.json
@@ -909,6 +909,18 @@
       "path": "recipe/recipe.yaml"
     },
     {
+      "name": "PythonVersionIndependentTestLatest",
+      "identifier": "R1-005",
+      "category": "R1",
+      "kind": "hint",
+      "added_in": "2026.7",
+      "deprecated_in": "",
+      "documentation": "Python version-independent packages (e.g. abi3) are built once against\n`python_min` but install on every Python version at or above it, so tests\nshould cover both ends of that range.",
+      "message": "This package is Python version-independent (e.g. abi3): it is built once but installs on every Python version at or above `python_min`, yet the Python test only runs against a single version. Consider testing against both the minimum and the latest supported Python:\n```yaml\ntests:\n  - python:\n      python_version:\n        - ${{ python_min }}.*\n        - \"*\"\n```",
+      "examples": [],
+      "path": "recipe/recipe.yaml"
+    },
+    {
       "name": "MacOSDeploymentTargetRename",
       "identifier": "RC-000",
       "category": "RC",

--- a/conda_smithy/data/linter-messages.json
+++ b/conda_smithy/data/linter-messages.json
@@ -897,6 +897,18 @@
       "path": "recipe/recipe.yaml"
     },
     {
+      "name": "NoarchPythonTestLatest",
+      "identifier": "R1-004",
+      "category": "R1",
+      "kind": "hint",
+      "added_in": "2026.6",
+      "deprecated_in": "",
+      "documentation": "`noarch: python` packages install on every Python version at or above\n`python_min`, so tests should cover both ends of that range.",
+      "message": "`noarch: python` packages install on every Python version at or above `python_min`, but the Python test only runs against a single version. Consider testing against both the minimum and the latest supported Python:\n```yaml\ntests:\n  - python:\n      python_version:\n        - ${{ python_min }}.*\n        - \"*\"\n```",
+      "examples": [],
+      "path": "recipe/recipe.yaml"
+    },
+    {
       "name": "MacOSDeploymentTargetRename",
       "identifier": "RC-000",
       "category": "RC",

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -36,6 +36,7 @@ from conda_smithy.linter.hints import (
     hint_os_version,
     hint_pip_no_build_backend,
     hint_pip_usage,
+    hint_python_version_independent_test_latest,
     hint_rattler_build_bld_bat,
     hint_shellcheck_usage,
     hint_sources_should_not_mention_pypi_io_but_pypi_org,
@@ -790,6 +791,20 @@ def run_conda_forge_specific(
             requirements_section.get("run") or [],
             outputs_section,
             noarch_value,
+            recipe_version,
+            hints,
+        )
+
+    # 10c: python version-independent (abi3) recipes should test latest too
+    if (
+        "hint_python_version_independent_test_latest" not in lints_to_skip
+        and recipe_version == 1
+    ):
+        hint_python_version_independent_test_latest(
+            get_section(meta, "tests", lints, recipe_version),
+            requirements_section.get("run") or [],
+            outputs_section,
+            build_section,
             recipe_version,
             hints,
         )

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -31,6 +31,7 @@ from conda_smithy.linter.hints import (
     hint_check_spdx,
     hint_dependency_pins,
     hint_deprecated_environment_variables,
+    hint_noarch_python_test_latest,
     hint_noarch_python_use_python_min,
     hint_os_version,
     hint_pip_no_build_backend,
@@ -776,6 +777,17 @@ def run_conda_forge_specific(
             requirements_section.get("host") or [],
             requirements_section.get("run") or [],
             test_reqs,
+            outputs_section,
+            noarch_value,
+            recipe_version,
+            hints,
+        )
+
+    # 10b: noarch python recipes should test the minimum AND latest python
+    if "hint_noarch_python_test_latest" not in lints_to_skip and recipe_version == 1:
+        hint_noarch_python_test_latest(
+            get_section(meta, "tests", lints, recipe_version),
+            requirements_section.get("run") or [],
             outputs_section,
             noarch_value,
             recipe_version,

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -361,6 +361,67 @@ def hint_noarch_python_use_python_min(
         hints.append(msg.r.PythonMinPin(recommendations=recommendations).as_string())
 
 
+def _noarch_python_tests_cover_latest(tests_section, run_reqs):
+    """True if every python test covers the latest Python via a "*" entry,
+    or if the run requirements cap python's upper bound (making a latest-python
+    test entry redundant)."""
+    for req in flatten_v1_if_else(run_reqs or []):
+        if isinstance(req, str) and req.strip().split()[0] == "python" and "<" in req:
+            return True
+
+    for test in tests_section or []:
+        if not isinstance(test, Mapping) or "python" not in test:
+            continue
+        python_version = (test.get("python") or {}).get("python_version")
+        if isinstance(python_version, str):
+            python_version = [python_version]
+        if not isinstance(python_version, list):
+            python_version = []
+        # The latest-Python marker is the exact entry `"*"`. We match it by
+        # equality, so the `.*` in a min-pin like `${{ python_min }}.*` (or its
+        # rendered `3.10.*`) is never mistaken for it. (The v1 parser also
+        # forbids a bare `- *`, so `"*"` is always a quoted string here.)
+        if "*" not in flatten_v1_if_else(python_version):
+            return False
+    return True
+
+
+def hint_noarch_python_test_latest(
+    tests_section,
+    run_reqs,
+    outputs_section,
+    noarch_value,
+    recipe_version,
+    hints,
+):
+    if recipe_version != 1:
+        return
+
+    scopes = []
+    if outputs_section:
+        for output in outputs_section:
+            requirements = output.get("requirements", {})
+            output_run_reqs = (
+                requirements.get("run")
+                if isinstance(requirements, Mapping)
+                else requirements
+            )
+            scopes.append(
+                (
+                    output.get("tests"),
+                    output_run_reqs,
+                    output.get("build", {}).get("noarch"),
+                )
+            )
+    else:
+        scopes.append((tests_section, run_reqs, noarch_value))
+
+    for tests, run, noarch in scopes:
+        if noarch == "python" and not _noarch_python_tests_cover_latest(tests, run):
+            hints.append(msg.r.NoarchPythonTestLatest().as_string())
+            return
+
+
 def hint_space_separated_specs(
     requirements_section,
     test_section,

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -16,6 +16,7 @@ from conda_smithy.linter.utils import (
     find_local_config_file,
     flatten_v1_if_else,
     get_all_test_requirements,
+    get_version_independent,
     is_selector_line,
 )
 from conda_smithy.utils import get_yaml
@@ -361,7 +362,7 @@ def hint_noarch_python_use_python_min(
         hints.append(msg.r.PythonMinPin(recommendations=recommendations).as_string())
 
 
-def _noarch_python_tests_cover_latest(tests_section, run_reqs):
+def _python_tests_cover_latest(tests_section, run_reqs):
     """True if every python test covers the latest Python via a "*" entry,
     or if the run requirements cap python's upper bound (making a latest-python
     test entry redundant)."""
@@ -417,8 +418,46 @@ def hint_noarch_python_test_latest(
         scopes.append((tests_section, run_reqs, noarch_value))
 
     for tests, run, noarch in scopes:
-        if noarch == "python" and not _noarch_python_tests_cover_latest(tests, run):
+        if noarch == "python" and not _python_tests_cover_latest(tests, run):
             hints.append(msg.r.NoarchPythonTestLatest().as_string())
+            return
+
+
+def hint_python_version_independent_test_latest(
+    tests_section,
+    run_reqs,
+    outputs_section,
+    build_section,
+    recipe_version,
+    hints,
+):
+    if recipe_version != 1:
+        return
+
+    scopes = []
+    if outputs_section:
+        for output in outputs_section:
+            requirements = output.get("requirements", {})
+            output_run_reqs = (
+                requirements.get("run")
+                if isinstance(requirements, Mapping)
+                else requirements
+            )
+            scopes.append(
+                (
+                    output.get("tests"),
+                    output_run_reqs,
+                    output.get("build", {}),
+                )
+            )
+    else:
+        scopes.append((tests_section, run_reqs, build_section))
+
+    for tests, run, build in scopes:
+        if get_version_independent(
+            build or {}, "python", recipe_version
+        ) and not _python_tests_cover_latest(tests, run):
+            hints.append(msg.r.PythonVersionIndependentTestLatest().as_string())
             return
 
 

--- a/conda_smithy/linter/messages/recipe.py
+++ b/conda_smithy/linter/messages/recipe.py
@@ -1244,4 +1244,30 @@ class NoarchPythonTestLatest(LinterMessage, _RecipeYamlMessage):
     )
 
 
+@dataclass(kw_only=True)
+class PythonVersionIndependentTestLatest(LinterMessage, _RecipeYamlMessage):
+    """
+    Python version-independent packages (e.g. abi3) are built once against
+    `python_min` but install on every Python version at or above it, so tests
+    should cover both ends of that range.
+    """
+
+    kind = "hint"
+    identifier = "R1-005"
+    added_in = "2026.7"
+    message = (
+        "This package is Python version-independent (e.g. abi3): it is built "
+        "once but installs on every Python version at or above `python_min`, "
+        "yet the Python test only runs against a single version. Consider "
+        "testing against both the minimum and the latest supported Python:\n"
+        "```yaml\n"
+        "tests:\n"
+        "  - python:\n"
+        "      python_version:\n"
+        "        - ${{ python_min }}.*\n"
+        '        - "*"\n'
+        "```"
+    )
+
+
 # endregion

--- a/conda_smithy/linter/messages/recipe.py
+++ b/conda_smithy/linter/messages/recipe.py
@@ -1218,4 +1218,29 @@ class RattlerBldBat(LinterMessage, _RecipeYamlMessage):
     )
 
 
+@dataclass(kw_only=True)
+class NoarchPythonTestLatest(LinterMessage, _RecipeYamlMessage):
+    """
+    `noarch: python` packages install on every Python version at or above
+    `python_min`, so tests should cover both ends of that range.
+    """
+
+    kind = "hint"
+    identifier = "R1-004"
+    added_in = "2026.6"
+    message = (
+        "`noarch: python` packages install on every Python version at or "
+        "above `python_min`, but the Python test only runs against a single "
+        "version. Consider testing against both the minimum and the latest "
+        "supported Python:\n"
+        "```yaml\n"
+        "tests:\n"
+        "  - python:\n"
+        "      python_version:\n"
+        "        - ${{ python_min }}.*\n"
+        '        - "*"\n'
+        "```"
+    )
+
+
 # endregion

--- a/conda_smithy/linter/messages/recipe.py
+++ b/conda_smithy/linter/messages/recipe.py
@@ -1228,6 +1228,7 @@ class NoarchPythonTestLatest(LinterMessage, _RecipeYamlMessage):
     kind = "hint"
     identifier = "R1-004"
     added_in = "2026.6"
+    added_in: "2026.6"
     message = (
         "`noarch: python` packages install on every Python version at or "
         "above `python_min`, but the Python test only runs against a single "

--- a/news/abi3-test-latest.rst
+++ b/news/abi3-test-latest.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* New hint ``R1-005``: Python version-independent v1 recipes (e.g. ``abi3``, via ``build.python.version_independent``) whose Python test only runs against a single Python version are now hinted to test against both ``${{ python_min }}.*`` and ``"*"`` (the latest supported Python), unless the ``run`` requirements cap the Python upper bound.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/noarch-python-test-latest.rst
+++ b/news/noarch-python-test-latest.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* New hint ``R1-004``: ``noarch: python`` v1 recipes whose Python test only runs against a single Python version are now hinted to test against both ``${{ python_min }}.*`` and ``"*"`` (the latest supported Python), unless the ``run`` requirements cap the Python upper bound.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4228,6 +4228,159 @@ def test_lint_recipe_v1_python_min_in_python_version(text):
         )
 
 
+@pytest.mark.parametrize(
+    "text,expected_hint",
+    [
+        # scalar python_version only tests python_min -> hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+
+                build:
+                  noarch: python
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python >=${{ python_min }}
+
+                tests:
+                  - python:
+                      imports:
+                        - mypackage
+                      python_version: ${{ python_min }}.*
+                """),
+            True,
+        ),
+        # python_min AND latest -> no hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+
+                build:
+                  noarch: python
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python >=${{ python_min }}
+
+                tests:
+                  - python:
+                      imports:
+                        - mypackage
+                      python_version:
+                        - ${{ python_min }}.*
+                        - "*"
+                """),
+            False,
+        ),
+        # upper-bounded python in run caps the test env -> no hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+
+                build:
+                  noarch: python
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python >=${{ python_min }},<3.12
+
+                tests:
+                  - python:
+                      imports:
+                        - mypackage
+                      python_version: ${{ python_min }}.*
+                """),
+            False,
+        ),
+        # abi3-style conditional list including "*" -> no hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+
+                build:
+                  noarch: python
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python >=${{ python_min }}
+
+                tests:
+                  - python:
+                      imports:
+                        - mypackage
+                      python_version:
+                        - if: is_abi3
+                          then: ${{ python_min }}.*
+                        - "*"
+                """),
+            False,
+        ),
+        # not noarch -> no hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+
+                requirements:
+                  run:
+                    - python
+
+                tests:
+                  - python:
+                      imports:
+                        - mypackage
+                      python_version: ${{ python_min }}.*
+                """),
+            False,
+        ),
+        # no python test at all -> no hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+
+                build:
+                  noarch: python
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python >=${{ python_min }}
+
+                tests:
+                  - script:
+                      - mypackage --help
+                """),
+            False,
+        ),
+    ],
+    ids=(f"recipe-{i}" for i in count(1)),
+)
+def test_lint_recipe_v1_noarch_python_test_latest(text, expected_hint):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:
+            f.write(text)
+        _, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
+        has_hint = any(
+            "testing against both the minimum and the latest" in h for h in hints
+        )
+        assert has_hint == expected_hint, hints
+
+
 def test_lint_recipe_v1_comment_selectors():
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:
@@ -4754,14 +4907,14 @@ tests:
 outputs:
   - package:
       name: foo
-{textwrap.indent(midpart, '    ')}\
+{textwrap.indent(midpart, "    ")}\
 """
 
     recipe = f"""\
 context:
   version: "1.0"
 
-{'recipe' if outputs else 'package'}:
+{"recipe" if outputs else "package"}:
   name: foo
   version: ${{{{ version }}}}
 

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4381,6 +4381,162 @@ def test_lint_recipe_v1_noarch_python_test_latest(text, expected_hint):
         assert has_hint == expected_hint, hints
 
 
+@pytest.mark.parametrize(
+    "text,expected_hint",
+    [
+        # version-independent, only tests python_min -> hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+
+                build:
+                  python:
+                    version_independent: true
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python >=${{ python_min }}
+
+                tests:
+                  - python:
+                      imports:
+                        - mypackage
+                      python_version: ${{ python_min }}.*
+                """),
+            True,
+        ),
+        # version-independent, tests python_min AND latest -> no hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+
+                build:
+                  python:
+                    version_independent: true
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python >=${{ python_min }}
+
+                tests:
+                  - python:
+                      imports:
+                        - mypackage
+                      python_version:
+                        - ${{ python_min }}.*
+                        - "*"
+                """),
+            False,
+        ),
+        # abi3 example recipe shape (conditional python_min + "*") -> no hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+
+                build:
+                  python:
+                    version_independent: ${{ is_abi3 }}
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python
+
+                tests:
+                  - python:
+                      imports:
+                        - mypackage
+                      python_version:
+                        - if: is_abi3
+                          then: ${{ python_min }}.*
+                        - "*"
+                """),
+            False,
+        ),
+        # not version-independent -> no hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+
+                requirements:
+                  run:
+                    - python
+
+                tests:
+                  - python:
+                      imports:
+                        - mypackage
+                      python_version: ${{ python_min }}.*
+                """),
+            False,
+        ),
+        # version-independent but no python test -> no hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+
+                build:
+                  python:
+                    version_independent: true
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python >=${{ python_min }}
+
+                tests:
+                  - script:
+                      - mypackage --help
+                """),
+            False,
+        ),
+        # abi3 via `${{ is_abi3 }}`, only tests python_min -> hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+
+                build:
+                  python:
+                    version_independent: ${{ is_abi3 }}
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python
+
+                tests:
+                  - python:
+                      imports:
+                        - mypackage
+                      python_version: ${{ python_min }}.*
+                """),
+            True,
+        ),
+    ],
+    ids=(f"recipe-{i}" for i in count(1)),
+)
+def test_lint_recipe_v1_python_version_independent_test_latest(text, expected_hint):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:
+            f.write(text)
+        _, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
+        has_hint = any("version-independent (e.g. abi3)" in h for h in hints)
+        assert has_hint == expected_hint, hints
+
+
 def test_lint_recipe_v1_comment_selectors():
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:


### PR DESCRIPTION
Superseded and closed. No longer needed.