### PR TITLE
Add hint: manual SP_DIR definition is an obsolete rattler-build workaround

### DIFF
--- a/conda_smithy/data/linter-messages.json
+++ b/conda_smithy/data/linter-messages.json
@@ -983,6 +983,18 @@
       "path": "recipe/recipe.yaml"
     },
     {
+      "name": "RattlerSPDir",
+      "identifier": "R1-006",
+      "category": "R1",
+      "kind": "hint",
+      "added_in": "2026.7",
+      "deprecated_in": "",
+      "documentation": "rattler-build defines `$SP_DIR` (the environment's site-packages\ndirectory), so recipes no longer need to set it themselves. Older abi3\nrecipes exported it manually as a workaround for it being undefined.",
+      "message": "This recipe defines `SP_DIR` itself, which used to be a workaround for rattler-build not providing it. rattler-build now defines `$SP_DIR` (the site-packages directory), so the manual definition can be removed and `$SP_DIR` used directly.",
+      "examples": [],
+      "path": "recipe/recipe.yaml"
+    },
+    {
       "name": "MacOSDeploymentTargetRename",
       "identifier": "RC-000",
       "category": "RC",

--- a/conda_smithy/data/linter-messages.json
+++ b/conda_smithy/data/linter-messages.json
@@ -989,8 +989,8 @@
       "kind": "hint",
       "added_in": "2026.7",
       "deprecated_in": "",
-      "documentation": "rattler-build defines `$SP_DIR` (the environment's site-packages\ndirectory), so recipes no longer need to set it themselves. Older abi3\nrecipes exported it manually as a workaround for it being undefined.",
-      "message": "This recipe defines `SP_DIR` itself, which used to be a workaround for rattler-build not providing it. rattler-build now defines `$SP_DIR` (the site-packages directory), so the manual definition can be removed and `$SP_DIR` used directly.",
+      "documentation": "rattler-build defines `$SP_DIR` (the environment's site-packages\ndirectory, `%SP_DIR%` on Windows), so recipes no longer need to set it\nthemselves or hardcode the path. Older abi3 recipes exported it manually\nas a workaround for it being undefined, or hardcoded a Windows path such\nas `%PREFIX%\\Lib\\site-packages`.",
+      "message": "This recipe handles the site-packages directory manually, either by defining `SP_DIR` itself or by hardcoding a path such as `%PREFIX%\\Lib\\site-packages`. rattler-build now defines `$SP_DIR` (`%SP_DIR%` on Windows), so the manual definition can be removed and hardcoded paths replaced with `$SP_DIR` / `%SP_DIR%`.",
       "examples": [],
       "path": "recipe/recipe.yaml"
     },

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -38,6 +38,7 @@ from conda_smithy.linter.hints import (
     hint_pip_usage,
     hint_python_version_independent_test_latest,
     hint_rattler_build_bld_bat,
+    hint_rattler_build_sp_dir,
     hint_redundant_python_min,
     hint_shellcheck_usage,
     hint_sources_should_not_mention_pypi_io_but_pypi_org,
@@ -837,6 +838,14 @@ def run_conda_forge_specific(
             recipe_text,
             lints,
         )
+
+        # 12b: defining SP_DIR is an obsolete rattler-build workaround
+        if "hint_rattler_build_sp_dir" not in lints_to_skip:
+            hint_rattler_build_sp_dir(
+                recipe_text,
+                hints,
+                recipe_version,
+            )
 
     # 13: no empty conda_build_config.yaml files
     cbc_pth = os.path.join(recipe_dir or "", "conda_build_config.yaml")

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -602,6 +602,32 @@ def hint_rattler_build_bld_bat(
         hints.append(msg.r.RattlerBldBat().as_string())
 
 
+# Matches a manual definition of SP_DIR in a script line, e.g.
+# `- export SP_DIR=$(python -c "...")`. It must be an assignment (`SP_DIR=`),
+# so plain uses like `$SP_DIR/foo` or `%SP_DIR%` are not matched.
+SP_DIR_DEFINITION_RE = re.compile(
+    r"(?m)^\s*(?:-\s+)?(?:then:\s+)?(?:export\s+)?SP_DIR\s*="
+)
+
+
+def hint_rattler_build_sp_dir(
+    recipe_text: str,
+    hints: list[str],
+    recipe_version: int = 0,
+):
+    """Hint that manually defining SP_DIR is an obsolete rattler-build workaround.
+
+    rattler-build now defines `$SP_DIR` (the environment's site-packages
+    directory). Older abi3 recipes exported it themselves as a workaround for
+    it previously being undefined; that definition can now be removed.
+    """
+    if recipe_version != 1:
+        return
+
+    if SP_DIR_DEFINITION_RE.search(recipe_text or ""):
+        hints.append(msg.r.RattlerSPDir().as_string())
+
+
 def _check_pin_overridden(
     requirements_section: dict[str, list[str]],
     pins: set[str],

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -609,22 +609,31 @@ SP_DIR_DEFINITION_RE = re.compile(
     r"(?m)^\s*(?:-\s+)?(?:then:\s+)?(?:export\s+)?SP_DIR\s*="
 )
 
+# Matches a hardcoded Windows site-packages path, e.g.
+# `%PREFIX%\Lib\site-packages` or `%PREFIX%/Lib/site-packages`, which should
+# use `%SP_DIR%` instead. Either path separator is accepted.
+PREFIX_SITE_PACKAGES_RE = re.compile(
+    r"%PREFIX%[\\/]+Lib[\\/]+site-packages", re.IGNORECASE
+)
+
 
 def hint_rattler_build_sp_dir(
     recipe_text: str,
     hints: list[str],
     recipe_version: int = 0,
 ):
-    """Hint that manually defining SP_DIR is an obsolete rattler-build workaround.
+    """Hint that handling site-packages manually is an obsolete rattler-build workaround.
 
     rattler-build now defines `$SP_DIR` (the environment's site-packages
-    directory). Older abi3 recipes exported it themselves as a workaround for
-    it previously being undefined; that definition can now be removed.
+    directory, `%SP_DIR%` on Windows). Older abi3 recipes exported it themselves
+    as a workaround for it previously being undefined, or hardcoded a path such
+    as `%PREFIX%\\Lib\\site-packages`; both can now use `$SP_DIR` / `%SP_DIR%`.
     """
     if recipe_version != 1:
         return
 
-    if SP_DIR_DEFINITION_RE.search(recipe_text or ""):
+    text = recipe_text or ""
+    if SP_DIR_DEFINITION_RE.search(text) or PREFIX_SITE_PACKAGES_RE.search(text):
         hints.append(msg.r.RattlerSPDir().as_string())
 
 

--- a/conda_smithy/linter/messages/recipe.py
+++ b/conda_smithy/linter/messages/recipe.py
@@ -1294,4 +1294,23 @@ class PythonVersionIndependentTestLatest(LinterMessage, _RecipeYamlMessage):
     )
 
 
+@dataclass(kw_only=True)
+class RattlerSPDir(LinterMessage, _RecipeYamlMessage):
+    """
+    rattler-build defines `$SP_DIR` (the environment's site-packages
+    directory), so recipes no longer need to set it themselves. Older abi3
+    recipes exported it manually as a workaround for it being undefined.
+    """
+
+    kind = "hint"
+    identifier = "R1-006"
+    added_in = "2026.7"
+    message = (
+        "This recipe defines `SP_DIR` itself, which used to be a workaround "
+        "for rattler-build not providing it. rattler-build now defines "
+        "`$SP_DIR` (the site-packages directory), so the manual definition "
+        "can be removed and `$SP_DIR` used directly."
+    )
+
+
 # endregion

--- a/conda_smithy/linter/messages/recipe.py
+++ b/conda_smithy/linter/messages/recipe.py
@@ -1298,18 +1298,21 @@ class PythonVersionIndependentTestLatest(LinterMessage, _RecipeYamlMessage):
 class RattlerSPDir(LinterMessage, _RecipeYamlMessage):
     """
     rattler-build defines `$SP_DIR` (the environment's site-packages
-    directory), so recipes no longer need to set it themselves. Older abi3
-    recipes exported it manually as a workaround for it being undefined.
+    directory, `%SP_DIR%` on Windows), so recipes no longer need to set it
+    themselves or hardcode the path. Older abi3 recipes exported it manually
+    as a workaround for it being undefined, or hardcoded a Windows path such
+    as `%PREFIX%\\Lib\\site-packages`.
     """
 
     kind = "hint"
     identifier = "R1-006"
     added_in = "2026.7"
     message = (
-        "This recipe defines `SP_DIR` itself, which used to be a workaround "
-        "for rattler-build not providing it. rattler-build now defines "
-        "`$SP_DIR` (the site-packages directory), so the manual definition "
-        "can be removed and `$SP_DIR` used directly."
+        "This recipe handles the site-packages directory manually, either by "
+        "defining `SP_DIR` itself or by hardcoding a path such as "
+        "`%PREFIX%\\Lib\\site-packages`. rattler-build now defines `$SP_DIR` "
+        "(`%SP_DIR%` on Windows), so the manual definition can be removed and "
+        "hardcoded paths replaced with `$SP_DIR` / `%SP_DIR%`."
     )
 
 

--- a/news/rattler-build-sp-dir.rst
+++ b/news/rattler-build-sp-dir.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* New hint ``R1-004``: v1 (rattler-build) recipes that define ``SP_DIR`` themselves (e.g. ``export SP_DIR=$(python -c "import site; ...")``) are hinted to remove it. This was a workaround for ``$SP_DIR`` previously being undefined in rattler-build, which now provides it.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/rattler-build-sp-dir.rst
+++ b/news/rattler-build-sp-dir.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* New hint ``R1-004``: v1 (rattler-build) recipes that define ``SP_DIR`` themselves (e.g. ``export SP_DIR=$(python -c "import site; ...")``) are hinted to remove it. This was a workaround for ``$SP_DIR`` previously being undefined in rattler-build, which now provides it.
+* New hint ``R1-004``: v1 (rattler-build) recipes that define ``SP_DIR`` themselves (e.g. ``export SP_DIR=$(python -c "import site; ...")``) are hinted to remove it. This was a workaround for ``$SP_DIR`` previously being undefined in rattler-build, which now provides it. (#2619)
 
 **Changed:**
 

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4652,6 +4652,92 @@ def test_lint_recipe_hint_redundant_python_min(
         assert has_hint == expected_hint, hints
 
 
+@pytest.mark.parametrize(
+    "recipe_name,text,expected_hint",
+    [
+        # v1: manual `export SP_DIR=...` workaround -> hint
+        (
+            "recipe.yaml",
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+                  version: 1.0.0
+
+                tests:
+                  - script:
+                      - export SP_DIR=$(python -c "import site; print(site.getsitepackages()[0])")
+                      - abi3audit $SP_DIR/mypackage/mypackage.abi3.so
+                """),
+            True,
+        ),
+        # v1: only *uses* $SP_DIR (no definition) -> no hint
+        (
+            "recipe.yaml",
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+                  version: 1.0.0
+
+                tests:
+                  - script:
+                      - abi3audit $SP_DIR/mypackage/mypackage.abi3.so
+                """),
+            False,
+        ),
+        # v1: windows-style %SP_DIR% usage -> no hint
+        (
+            "recipe.yaml",
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+                  version: 1.0.0
+
+                tests:
+                  - script:
+                      - abi3audit %SP_DIR%/mypackage/mypackage.pyd
+                """),
+            False,
+        ),
+        # v1: no SP_DIR at all -> no hint
+        (
+            "recipe.yaml",
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+                  version: 1.0.0
+
+                tests:
+                  - script:
+                      - mypackage --help
+                """),
+            False,
+        ),
+        # v0 (meta.yaml): SP_DIR definition -> no hint (rattler-build only)
+        (
+            "meta.yaml",
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+                  version: 1.0.0
+
+                test:
+                  commands:
+                    - export SP_DIR=$(python -c "import site; print(site.getsitepackages()[0])")
+                """),
+            False,
+        ),
+    ],
+    ids=(f"recipe-{i}" for i in count(1)),
+)
+def test_lint_recipe_v1_rattler_build_sp_dir(recipe_name, text, expected_hint):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, recipe_name), "w") as f:
+            f.write(text)
+        _, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
+        has_hint = any("rattler-build now defines" in h for h in hints)
+        assert has_hint == expected_hint, hints
+
+
 def test_lint_recipe_v1_comment_selectors():
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4698,6 +4698,34 @@ def test_lint_recipe_hint_redundant_python_min(
                 """),
             False,
         ),
+        # v1: hardcoded %PREFIX%\Lib\site-packages (backslash) -> hint
+        (
+            "recipe.yaml",
+            textwrap.dedent(r"""
+                package:
+                  name: mypackage
+                  version: 1.0.0
+
+                tests:
+                  - script:
+                      - abi3audit %PREFIX%\Lib\site-packages\mypackage\mypackage.pyd
+                """),
+            True,
+        ),
+        # v1: hardcoded %PREFIX%/Lib/site-packages (forward slash) -> hint
+        (
+            "recipe.yaml",
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+                  version: 1.0.0
+
+                tests:
+                  - script:
+                      - abi3audit %PREFIX%/Lib/site-packages/mypackage/mypackage.pyd
+                """),
+            True,
+        ),
         # v1: no SP_DIR at all -> no hint
         (
             "recipe.yaml",


### PR DESCRIPTION
Part of #2606.

rattler-build now defines `$SP_DIR`, so recipes don't need to export it. Adds hint `R1-006` for v1 recipes that set `SP_DIR` in a script (e.g. `export SP_DIR=$(...)`). Uses like `$SP_DIR/...` and `%SP_DIR%` aren't flagged.

Example: https://github.com/conda-forge/fsspec-rs-feedstock/blob/main/recipe/recipe.yaml
