### PR TITLE
Define build_platform and pass it to conda-build and rattler-build

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2040,7 +2040,7 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
         )
         # fmt: off
         if platform == "linux":
-            if docker_image := data.get("config"):
+            if docker_image := data.get("config", {}).get("docker_image"):
                 config_rendered["DOCKER_IMAGE"] = docker_image[-1]
         elif platform == "win":
             config_rendered["build_platform"] = data["build_platform"]

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2039,9 +2039,12 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
             }
         )
         # fmt: off
-        if "docker_image" in data["config"] and platform == "linux":
-            config_rendered["DOCKER_IMAGE"] = data["config"]["docker_image"][-1]
-        if platform == "osx":
+        if platform == "linux":
+            if docker_image := data.get("config"):
+                config_rendered["DOCKER_IMAGE"] = docker_image[-1]
+        elif platform == "win":
+            config_rendered["build_platform"] = data["build_platform"]
+        elif platform == "osx":
             if data["build_platform"] == "osx-64":
                 config_rendered["VMIMAGE"] = "macOS-15"
             elif data["build_platform"] == "osx-arm64":

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -90,6 +90,7 @@ jobs:
 {%- endif %}
         UPLOAD_PACKAGES: $(UPLOAD_PACKAGES)
         UPLOAD_TEMP: $(UPLOAD_TEMP)
+        build_platform: $(build_platform)
         flow_run_id: azure_$(Build.BuildNumber).$(System.JobAttempt)
         remote_url: $(Build.Repository.Uri)
         sha: $(Build.SourceVersion)

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -134,7 +134,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     #   - --clobber-file vs. none
     #   - none vs. --target-platform
     {%- if conda_build_tool.startswith("conda-build") %}
-    conda debug \
+    CONDA_SUBDIR="${BUILD_PLATFORM}" conda debug \
         "${RECIPE_ROOT}" \
         -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
@@ -166,7 +166,7 @@ else
     #   - none vs. --target-platform
     #   - --extra-meta a=b c=d vs. --extra-meta a=b --extra-meta c=d
     {%- if conda_build_tool != "rattler-build" %}
-    {{ BUILD_CMD }} \
+    CONDA_SUBDIR="${BUILD_PLATFORM}" {{ BUILD_CMD }} \
         "${RECIPE_ROOT}" \
         -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -150,6 +150,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
         -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
         ${BUILD_OUTPUT_ID:+--output-name "${BUILD_OUTPUT_ID}"} \
+        --build-platform "${BUILD_PLATFORM}" \
         --target-platform "${HOST_PLATFORM}"
 
     rattler-build debug shell
@@ -179,6 +180,7 @@ else
         --recipe "${RECIPE_ROOT}" \
         -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
+        --build-platform "${BUILD_PLATFORM}" \
         --target-platform "${HOST_PLATFORM}" \
         --extra-meta flow_run_id="${flow_run_id:-}" \
         --extra-meta remote_url="${remote_url:-}" \

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -61,7 +61,9 @@ jobs:
         {%- endif %}
             STORE_BUILD_ARTIFACTS: {{ data.store_build_artifacts is true }}
             UPLOAD_PACKAGES: {{ data.upload }}
+        {%- if data.build_platform.startswith("win") %}    
             build_platform: {{ data.build_platform }}
+        {%- endif %}
             build_workspace_dir: {{ data.build_workspace_dir }}
             docker_run_args: {{ data.docker_run_args }}
             free_disk_space: {{ data.free_disk_space }}

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -61,6 +61,7 @@ jobs:
         {%- endif %}
             STORE_BUILD_ARTIFACTS: {{ data.store_build_artifacts is true }}
             UPLOAD_PACKAGES: {{ data.upload }}
+            build_platform: {{ data.build_platform }}
             build_workspace_dir: {{ data.build_workspace_dir }}
             docker_run_args: {{ data.docker_run_args }}
             free_disk_space: {{ data.free_disk_space }}
@@ -231,6 +232,8 @@ jobs:
         set "sha=%GITHUB_SHA%"
         call ".scripts\run_win_build.bat"
       env:
+        {#- BUILD_PLATFORM needed to distinguish emulated/native builds #}
+        BUILD_PLATFORM: {% raw %}${{ matrix.build_platform }}{% endraw %}
         CI: github_actions
         CONDA_BLD_PATH: {% raw %}${{ matrix.build_workspace_dir }}{% endraw %}
         CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -61,7 +61,7 @@ jobs:
         {%- endif %}
             STORE_BUILD_ARTIFACTS: {{ data.store_build_artifacts is true }}
             UPLOAD_PACKAGES: {{ data.upload }}
-        {%- if data.build_platform.startswith("win") %}    
+        {%- if data.build_platform.startswith("win") %}
             build_platform: {{ data.build_platform }}
         {%- endif %}
             build_workspace_dir: {{ data.build_workspace_dir }}

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -176,6 +176,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     rattler-build debug setup \
         --recipe ./{{ recipe_dir }} \
         -m ./.ci_support/${CONFIG}.yaml \
+        --build-platform "${BUILD_PLATFORM}" \
         --target-platform "${HOST_PLATFORM}" \
         ${BUILD_OUTPUT_ID:+--output-name "${BUILD_OUTPUT_ID}"} \
         ${EXTRA_CB_OPTIONS:-}
@@ -198,6 +199,7 @@ else
     {{ BUILD_CMD }} --recipe ./{{ recipe_dir }} \
         -m ./.ci_support/${CONFIG}.yaml \
         ${EXTRA_CB_OPTIONS:-} \
+        --build-platform "${BUILD_PLATFORM}" \
         --target-platform "${HOST_PLATFORM}" \
         --extra-meta flow_run_id="$flow_run_id" \
         --extra-meta remote_url="$remote_url" \

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -165,7 +165,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
     fi
-    conda debug ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml \
+    CONDA_SUBDIR="${BUILD_PLATFORM}" conda debug ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml \
         ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
 
@@ -190,7 +190,7 @@ else
     fi
 {% endif %}
     {%- if conda_build_tool != "rattler-build" %}
-    {{ BUILD_CMD }} ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml \
+    CONDA_SUBDIR="${BUILD_PLATFORM}" {{ BUILD_CMD }} ./{{ recipe_dir }} -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -189,7 +189,7 @@ call :end_group
 
 :: Build the recipe
 echo Building recipe
-{%- if conda_build_tool.startswith(("conda-build", "mambabuild") %}
+{%- if conda_build_tool.startswith(("conda-build", "mambabuild")) %}
 set "_OLD_CONDA_SUBDIR=%CONDA_SUBDIR%"
 set "CONDA_SUBDIR=%BUILD_PLATFORM%"
 {%- endif %}
@@ -207,7 +207,7 @@ conda-build.exe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-varia
 rattler-build.exe build --recipe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml %EXTRA_CB_OPTIONS% --build-platform %BUILD_PLATFORM% --target-platform %HOST_PLATFORM%
 {%- endif %}
 if !errorlevel! neq 0 exit /b !errorlevel!
-{%- if conda_build_tool.startswith(("conda-build", "mambabuild") %}
+{%- if conda_build_tool.startswith(("conda-build", "mambabuild")) %}
 set "_OLD_CONDA_SUBDIR="
 set "CONDA_SUBDIR=%_OLD_CONDA_SUBDIR%"
 {%- endif %}

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -68,7 +68,8 @@ if "%PIXI_CACHE_DIR%"=="%MINIFORGE_HOME%" (
 )
 move /y pixi.toml pixi.toml.bak
 set "arch=64"
-if "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "arch=arm64"
+{#- TODO: Enable this line again once we have bootstrapped all the dependencies for a full base environment on win-arm64; emulate win-64 for now  #}
+{#- if "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "arch=arm64" #}
 powershell -NoProfile -ExecutionPolicy unrestricted -Command "(Get-Content pixi.toml.bak -Encoding UTF8) -replace 'platforms = .*', 'platforms = [''win-%arch%'']' | Out-File pixi.toml -Encoding UTF8"
 :: Git on Windows needs to run post link scripts to properly set up SSL certificates
 pixi config set --global run-post-link-scripts insecure

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -193,7 +193,7 @@ conda-build.exe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-varia
 {%- elif conda_build_tool == "conda-build" %}
 conda-build.exe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 {%- elif conda_build_tool == "rattler-build" %}
-rattler-build.exe build --recipe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml %EXTRA_CB_OPTIONS% --target-platform %HOST_PLATFORM%
+rattler-build.exe build --recipe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml %EXTRA_CB_OPTIONS% --build-platform %BUILD_PLATFORM% --target-platform %HOST_PLATFORM%
 {%- endif %}
 if !errorlevel! neq 0 exit /b !errorlevel!
 

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -183,6 +183,10 @@ call :end_group
 
 :: Build the recipe
 echo Building recipe
+{%- if conda_build_tool.startswith(("conda-build", "mambabuild") %}
+set "_OLD_CONDA_SUBDIR=%CONDA_SUBDIR%"
+set "CONDA_SUBDIR=%BUILD_PLATFORM%"
+{%- endif %}
 {%- if conda_build_tool == "mambabuild" %}
 conda-mambabuild.exe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 {%- elif conda_build_tool == "conda-build+conda-libmamba-solver" %}
@@ -197,6 +201,10 @@ conda-build.exe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml --suppress-varia
 rattler-build.exe build --recipe "{{ recipe_dir }}" -m .ci_support\%CONFIG%.yaml %EXTRA_CB_OPTIONS% --build-platform %BUILD_PLATFORM% --target-platform %HOST_PLATFORM%
 {%- endif %}
 if !errorlevel! neq 0 exit /b !errorlevel!
+{%- if conda_build_tool.startswith(("conda-build", "mambabuild") %}
+set "_OLD_CONDA_SUBDIR="
+set "CONDA_SUBDIR=%_OLD_CONDA_SUBDIR%"
+{%- endif %}
 
 call :start_group "Inspecting artifacts"
 :: inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -131,6 +131,12 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 {%- endif %}
 
 :: Set basic configuration
+if [%BUILD_PLATFORM%]==[] (
+    echo Defining build platform
+    if "%PROCESSOR_ARCHITECTURE%"=="AMD64" set "BUILD_PLATFORM=win-64"
+    if "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "BUILD_PLATFORM=win-arm64"
+    if "%PROCESSOR_ARCHITECTURE%"=="x86"   set "BUILD_PLATFORM=win-32"
+)
 echo Setting up configuration
 setup_conda_rc .\ ".\{{ recipe_dir }}" .\.ci_support\%CONFIG%.yaml
 if !errorlevel! neq 0 exit /b !errorlevel!

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -131,12 +131,6 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 {%- endif %}
 
 :: Set basic configuration
-if [%BUILD_PLATFORM%]==[] (
-    echo Defining build platform
-    if "%PROCESSOR_ARCHITECTURE%"=="AMD64" set "BUILD_PLATFORM=win-64"
-    if "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "BUILD_PLATFORM=win-arm64"
-    if "%PROCESSOR_ARCHITECTURE%"=="x86"   set "BUILD_PLATFORM=win-32"
-)
 echo Setting up configuration
 setup_conda_rc .\ ".\{{ recipe_dir }}" .\.ci_support\%CONFIG%.yaml
 if !errorlevel! neq 0 exit /b !errorlevel!

--- a/news/2622-build-platform.rst
+++ b/news/2622-build-platform.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``rattler-build`` is now called with an explicit ``--build-platform`` flag. (#2622)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/2622-build-platform.rst
+++ b/news/2622-build-platform.rst
@@ -5,6 +5,7 @@
 **Changed:**
 
 * ``rattler-build`` is now called with an explicit ``--build-platform`` flag. (#2622)
+* ``pixi`` will provision ``win-64`` tooling while ``win-arm64`` is being bootstrapped. (#2622)
 
 **Deprecated:**
 

--- a/news/2622-build-platform.rst
+++ b/news/2622-build-platform.rst
@@ -4,8 +4,8 @@
 
 **Changed:**
 
-* ``rattler-build`` is now called with an explicit ``--build-platform`` flag. (#2622)
-* ``pixi`` will provision ``win-64`` tooling while ``win-arm64`` is being bootstrapped. (#2622)
+* ``rattler-build`` and ``conda-build`` are now called explicit build platforms (via ``--build-platform`` and ``CONDA_SUBDIR``, respectively). (#2622)
+* On Windows ARM machines, ``pixi`` will always provision ``win-64`` tooling while the ``win-arm64`` platform is being bootstrapped. (#2622)
 
 **Deprecated:**
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Comes from https://github.com/conda-forge/conda-forge.github.io/issues/1940#issuecomment-4984071281.

Changes:

- On Windows, define `%BUILD_PLATFORM%` directly from GHA/AZP job matrix
- We also implement a fallback where BUILD_PLATFORM is inferred from PROCESSOR_ARCHITECTURE
- For `conda-build`, we export `CONDA_SUBDIR=%BUILD_PLATFORM%`
- For `rattler-build`, we pass `--build-platform %BUILD_PLATFORM%`

Needs these PRs for full effect:

- https://github.com/conda/conda-build/pull/6047
- https://github.com/prefix-dev/rattler-build/pull/2664
- https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/423
- https://github.com/conda/conda/pull/16417