### PR TITLE
Add test for executable bits of rendered feedstock content.

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -210,8 +210,22 @@ GITHUB_ACTIONS_RUNS_ON = {
 }
 
 
-ALL_EXECUTABLE_FILES = [
-    ".circleci/checkout_merge_commit.sh",
+NON_EXECUTABLE_TEMPLATES = [
+    ".azure-pipelines/azure-pipelines-linux.yml",
+    ".azure-pipelines/azure-pipelines-osx.yml",
+    ".azure-pipelines/azure-pipelines-win.yml",
+    ".drone.yml",
+    ".travis.yml",
+    "README.md",
+    "appveyor.yml",
+    "azure-pipelines.yml",
+    "circle.yml",
+    "github-actions.yml",
+    "pixi.toml",
+]
+
+
+EXECUTABLE_TEMPLATES = [
     ".scripts/SetPageFileSize.ps1",
     ".scripts/build_steps.sh",
     ".scripts/create_conda_build_artifacts.bat",
@@ -219,10 +233,16 @@ ALL_EXECUTABLE_FILES = [
     ".scripts/create_pagefile.bat",
     ".scripts/create_pagefile.sh",
     ".scripts/free_disk_space.sh",
-    ".scripts/logging_utils.sh",
     ".scripts/run_docker_build.sh",
     ".scripts/run_osx_build.sh",
     ".scripts/run_win_build.bat",
+]
+
+
+ALL_EXECUTABLE_FILES = EXECUTABLE_TEMPLATES + [
+    ".circleci/checkout_merge_commit.sh",
+    ".circleci/fast_finish_ci_pr_build.sh",
+    ".scripts/logging_utils.sh",
     "build-locally.py",
 ]
 
@@ -1736,7 +1756,7 @@ def _render_template_files(forge_config, jinja_env, template_files, forge_dir):
         # ensure trailing newline
         if new_file_contents[-1] != "\n":
             new_file_contents += "\n"
-        if target_fname in get_common_scripts(forge_dir) and os.path.exists(
+        if target_fname in iter_all_templates(forge_dir) and os.path.exists(
             target_fname
         ):
             with open(target_fname, encoding="utf-8") as fh:
@@ -3035,8 +3055,8 @@ def clear_variants(forge_dir):
             remove_file(config)
 
 
-def get_common_scripts(forge_dir):
-    for file in ALL_EXECUTABLE_FILES:
+def iter_all_templates(forge_dir):
+    for file in EXECUTABLE_TEMPLATES + NON_EXECUTABLE_TEMPLATES:
         yield os.path.join(forge_dir, file)
 
 

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -22,6 +22,8 @@ from pathlib import Path, PurePath
 import requests
 import yaml
 
+from conda_smithy.deprecations import deprecated
+
 # The `requests` lib uses `simplejson` instead of `json` when available.
 # In consequence the same JSON library must be used or the `JSONDecodeError`
 # used when catching an exception won't be the same as the one raised
@@ -1756,7 +1758,7 @@ def _render_template_files(forge_config, jinja_env, template_files, forge_dir):
         # ensure trailing newline
         if new_file_contents[-1] != "\n":
             new_file_contents += "\n"
-        if target_fname in iter_all_templates(forge_dir) and os.path.exists(
+        if target_fname in _iter_all_templates(forge_dir) and os.path.exists(
             target_fname
         ):
             with open(target_fname, encoding="utf-8") as fh:
@@ -3055,9 +3057,18 @@ def clear_variants(forge_dir):
             remove_file(config)
 
 
-def iter_all_templates(forge_dir):
+def _iter_all_templates(forge_dir):
     for file in EXECUTABLE_TEMPLATES + NON_EXECUTABLE_TEMPLATES:
         yield os.path.join(forge_dir, file)
+
+
+deprecated.constant(
+    "2026.7",
+    "2026.10",
+    "get_common_scripts",
+    _iter_all_templates,
+    addendum="Raise an issue if you need this function",
+)
 
 
 def clear_scripts(forge_dir):

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -210,6 +210,23 @@ GITHUB_ACTIONS_RUNS_ON = {
 }
 
 
+ALL_EXECUTABLE_FILES = [
+    ".circleci/checkout_merge_commit.sh",
+    ".scripts/SetPageFileSize.ps1",
+    ".scripts/build_steps.sh",
+    ".scripts/create_conda_build_artifacts.bat",
+    ".scripts/create_conda_build_artifacts.sh",
+    ".scripts/create_pagefile.bat",
+    ".scripts/create_pagefile.sh",
+    ".scripts/free_disk_space.sh",
+    ".scripts/logging_utils.sh",
+    ".scripts/run_docker_build.sh",
+    ".scripts/run_osx_build.sh",
+    ".scripts/run_win_build.bat",
+    "build-locally.py",
+]
+
+
 # use lru_cache to avoid repeating warnings endlessly;
 # this keeps track of 10 different messages and then warns again
 @lru_cache(10)
@@ -1562,17 +1579,16 @@ def _circle_specific_setup(jinja_env, forge_config, forge_dir, platform):
     else:
         template_files.append(".scripts/run_osx_build.sh")
 
-    _render_template_exe_files(
+    # all template_files are also executable
+    exe_files = template_files + [".circleci/checkout_merge_commit.sh"]
+
+    _render_template_files(
         forge_config=forge_config,
         jinja_env=jinja_env,
         template_files=template_files,
         forge_dir=forge_dir,
     )
-
-    # Fix permission of other shell files.
-    target_fnames = [os.path.join(forge_dir, ".circleci", "checkout_merge_commit.sh")]
-    for target_fname in target_fnames:
-        set_exe_file(target_fname, True)
+    _add_exec_bit(exe_files=exe_files, forge_dir=forge_dir)
 
 
 def generate_yum_requirements(forge_config, forge_dir):
@@ -1702,15 +1718,17 @@ def _travis_specific_setup(jinja_env, forge_config, forge_dir, platform):
 
     forge_config["build_setup"] = build_setup
 
-    _render_template_exe_files(
+    _render_template_files(
         forge_config=forge_config,
         jinja_env=jinja_env,
         template_files=template_files,
         forge_dir=forge_dir,
     )
+    # all template files are also executable
+    _add_exec_bit(exe_files=template_files, forge_dir=forge_dir)
 
 
-def _render_template_exe_files(forge_config, jinja_env, template_files, forge_dir):
+def _render_template_files(forge_config, jinja_env, template_files, forge_dir):
     for template_file in template_files:
         template = jinja_env.get_template(os.path.basename(template_file) + ".tmpl")
         target_fname = os.path.join(forge_dir, template_file)
@@ -1742,7 +1760,13 @@ def _render_template_exe_files(forge_config, jinja_env, template_files, forge_di
                     )
         with write_file(target_fname) as fh:
             fh.write(new_file_contents)
-        # Fix permission of template shell files
+
+
+def _add_exec_bit(exe_files, forge_dir):
+    for exe_file in exe_files:
+        target_fname = os.path.join(forge_dir, exe_file)
+        # Fix permission of executable files
+        logger.debug("adding exec bit to %", target_fname)
         set_exe_file(target_fname, True)
 
 
@@ -1936,12 +1960,14 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
     forge_config = deepcopy(forge_config)
     forge_config["build_setup"] = build_setup
 
-    _render_template_exe_files(
+    _render_template_files(
         forge_config=forge_config,
         jinja_env=jinja_env,
         template_files=template_files,
         forge_dir=forge_dir,
     )
+    # all template_files are also executable
+    _add_exec_bit(exe_files=template_files, forge_dir=forge_dir)
 
 
 def render_github_actions(jinja_env, forge_config, forge_dir, return_metadata=False):
@@ -1987,22 +2013,25 @@ def render_github_actions(jinja_env, forge_config, forge_dir, return_metadata=Fa
 def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
     build_setup = _get_build_setup_line(forge_dir, platform, forge_config)
 
-    platform_templates = {
+    exec_templates = {
         "linux": [
             ".scripts/run_docker_build.sh",
             ".scripts/build_steps.sh",
-            ".azure-pipelines/azure-pipelines-linux.yml",
         ],
         "osx": [
-            ".azure-pipelines/azure-pipelines-osx.yml",
             ".scripts/run_osx_build.sh",
         ],
         "win": [
-            ".azure-pipelines/azure-pipelines-win.yml",
             ".scripts/run_win_build.bat",
         ],
     }
-    template_files = platform_templates.get(platform, [])
+    non_exec_templates = {
+        "linux": [".azure-pipelines/azure-pipelines-linux.yml"],
+        "osx": [".azure-pipelines/azure-pipelines-osx.yml"],
+        "win": [".azure-pipelines/azure-pipelines-win.yml"],
+    }
+    exe_files = exec_templates.get(platform, [])
+    template_files = exe_files + non_exec_templates.get(platform, [])
 
     if platform == "linux":
         yum_build_setup = generate_yum_requirements(forge_config, forge_dir)
@@ -2064,12 +2093,13 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
         # fmt: on
 
     forge_config["azure_yaml"] = yaml.dump(azure_settings)
-    _render_template_exe_files(
+    _render_template_files(
         forge_config=forge_config,
         jinja_env=jinja_env,
         template_files=template_files,
         forge_dir=forge_dir,
     )
+    _add_exec_bit(exe_files=exe_files, forge_dir=forge_dir)
 
 
 def render_azure(jinja_env, forge_config, forge_dir, return_metadata=False):
@@ -2121,12 +2151,14 @@ def _drone_specific_setup(jinja_env, forge_config, forge_dir, platform):
 
     forge_config["build_setup"] = build_setup
 
-    _render_template_exe_files(
+    _render_template_files(
         forge_config=forge_config,
         jinja_env=jinja_env,
         template_files=template_files,
         forge_dir=forge_dir,
     )
+    # all template_files are also executable
+    _add_exec_bit(exe_files=template_files, forge_dir=forge_dir)
 
 
 def render_drone(jinja_env, forge_config, forge_dir, return_metadata=False):
@@ -3004,18 +3036,8 @@ def clear_variants(forge_dir):
 
 
 def get_common_scripts(forge_dir):
-    for old_file in [
-        "run_docker_build.sh",
-        "build_steps.sh",
-        "run_osx_build.sh",
-        "create_conda_build_artifacts.bat",
-        "create_conda_build_artifacts.sh",
-        "create_pagefile.bat",
-        "create_pagefile.sh",
-        "SetPageFileSize.ps1",
-        "free_disk_space.sh",
-    ]:
-        yield os.path.join(forge_dir, ".scripts", old_file)
+    for file in ALL_EXECUTABLE_FILES:
+        yield os.path.join(forge_dir, file)
 
 
 def clear_scripts(forge_dir):
@@ -3187,9 +3209,8 @@ def main(
     logger.debug("env rendered")
 
     copy_feedstock_content(config, forge_dir)
-
-    if os.path.exists(os.path.join(forge_dir, "build-locally.py")):
-        set_exe_file(os.path.join(forge_dir, "build-locally.py"))
+    exe_files = [".scripts/logging_utils.sh", "build-locally.py"]
+    _add_exec_bit(exe_files, forge_dir)
 
     clear_variants(forge_dir)
     clear_scripts(forge_dir)

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -216,7 +216,9 @@ NON_EXECUTABLE_TEMPLATES = [
     ".azure-pipelines/azure-pipelines-linux.yml",
     ".azure-pipelines/azure-pipelines-osx.yml",
     ".azure-pipelines/azure-pipelines-win.yml",
+    ".circleci/config.yml",
     ".drone.yml",
+    ".github/workflows/conda-build.yml",
     ".travis.yml",
     "README.md",
     "appveyor.yml",
@@ -247,6 +249,16 @@ ALL_EXECUTABLE_FILES = EXECUTABLE_TEMPLATES + [
     ".scripts/logging_utils.sh",
     "build-locally.py",
 ]
+
+NON_EXECUTABLE_SUPPORT_FILES = [
+    ".gitattributes",
+    ".gitignore",
+    "LICENSE.txt",
+]
+
+ALL_SUPPORT_FILES = (
+    ALL_EXECUTABLE_FILES + NON_EXECUTABLE_TEMPLATES + NON_EXECUTABLE_SUPPORT_FILES
+)
 
 
 # use lru_cache to avoid repeating warnings endlessly;

--- a/news/exec-bit.rst
+++ b/news/exec-bit.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed spurious executable bits on non-exectuable files (#2623).
+
+**Security:**
+
+* <news item>

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -22,6 +22,7 @@ import conda_smithy
 from conda_smithy import configure_feedstock
 from conda_smithy.configure_feedstock import (
     ALL_EXECUTABLE_FILES,
+    ALL_SUPPORT_FILES,
     DEFAULT_PROVIDER,
     DEFAULT_PROVIDERS,
     _read_forge_config,
@@ -766,7 +767,7 @@ def test_secrets(py_recipe, jinja_env):
 
 
 @pytest.mark.parametrize("provider", ["azure", "github_actions", "drone", "travis"])
-def test_exec_bits(py_recipe, jinja_env, provider):
+def test_exec_bits_and_content(py_recipe, jinja_env, provider):
     recipe_dir = py_recipe.recipe
     forge_yml = Path(recipe_dir, "conda-forge.yml")
     with open(forge_yml, "a") as f:
@@ -798,6 +799,9 @@ def test_exec_bits(py_recipe, jinja_env, provider):
     repo = get_repo(recipe_dir)
 
     def is_executable(file):
+        if file not in repo.index:
+            # platform-specific files may be missing in render; fall back to canonical info
+            return str(file).replace("\\", "/") in ALL_EXECUTABLE_FILES
         entry = repo.index[file]
         return entry.mode == pygit2.GIT_FILEMODE_BLOB_EXECUTABLE
 
@@ -816,6 +820,21 @@ def test_exec_bits(py_recipe, jinja_env, provider):
         # we expect all executable files to have the exec bit,
         # and all non-executable files to not have it
         assert is_executable(file) == (fname in ALL_EXECUTABLE_FILES)
+
+        # check that we know the provenance of all files that got generated
+        allowlist = [
+            # variant configs
+            ".ci_support/",
+            # actual recipe
+            "conda-forge.yml",
+            "recipe/",
+            # test support files (see config_yaml & testing_workdir fixtures)
+            "config.yaml",
+            "prof/",
+        ]
+        if any(fname.startswith(x) for x in allowlist):
+            continue
+        assert fname in ALL_SUPPORT_FILES
 
 
 def test_migrator_recipe(recipe_migration_cfep9, jinja_env):

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -5,11 +5,14 @@ import logging
 import os
 import re
 import shutil
+import subprocess
+import sys
 import tempfile
 import textwrap
 import tomllib
 from pathlib import Path
 
+import pygit2
 import pytest
 import yaml
 from conftest import ConfigYAML
@@ -18,10 +21,12 @@ from rattler_build_conda_compat.loader import parse_recipe_config_file
 import conda_smithy
 from conda_smithy import configure_feedstock
 from conda_smithy.configure_feedstock import (
+    ALL_EXECUTABLE_FILES,
     DEFAULT_PROVIDER,
     DEFAULT_PROVIDERS,
     _read_forge_config,
 )
+from conda_smithy.feedstock_io import get_repo
 from conda_smithy.utils import ensure_standard_strings
 
 
@@ -758,6 +763,59 @@ def test_secrets(py_recipe, jinja_env):
             == "BINSTAR_TOKEN"
             for step in config["steps"]
         )
+
+
+@pytest.mark.parametrize("provider", ["azure", "github_actions", "drone", "travis"])
+def test_exec_bits(py_recipe, jinja_env, provider):
+    recipe_dir = py_recipe.recipe
+    forge_yml = Path(recipe_dir, "conda-forge.yml")
+    with open(forge_yml, "a") as f:
+        f.write(textwrap.dedent(f"""\
+            provider:
+              # travis intentionally not allowed for linux_64
+              linux_aarch64: {provider}
+              osx_64: {provider if provider not in ["drone", "travis"] else "default"}
+              win_64: {provider if provider not in ["drone", "travis"] else "default"}
+        """))
+
+    # initialize a git repo (we want to check exec bits as commited by rerender)
+    subprocess.call(
+        'git init && git add . && git commit -m "initial commit"',
+        cwd=recipe_dir,
+        shell=True,
+        stdout=sys.stderr,
+    )
+
+    configure_feedstock.main(
+        forge_file_directory=recipe_dir,
+        forge_yml=forge_yml,
+        no_check_uptodate=True,
+        commit=True,
+    )
+
+    # sanity check for pytest failure logs: check content of recipe folder
+    subprocess.call(["ls", "-lla"], cwd=recipe_dir, stdout=sys.stderr)
+    repo = get_repo(recipe_dir)
+
+    def is_executable(file):
+        entry = repo.index[file]
+        return entry.mode == pygit2.GIT_FILEMODE_BLOB_EXECUTABLE
+
+    def iter_files(root_dir):
+        # traverse through all subfolders, only return actual files, nothing from .git/
+        for p in Path(root_dir).rglob("*"):
+            if not p.is_file():
+                continue
+            rel = p.relative_to(root_dir)
+            if ".git" in rel.parts:
+                continue
+            yield rel
+
+    for file in iter_files(recipe_dir):
+        fname = str(file).replace("\\", "/")
+        # we expect all executable files to have the exec bit,
+        # and all non-executable files to not have it
+        assert is_executable(file) == (fname in ALL_EXECUTABLE_FILES)
 
 
 def test_migrator_recipe(recipe_migration_cfep9, jinja_env):

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -795,7 +795,8 @@ def test_exec_bits_and_content(py_recipe, jinja_env, provider):
     )
 
     # sanity check for pytest failure logs: check content of recipe folder
-    subprocess.call(["ls", "-lla"], cwd=recipe_dir, stdout=sys.stderr)
+    show_content = ["dir"] if os.name == "nt" else ["ls", "-lla"]
+    subprocess.call(show_content, cwd=recipe_dir, stdout=sys.stderr)
     repo = get_repo(recipe_dir)
 
     def is_executable(file):


### PR DESCRIPTION
Broken out from #2596; it contains the fix for executable AZP yaml files, and a test that tests the expected executable bit of all rendered files. The test depends on the clean-up (not least because it needs to know which files are supposed to be executable); a04bcc288dbc509712e45cd8882f6c05e44c61d9 can be left out if preferred, it's a minor clean-up on top to guard more templates against conflicting rerenders.