### PR TITLE
Added missing parenthesis in Azure's `ARTIFACT_STAGING_DIR` definition

### DIFF
--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -99,7 +99,7 @@ jobs:
 {%- if vars.store_build_artifacts %}
 
     - script: |
-        set ARTIFACT_STAGING_DIR=$(Build.ArtifactStagingDirectory
+        set ARTIFACT_STAGING_DIR=$(Build.ArtifactStagingDirectory)
         set BLD_ARTIFACT_PREFIX=conda_artifacts
         set CI=azure
         set CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)

--- a/news/closing-parens.rst
+++ b/news/closing-parens.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Added missing parenthesis in Azure's ``ARTIFACT_STAGING_DIR`` definition.
+* Added missing parenthesis in Azure's ``ARTIFACT_STAGING_DIR`` definition. (#2624)
 
 **Security:**
 

--- a/news/closing-parens.rst
+++ b/news/closing-parens.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Added missing parenthesis in Azure's ``ARTIFACT_STAGING_DIR`` definition.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
