### PR TITLE
Add hint: remove obsolete cross-python ignore_run_exports abi3 workaround

### DIFF
--- a/conda_smithy/data/linter-messages.json
+++ b/conda_smithy/data/linter-messages.json
@@ -1007,6 +1007,18 @@
       "path": "recipe/recipe.yaml"
     },
     {
+      "name": "Abi3CrossPythonRunExports",
+      "identifier": "R1-007",
+      "category": "R1",
+      "kind": "hint",
+      "added_in": "2026.7",
+      "deprecated_in": "",
+      "documentation": "abi3 (Python version-independent) recipes used to carry a manual\nworkaround for a rattler-build limitation: they ignored the `python`\nrun-export coming from the `cross-python_<target_platform>` build\ndependency, which would otherwise pin the package to a single Python\nversion and defeat the purpose of abi3.\n\n```yaml\nrequirements:\n  ignore_run_exports:\n    from_package:\n      - cross-python_${{ target_platform }}\n```\n\nRecent rattler-build filters this run-export automatically for abi3 /\n`build.python.version_independent` recipes (see\nprefix-dev/rattler-build#2252), so the manual `ignore_run_exports` entry\nis now redundant and should be removed.",
+      "message": "This recipe manually ignores the `python` run-export from `cross-python` via `ignore_run_exports`. This used to be required so that abi3 (Python version-independent) packages were not pinned to a single Python version. Recent rattler-build strips this run-export automatically for abi3 recipes, so the workaround is no longer needed and should be removed:\n```yaml\nrequirements:\n  ignore_run_exports:\n    from_package:\n      - cross-python_${{ target_platform }}\n```",
+      "examples": [],
+      "path": "recipe/recipe.yaml"
+    },
+    {
       "name": "MacOSDeploymentTargetRename",
       "identifier": "RC-000",
       "category": "RC",

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -823,6 +823,7 @@ def run_conda_forge_specific(
         hint_abi3_cross_python_run_exports(
             requirements_section,
             outputs_section,
+            build_section,
             recipe_version,
             hints,
         )

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -28,6 +28,7 @@ from conda_smithy.configure_feedstock import _read_forge_config
 from conda_smithy.linter import conda_recipe_v1_linter
 from conda_smithy.linter import messages as msg
 from conda_smithy.linter.hints import (
+    hint_abi3_cross_python_run_exports,
     hint_check_spdx,
     hint_dependency_pins,
     hint_deprecated_environment_variables,
@@ -809,6 +810,19 @@ def run_conda_forge_specific(
             requirements_section.get("run") or [],
             outputs_section,
             build_section,
+            recipe_version,
+            hints,
+        )
+
+    # 10d: abi3 recipes no longer need the manual cross-python
+    # `ignore_run_exports` workaround; rattler-build handles it natively
+    if (
+        "hint_abi3_cross_python_run_exports" not in lints_to_skip
+        and recipe_version == 1
+    ):
+        hint_abi3_cross_python_run_exports(
+            requirements_section,
+            outputs_section,
             recipe_version,
             hints,
         )

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -496,18 +496,33 @@ CROSS_PYTHON_RE = re.compile(r"^cross-python(?:_|\s|$)")
 def hint_abi3_cross_python_run_exports(
     requirements_section,
     outputs_section,
+    build_section,
     recipe_version,
     hints,
 ):
     if recipe_version != 1:
         return
 
-    scopes = [requirements_section or {}]
-    for output in outputs_section or []:
-        scopes.append(output.get("requirements") or {})
+    scopes = []
+    if outputs_section:
+        for output in outputs_section:
+            scopes.append(
+                (output.get("requirements") or {}, output.get("build") or {})
+            )
+    else:
+        scopes.append((requirements_section or {}, build_section or {}))
 
-    for requirements in scopes:
+    for requirements, build in scopes:
         if not isinstance(requirements, Mapping):
+            continue
+        # the cross-python run-export only pins Python for recipes that are
+        # not tied to a single Python version, i.e. `noarch: python` or
+        # `build.python.version_independent` (abi3) recipes
+        if not isinstance(build, Mapping):
+            continue
+        if build.get("noarch") != "python" and not get_version_independent(
+            build, "python", recipe_version
+        ):
             continue
         ignore_run_exports = requirements.get("ignore_run_exports")
         if not ignore_run_exports:

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -490,6 +490,40 @@ def hint_python_version_independent_test_latest(
             return
 
 
+CROSS_PYTHON_RE = re.compile(r"^cross-python(?:_|\s|$)")
+
+
+def hint_abi3_cross_python_run_exports(
+    requirements_section,
+    outputs_section,
+    recipe_version,
+    hints,
+):
+    if recipe_version != 1:
+        return
+
+    scopes = [requirements_section or {}]
+    for output in outputs_section or []:
+        scopes.append(output.get("requirements") or {})
+
+    for requirements in scopes:
+        if not isinstance(requirements, Mapping):
+            continue
+        ignore_run_exports = requirements.get("ignore_run_exports")
+        if not ignore_run_exports:
+            continue
+        # v1 ignore_run_exports is a dict, but rattler-build-conda-compat may
+        # return it wrapped in a length-1 list instead of the dict itself
+        if isinstance(ignore_run_exports, list):
+            ignore_run_exports = ignore_run_exports[0] if ignore_run_exports else {}
+        if not isinstance(ignore_run_exports, Mapping):
+            continue
+        from_package = flatten_v1_if_else(ignore_run_exports.get("from_package") or [])
+        if any(CROSS_PYTHON_RE.match(str(entry).strip()) for entry in from_package):
+            hints.append(msg.r.Abi3CrossPythonRunExports().as_string())
+            return
+
+
 def hint_space_separated_specs(
     requirements_section,
     test_section,

--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -506,9 +506,7 @@ def hint_abi3_cross_python_run_exports(
     scopes = []
     if outputs_section:
         for output in outputs_section:
-            scopes.append(
-                (output.get("requirements") or {}, output.get("build") or {})
-            )
+            scopes.append((output.get("requirements") or {}, output.get("build") or {}))
     else:
         scopes.append((requirements_section or {}, build_section or {}))
 

--- a/conda_smithy/linter/messages/recipe.py
+++ b/conda_smithy/linter/messages/recipe.py
@@ -1327,4 +1327,45 @@ class RattlerSPDir(LinterMessage, _RecipeYamlMessage):
     )
 
 
+@dataclass(kw_only=True)
+class Abi3CrossPythonRunExports(LinterMessage, _RecipeYamlMessage):
+    """
+    abi3 (Python version-independent) recipes used to carry a manual
+    workaround for a rattler-build limitation: they ignored the `python`
+    run-export coming from the `cross-python_<target_platform>` build
+    dependency, which would otherwise pin the package to a single Python
+    version and defeat the purpose of abi3.
+
+    ```yaml
+    requirements:
+      ignore_run_exports:
+        from_package:
+          - cross-python_${{ target_platform }}
+    ```
+
+    Recent rattler-build filters this run-export automatically for abi3 /
+    `build.python.version_independent` recipes (see
+    prefix-dev/rattler-build#2252), so the manual `ignore_run_exports` entry
+    is now redundant and should be removed.
+    """
+
+    kind = "hint"
+    identifier = "R1-007"
+    added_in = "2026.7"
+    message = (
+        "This recipe manually ignores the `python` run-export from "
+        "`cross-python` via `ignore_run_exports`. This used to be required so "
+        "that abi3 (Python version-independent) packages were not pinned to a "
+        "single Python version. Recent rattler-build strips this run-export "
+        "automatically for abi3 recipes, so the workaround is no longer needed "
+        "and should be removed:\n"
+        "```yaml\n"
+        "requirements:\n"
+        "  ignore_run_exports:\n"
+        "    from_package:\n"
+        "      - cross-python_${{ target_platform }}\n"
+        "```"
+    )
+
+
 # endregion

--- a/news/abi3-cross-python-run-exports.rst
+++ b/news/abi3-cross-python-run-exports.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* New hint ``R1-006``: abi3 (Python version-independent) v1 recipes that still carry the manual ``ignore_run_exports: {from_package: [cross-python_${{ target_platform }}]}`` workaround are now hinted to remove it, since recent rattler-build strips the ``cross-python`` ``python`` run-export automatically for abi3 recipes (prefix-dev/rattler-build#2252).
+* New hint: abi3 (Python version-independent) v1 recipes that still carry the manual ``ignore_run_exports: {from_package: [cross-python_${{ target_platform }}]}`` workaround are now hinted to remove it, since recent rattler-build strips the ``cross-python`` ``python`` run-export automatically for abi3 recipes (prefix-dev/rattler-build#2252).
 
 **Changed:**
 

--- a/news/abi3-cross-python-run-exports.rst
+++ b/news/abi3-cross-python-run-exports.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* New hint ``R1-006``: abi3 (Python version-independent) v1 recipes that still carry the manual ``ignore_run_exports: {from_package: [cross-python_${{ target_platform }}]}`` workaround are now hinted to remove it, since recent rattler-build strips the ``cross-python`` ``python`` run-export automatically for abi3 recipes (prefix-dev/rattler-build#2252).
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4768,6 +4768,152 @@ def test_lint_recipe_v1_rattler_build_sp_dir(recipe_name, text, expected_hint):
         assert has_hint == expected_hint, hints
 
 
+@pytest.mark.parametrize(
+    "text,expected_hint",
+    [
+        # abi3 recipe still carrying the cross-python workaround -> hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+                  version: 1.0.0
+
+                build:
+                  python:
+                    version_independent: true
+
+                requirements:
+                  build:
+                    - if: build_platform != host_platform
+                      then:
+                        - python
+                        - cross-python_${{ target_platform }}
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python
+                  ignore_run_exports:
+                    from_package:
+                      - cross-python_${{ target_platform }}
+
+                tests:
+                  - python:
+                      imports:
+                        - mypackage
+                """),
+            True,
+        ),
+        # abi3 recipe without the workaround -> no hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+                  version: 1.0.0
+
+                build:
+                  python:
+                    version_independent: true
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python
+
+                tests:
+                  - python:
+                      imports:
+                        - mypackage
+                """),
+            False,
+        ),
+        # ignores an unrelated package (not cross-python) -> no hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+                  version: 1.0.0
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python
+                  ignore_run_exports:
+                    from_package:
+                      - some-other-pkg
+
+                tests:
+                  - python:
+                      imports:
+                        - mypackage
+                """),
+            False,
+        ),
+        # workaround wrapped in an if/else selector -> hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+                  version: 1.0.0
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python
+                  ignore_run_exports:
+                    from_package:
+                      - if: build_platform != host_platform
+                        then: cross-python_${{ target_platform }}
+
+                tests:
+                  - python:
+                      imports:
+                        - mypackage
+                """),
+            True,
+        ),
+        # workaround present in a per-output requirements block -> hint
+        (
+            textwrap.dedent("""
+                recipe:
+                  name: mypackage
+                  version: 1.0.0
+
+                outputs:
+                  - package:
+                      name: myoutput
+                    build:
+                      python:
+                        version_independent: true
+                    requirements:
+                      host:
+                        - python ${{ python_min }}.*
+                      run:
+                        - python
+                      ignore_run_exports:
+                        from_package:
+                          - cross-python_${{ target_platform }}
+                    tests:
+                      - python:
+                          imports:
+                            - myoutput
+                """),
+            True,
+        ),
+    ],
+    ids=(f"recipe-{i}" for i in count(1)),
+)
+def test_lint_recipe_v1_abi3_cross_python_run_exports(text, expected_hint):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:
+            f.write(text)
+        _, hints = linter.main(tmpdir, return_hints=True, conda_forge=True)
+        has_hint = any("run-export from `cross-python`" in h for h in hints)
+        assert has_hint == expected_hint, hints
+
+
 def test_lint_recipe_v1_comment_selectors():
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "recipe.yaml"), "w") as f:

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4834,6 +4834,10 @@ def test_lint_recipe_v1_rattler_build_sp_dir(recipe_name, text, expected_hint):
                   name: mypackage
                   version: 1.0.0
 
+                build:
+                  python:
+                    version_independent: true
+
                 requirements:
                   host:
                     - python ${{ python_min }}.*
@@ -4857,6 +4861,10 @@ def test_lint_recipe_v1_rattler_build_sp_dir(recipe_name, text, expected_hint):
                   name: mypackage
                   version: 1.0.0
 
+                build:
+                  python:
+                    version_independent: true
+
                 requirements:
                   host:
                     - python ${{ python_min }}.*
@@ -4873,6 +4881,55 @@ def test_lint_recipe_v1_rattler_build_sp_dir(recipe_name, text, expected_hint):
                         - mypackage
                 """),
             True,
+        ),
+        # `noarch: python` recipe carrying the workaround -> hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+                  version: 1.0.0
+
+                build:
+                  noarch: python
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python >=${{ python_min }}
+                  ignore_run_exports:
+                    from_package:
+                      - cross-python_${{ target_platform }}
+
+                tests:
+                  - python:
+                      imports:
+                        - mypackage
+                """),
+            True,
+        ),
+        # neither `noarch: python` nor version-independent -> no hint
+        (
+            textwrap.dedent("""
+                package:
+                  name: mypackage
+                  version: 1.0.0
+
+                requirements:
+                  host:
+                    - python ${{ python_min }}.*
+                  run:
+                    - python
+                  ignore_run_exports:
+                    from_package:
+                      - cross-python_${{ target_platform }}
+
+                tests:
+                  - python:
+                      imports:
+                        - mypackage
+                """),
+            False,
         ),
         # workaround present in a per-output requirements block -> hint
         (


### PR DESCRIPTION
### Description

Adds linter hint **`R1-006`**, continuing the abi3 series after `R1-004`/`R1-005`.

abi3 (Python version-independent) recipes historically worked around a rattler-build limitation by manually ignoring the `python` run-export that `cross-python` injects when cross-compiling:

```yaml
requirements:
  ignore_run_exports:
    from_package:
      - cross-python_${{ target_platform }}
```

Without it, an abi3 package would pick up `cross-python`'s `python x.y.*` run-export and get pinned to a single Python version, defeating the purpose of abi3.

rattler-build now applies this run-export filtering automatically for abi3 recipes (prefix-dev/rattler-build#2252, extending the abi3 ignore to build-environment run exports), so the manual `ignore_run_exports` entry is redundant. `R1-006` detects it — at the top level or in any output, including `if/else`-wrapped entries — and hints that it should be removed.

An example of a recipe still carrying the workaround: [`fsspec-rs-feedstock` `recipe.yaml` L46-L48](https://github.com/conda-forge/fsspec-rs-feedstock/blob/main/recipe/recipe.yaml#L46-L48).

The hint is v1-only and skippable via `conda-forge.yml`'s `linter.skip: [hint_abi3_cross_python_run_exports]`.

### Checklist

- [x] Used a personal fork of the feedstock to propose changes
- [x] Ensured the license file is being packaged (n/a)
- [x] Added new hint `R1-006` with message, docs, regenerated `linter-messages.json`, news entry, and tests
