### PR TITLE
Artifact upload improvements

### DIFF
--- a/conda_smithy/data/conda-forge.json
+++ b/conda_smithy/data/conda-forge.json
@@ -1103,7 +1103,7 @@
             }
           ],
           "default": [],
-          "description": "Store the outputs of the build process as uploaded CI artifacts.",
+          "description": "Store the outputs of the build process as uploaded CI artifacts.\n\nUp to three artifacts in .tar.zstd format (additionally put in a .zip\non Azure) are created:\n\n- Build artifacts, containing the built packages (if any). This is\n  always created, though it may contain no packages if none built.\n- Work directory artifacts, containing the work directory (if any).\n  This is created if the build failed during one of the steps where\n  work directory was available.\n- Environment artifacts, containing build, host and test environments.\n  This is created if the build failed during one of the steps where\n  environments were available, with the appropriate environments.\n\nThe exact contents and paths in the archive will depend on the\n`conda_build_tool` used. If tar fails while creating the archive, it may\nnot be complete -- in that case it will be uploaded with \"-broken\"\nsuffix.",
           "title": "Store Build Artifacts"
         },
         "tools_install_dir": {

--- a/conda_smithy/schema.py
+++ b/conda_smithy/schema.py
@@ -551,6 +551,23 @@ class WorkflowSettings(BaseModel):
         default=[],
         description=cleandoc("""
         Store the outputs of the build process as uploaded CI artifacts.
+
+        Up to three artifacts in .tar.zstd format (additionally put in a .zip
+        on Azure) are created:
+
+        - Build artifacts, containing the built packages (if any). This is
+          always created, though it may contain no packages if none built.
+        - Work directory artifacts, containing the work directory (if any).
+          This is created if the build failed during one of the steps where
+          work directory was available.
+        - Environment artifacts, containing build, host and test environments.
+          This is created if the build failed during one of the steps where
+          environments were available, with the appropriate environments.
+
+        The exact contents and paths in the archive will depend on the
+        `conda_build_tool` used. If tar fails while creating the archive, it may
+        not be complete -- in that case it will be uploaded with "-broken"
+        suffix.
         """),
     )
 

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -84,6 +84,7 @@ jobs:
           export BLD_ARTIFACT_PREFIX=conda_pkgs_failed
           # Archive the CONDA_BLD_PATH environments only when the job fails
           export ENV_ARTIFACT_PREFIX=conda_envs
+          export WRK_ARTIFACT_PREFIX=conda_work
         fi
         ./.scripts/create_conda_build_artifacts.sh
     displayName: Prepare conda build artifacts
@@ -95,6 +96,13 @@ jobs:
     inputs:
       targetPath: $(BLD_ARTIFACT_PATH)
       artifactName: $(BLD_ARTIFACT_NAME)
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda work directoryartifacts
+    condition: not(eq(variables.WRK_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(WRK_ARTIFACT_PATH)
+      artifactName: $(WRK_ARTIFACT_NAME)
 
   - task: PublishPipelineArtifact@1
     displayName: Store conda build environment artifacts

--- a/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-linux.yml.tmpl
@@ -73,13 +73,15 @@ jobs:
   - script: |
         export ARTIFACT_STAGING_DIR="$(Build.ArtifactStagingDirectory)"
         # Archive everything in CONDA_BLD_PATH except environments
-        export BLD_ARTIFACT_PREFIX=conda_artifacts
+        export BLD_ARTIFACT_PREFIX=conda_pkgs
         export CI=azure
         export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
         export CONDA_BLD_PATH=$(build_workspace_dir)
         export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
         export MINIFORGE_HOME=$(tools_install_dir)
         if [[ "$AGENT_JOBSTATUS" == "Failed" ]]; then
+          # Use a distinct prefix on failure (to match GHA).
+          export BLD_ARTIFACT_PREFIX=conda_pkgs_failed
           # Archive the CONDA_BLD_PATH environments only when the job fails
           export ENV_ARTIFACT_PREFIX=conda_envs
         fi

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -69,6 +69,7 @@ jobs:
         export BLD_ARTIFACT_PREFIX=conda_pkgs_failed
         # Archive the CONDA_BLD_PATH environments only when the job fails
         export ENV_ARTIFACT_PREFIX=conda_envs
+        export WRK_ARTIFACT_PREFIX=conda_work
       fi
       ./.scripts/create_conda_build_artifacts.sh
     displayName: Prepare conda build artifacts
@@ -80,6 +81,13 @@ jobs:
     inputs:
       targetPath: $(BLD_ARTIFACT_PATH)
       artifactName: $(BLD_ARTIFACT_NAME)
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda work directoryartifacts
+    condition: not(eq(variables.WRK_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(WRK_ARTIFACT_PATH)
+      artifactName: $(WRK_ARTIFACT_NAME)
 
   - task: PublishPipelineArtifact@1
     displayName: Store conda build environment artifacts

--- a/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-osx.yml.tmpl
@@ -58,13 +58,15 @@ jobs:
   - script: |
       export ARTIFACT_STAGING_DIR="$(Build.ArtifactStagingDirectory)"
       # Archive everything in CONDA_BLD_PATH except environments
-      export BLD_ARTIFACT_PREFIX=conda_artifacts
+      export BLD_ARTIFACT_PREFIX=conda_pkgs
       export CI=azure
       export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
       export CONDA_BLD_PATH=$(build_workspace_dir)
       export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
       export MINIFORGE_HOME=$(tools_install_dir)
       if [[ "$AGENT_JOBSTATUS" == "Failed" ]]; then
+        # Use a distinct prefix on failure (to match GHA).
+        export BLD_ARTIFACT_PREFIX=conda_pkgs_failed
         # Archive the CONDA_BLD_PATH environments only when the job fails
         export ENV_ARTIFACT_PREFIX=conda_envs
       fi

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -101,7 +101,7 @@ jobs:
 
     - script: |
         set ARTIFACT_STAGING_DIR=$(Build.ArtifactStagingDirectory)
-        set BLD_ARTIFACT_PREFIX=conda_artifacts
+        set BLD_ARTIFACT_PREFIX=conda_pkgs
         set CI=azure
         set CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
         set CONDA_BLD_PATH=$(build_workspace_dir)
@@ -110,6 +110,7 @@ jobs:
         set FEEDSTOCK_NAME=%FEEDSTOCK_NAME:*/=%
         set MINIFORGE_HOME=$(tools_install_dir)
         if "%AGENT_JOBSTATUS%" == "Failed" (
+            set BLD_ARTIFACT_PREFIX=conda_pkgs_failed
             set ENV_ARTIFACT_PREFIX=conda_envs
         )
         call ".scripts\create_conda_build_artifacts.bat"

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -106,6 +106,8 @@ jobs:
         set CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
         set CONDA_BLD_PATH=$(build_workspace_dir)
         set FEEDSTOCK_NAME=$(build.Repository.Name)
+        rem strip '{org}/' from `{org}/{repo}` to get feedstock name
+        set FEEDSTOCK_NAME=%FEEDSTOCK_NAME:*/=%
         set MINIFORGE_HOME=$(tools_install_dir)
         if "%AGENT_JOBSTATUS%" == "Failed" (
             set ENV_ARTIFACT_PREFIX=conda_envs

--- a/conda_smithy/templates/azure-pipelines-win.yml.tmpl
+++ b/conda_smithy/templates/azure-pipelines-win.yml.tmpl
@@ -112,6 +112,7 @@ jobs:
         if "%AGENT_JOBSTATUS%" == "Failed" (
             set BLD_ARTIFACT_PREFIX=conda_pkgs_failed
             set ENV_ARTIFACT_PREFIX=conda_envs
+            set WRK_ARTIFACT_PREFIX=conda_work
         )
         call ".scripts\create_conda_build_artifacts.bat"
       displayName: Prepare conda build artifacts
@@ -123,6 +124,13 @@ jobs:
       inputs:
         targetPath: $(BLD_ARTIFACT_PATH)
         artifactName: $(BLD_ARTIFACT_NAME)
+
+    - task: PublishPipelineArtifact@1
+      displayName: Store conda work directoryartifacts
+      condition: not(eq(variables.WRK_ARTIFACT_PATH, ''))
+      inputs:
+        targetPath: $(WRK_ARTIFACT_PATH)
+        artifactName: $(WRK_ARTIFACT_NAME)
 
     - task: PublishPipelineArtifact@1
       displayName: Store conda build environment artifacts

--- a/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
@@ -12,6 +12,7 @@ rem Optional:
 rem ARTIFACT_STAGING_DIR (use working directory if unset)
 rem BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
 rem ENV_ARTIFACT_PREFIX (prefix for the conda build environments artifact name, skip if unset)
+rem WRK_ARTIFACT_PREFIX (prefix for the conda work directory artifact name, skip if unset)
 
 rem OUTPUTS
 rem
@@ -19,6 +20,8 @@ rem BLD_ARTIFACT_NAME
 rem BLD_ARTIFACT_PATH
 rem ENV_ARTIFACT_NAME
 rem ENV_ARTIFACT_PATH
+rem WRK_ARTIFACT_NAME
+rem WRK_ARTIFACT_PATH
 
 {%- if conda_install_tool == "pixi" %}
 set "PATH=%USERPROFILE%\.pixi\bin;%PATH%"
@@ -59,8 +62,10 @@ cd "%CONDA_BLD_PATH%"
 if errorlevel 1 exit 1
 
 set ENVIRONMENT_PATHS=
+set WORK_PATHS=
 set "EXCLUDE_COMMON=--exclude=.git --exclude=./pkg_cache --exclude=./src_cache"
 set EXCLUDE_FROM_BUILD_ARTIFACTS=
+set EXCLUDE_FROM_WORK=
 
 for /d %%a in (. bld test) do (
     if exist %%a (
@@ -70,10 +75,13 @@ for /d %%a in (. bld test) do (
                 set "EXCLUDE_COMMON=!EXCLUDE_COMMON! --exclude=%%a/%%b/pip_cache"
             )
 
+            set "WORK_PATHS=!WORK_PATHS! %%a/%%b"
+            set "EXCLUDE_FROM_BUILD_ARTIFACTS=!EXCLUDE_FROM_BUILD_ARTIFACTS! --exclude=%%a/%%b"
+
             cd %%b
             for /d %%c in (*_env* *_prefix_moved_*) do (
                 set "ENVIRONMENT_PATHS=!ENVIRONMENT_PATHS! %%a/%%b/%%c"
-                set "EXCLUDE_FROM_BUILD_ARTIFACTS=!EXCLUDE_FROM_BUILD_ARTIFACTS! --exclude=%%a/%%b/%%c"
+                set "EXCLUDE_FROM_WORK=!EXCLUDE_FROM_WORK! --exclude=%%a/%%b/%%c"
             )
             cd ..
         )
@@ -82,6 +90,7 @@ for /d %%a in (. bld test) do (
 )
 
 set "EXCLUDE_FROM_BUILD_ARTIFACTS=%EXCLUDE_COMMON%%EXCLUDE_FROM_BUILD_ARTIFACTS%"
+set "EXCLUDE_FROM_WORK=%EXCLUDE_COMMON%%EXCLUDE_FROM_WORK%"
 
 rem Make the build artifact archive
 if defined BLD_ARTIFACT_PREFIX (
@@ -100,6 +109,26 @@ if defined BLD_ARTIFACT_PREFIX (
     if "%CI%" == "github_actions" (
         echo BLD_ARTIFACT_NAME=!BLD_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
         echo BLD_ARTIFACT_PATH=!BLD_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
+    )
+)
+
+rem Make the work directory artifact archive
+if defined WRK_ARTIFACT_PREFIX (
+    set WRK_ARTIFACT_NAME=!WRK_ARTIFACT_PREFIX!_%ARTIFACT_UNIQUE_ID%
+    echo WRK_ARTIFACT_NAME: !WRK_ARTIFACT_NAME!
+
+    set "WRK_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%WRK_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.tar.zst"
+    bsdtar -c -f "!WRK_ARTIFACT_PATH!" %ZSTD% %EXCLUDE_FROM_WORK% %WORK_PATHS%
+    if errorlevel 1 exit 1
+    echo WRK_ARTIFACT_PATH: !WRK_ARTIFACT_PATH!
+
+    if "%CI%" == "azure" (
+        echo ##vso[task.setVariable variable=WRK_ARTIFACT_NAME]!WRK_ARTIFACT_NAME!
+        echo ##vso[task.setVariable variable=WRK_ARTIFACT_PATH]!WRK_ARTIFACT_PATH!
+    )
+    if "%CI%" == "github_actions" (
+        echo WRK_ARTIFACT_NAME=!WRK_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
+        echo WRK_ARTIFACT_PATH=!WRK_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
     )
 )
 

--- a/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
@@ -1,3 +1,4 @@
+@echo off
 setlocal enableextensions enabledelayedexpansion
 
 rem INPUTS (environment variables that need to be set before calling this script):
@@ -94,8 +95,8 @@ set "EXCLUDE_FROM_WORK=%EXCLUDE_COMMON%%EXCLUDE_FROM_WORK%"
 
 rem Make the build artifact archive
 if defined BLD_ARTIFACT_PREFIX (
+    echo Creating build artifact archive ...
     set BLD_ARTIFACT_NAME=%BLD_ARTIFACT_PREFIX%_%ARTIFACT_UNIQUE_ID%
-    echo BLD_ARTIFACT_NAME: !BLD_ARTIFACT_NAME!
 
     set "BLD_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%BLD_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.tar.zst"
     bsdtar -c -f "!BLD_ARTIFACT_PATH!" %ZSTD% %EXCLUDE_FROM_BUILD_ARTIFACTS% .
@@ -107,7 +108,8 @@ if defined BLD_ARTIFACT_PREFIX (
     )
 
     if exist "!BLD_ARTIFACT_PATH!" (
-        echo BLD_ARTIFACT_PATH: !BLD_ARTIFACT_PATH!
+        echo Archive created:
+        dir "!BLD_ARTIFACT_PATH!"
 
         if "%CI%" == "azure" (
             echo ##vso[task.setVariable variable=BLD_ARTIFACT_NAME]!BLD_ARTIFACT_NAME!
@@ -117,14 +119,19 @@ if defined BLD_ARTIFACT_PREFIX (
             echo BLD_ARTIFACT_NAME=!BLD_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
             echo BLD_ARTIFACT_PATH=!BLD_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
         )
+    ) else (
+        echo No archive created
     )
+) else (
+    echo Skipping build artifact archive
 )
+echo.
 
 rem Make the work directory artifact archive
 if defined WRK_ARTIFACT_PREFIX (
     if not "%WORK_PATHS%" == "" (
+        echo Creating work directory archive ...
         set WRK_ARTIFACT_NAME=!WRK_ARTIFACT_PREFIX!_%ARTIFACT_UNIQUE_ID%
-        echo WRK_ARTIFACT_NAME: !WRK_ARTIFACT_NAME!
 
         set "WRK_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%WRK_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.tar.zst"
         bsdtar -c -f "!WRK_ARTIFACT_PATH!" %ZSTD% %EXCLUDE_FROM_WORK% %WORK_PATHS%
@@ -136,7 +143,8 @@ if defined WRK_ARTIFACT_PREFIX (
         )
 
         if exist "!WRK_ARTIFACT_PATH!" (
-            echo WRK_ARTIFACT_PATH: !WRK_ARTIFACT_PATH!
+            echo Archive created:
+            dir "!WRK_ARTIFACT_PATH!"
 
             if "%CI%" == "azure" (
                 echo ##vso[task.setVariable variable=WRK_ARTIFACT_NAME]!WRK_ARTIFACT_NAME!
@@ -146,15 +154,22 @@ if defined WRK_ARTIFACT_PREFIX (
                 echo WRK_ARTIFACT_NAME=!WRK_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
                 echo WRK_ARTIFACT_PATH=!WRK_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
             )
+        ) else (
+            echo No archive created
         )
+    ) else (
+        echo Skipping work directory artifact archive because of no files
     )
+) else (
+    echo Skipping work directory artifact archive
 )
+echo.
 
 rem Make the environment artifact archive
 if defined ENV_ARTIFACT_PREFIX (
     if not "%ENVIRONMENT_PATHS%" == "" (
+        echo Creating build environment artifact archive ...
         set ENV_ARTIFACT_NAME=!ENV_ARTIFACT_PREFIX!_%ARTIFACT_UNIQUE_ID%
-        echo ENV_ARTIFACT_NAME: !ENV_ARTIFACT_NAME!
 
         set "ENV_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%ENV_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.tar.zst"
         bsdtar -c -f "!ENV_ARTIFACT_PATH!" %ZSTD% %ENVIRONMENT_PATHS%
@@ -166,7 +181,8 @@ if defined ENV_ARTIFACT_PREFIX (
         )
 
         if exist "!ENV_ARTIFACT_PATH!" (
-            echo ENV_ARTIFACT_PATH: !ENV_ARTIFACT_PATH!
+            echo Archive created:
+            dir "!ENV_ARTIFACT_PATH!"
 
             if "%CI%" == "azure" (
                 echo ##vso[task.setVariable variable=ENV_ARTIFACT_NAME]!ENV_ARTIFACT_NAME!
@@ -176,6 +192,13 @@ if defined ENV_ARTIFACT_PREFIX (
                 echo ENV_ARTIFACT_NAME=!ENV_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
                 echo ENV_ARTIFACT_PATH=!ENV_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
             )
+        ) else (
+            echo No archive created
         )
+    ) else (
+        echo Skipping environment artifact archive because of no files
     )
+) else (
+    echo Skipping environment artifact archive
 )
+echo.

--- a/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
@@ -20,6 +20,18 @@ rem BLD_ARTIFACT_PATH
 rem ENV_ARTIFACT_NAME
 rem ENV_ARTIFACT_PATH
 
+{%- if conda_install_tool == "pixi" %}
+set "PATH=%USERPROFILE%\.pixi\bin;%PATH%"
+set "ACTIVATE_PIXI=%TMP%\pixi-activate-%RANDOM%.bat"
+pixi shell-hook --environment build > "%ACTIVATE_PIXI%"
+if !errorlevel! neq 0 exit /b !errorlevel!
+call "%ACTIVATE_PIXI%"
+if !errorlevel! neq 0 exit /b !errorlevel!
+{%- else %}
+call "%MINIFORGE_HOME%\Scripts\activate.bat"
+if !errorlevel! neq 0 exit /b !errorlevel!
+{%- endif %}
+
 rem Check that the conda-build directory exists
 if not exist %CONDA_BLD_PATH% (
     echo conda-build directory does not exist
@@ -37,13 +49,47 @@ if not "%ARTIFACT_UNIQUE_ID%" == "%ARTIFACT_UNIQUE_ID:~0,80%" (
     set ARTIFACT_UNIQUE_ID=%CI_RUN_ID%_%CONFIG_SHORT%
 )
 
-rem Make the build artifact zip
+rem --use-compress-prog hangs on Azure, but we can use bsdtar unconditionally.
+set "ZSTD=--zstd --options=zstd:compression-level=12,zstd:threads=0"
+
+rem Mirror the logic from create_conda_build_artifacts.sh.tmpl.
+rem Note that paths to tar must use forward slashes.
+
+cd "%CONDA_BLD_PATH%"
+if errorlevel 1 exit 1
+
+set ENVIRONMENT_PATHS=
+set "EXCLUDE_COMMON=--exclude=.git --exclude=./pkg_cache --exclude=./src_cache"
+set EXCLUDE_FROM_BUILD_ARTIFACTS=
+
+for /d %%a in (. bld test) do (
+    if exist %%a (
+        cd %%a
+        for /d %%b in (*_*) do (
+            if exist %%a\%%b\pip_cache (
+                set "EXCLUDE_COMMON=!EXCLUDE_COMMON! --exclude=%%a/%%b/pip_cache"
+            )
+
+            cd %%b
+            for /d %%c in (*_env* *_prefix_moved_*) do (
+                set "ENVIRONMENT_PATHS=!ENVIRONMENT_PATHS! %%a/%%b/%%c"
+                set "EXCLUDE_FROM_BUILD_ARTIFACTS=!EXCLUDE_FROM_BUILD_ARTIFACTS! --exclude=%%a/%%b/%%c"
+            )
+            cd ..
+        )
+        if not %%a == . cd ..
+    )
+)
+
+set "EXCLUDE_FROM_BUILD_ARTIFACTS=%EXCLUDE_COMMON%%EXCLUDE_FROM_BUILD_ARTIFACTS%"
+
+rem Make the build artifact archive
 if defined BLD_ARTIFACT_PREFIX (
     set BLD_ARTIFACT_NAME=%BLD_ARTIFACT_PREFIX%_%ARTIFACT_UNIQUE_ID%
     echo BLD_ARTIFACT_NAME: !BLD_ARTIFACT_NAME!
 
-    set "BLD_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%BLD_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.zip"
-    7z a "!BLD_ARTIFACT_PATH!" "%CONDA_BLD_PATH%" -xr^^!.git/ -xr^^!_*_env*/ -xr^^!*_cache/ -bb
+    set "BLD_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%BLD_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.tar.zst"
+    bsdtar -c -f "!BLD_ARTIFACT_PATH!" %ZSTD% %EXCLUDE_FROM_BUILD_ARTIFACTS% .
     if errorlevel 1 exit 1
     echo BLD_ARTIFACT_PATH: !BLD_ARTIFACT_PATH!
 
@@ -57,13 +103,13 @@ if defined BLD_ARTIFACT_PREFIX (
     )
 )
 
-rem Make the environments artifact zip
+rem Make the environment artifact archive
 if defined ENV_ARTIFACT_PREFIX (
     set ENV_ARTIFACT_NAME=!ENV_ARTIFACT_PREFIX!_%ARTIFACT_UNIQUE_ID%
     echo ENV_ARTIFACT_NAME: !ENV_ARTIFACT_NAME!
 
-    set "ENV_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%ENV_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.zip"
-    7z a "!ENV_ARTIFACT_PATH!" -r "%CONDA_BLD_PATH%"/_*_env*/ -bb
+    set "ENV_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%ENV_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.tar.zst"
+    bsdtar -c -f "!ENV_ARTIFACT_PATH!" %ZSTD% %ENVIRONMENT_PATHS%
     if errorlevel 1 exit 1
     echo ENV_ARTIFACT_PATH: !ENV_ARTIFACT_PATH!
 

--- a/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
@@ -114,40 +114,44 @@ if defined BLD_ARTIFACT_PREFIX (
 
 rem Make the work directory artifact archive
 if defined WRK_ARTIFACT_PREFIX (
-    set WRK_ARTIFACT_NAME=!WRK_ARTIFACT_PREFIX!_%ARTIFACT_UNIQUE_ID%
-    echo WRK_ARTIFACT_NAME: !WRK_ARTIFACT_NAME!
+    if not "%WORK_PATHS%" == "" (
+        set WRK_ARTIFACT_NAME=!WRK_ARTIFACT_PREFIX!_%ARTIFACT_UNIQUE_ID%
+        echo WRK_ARTIFACT_NAME: !WRK_ARTIFACT_NAME!
 
-    set "WRK_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%WRK_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.tar.zst"
-    bsdtar -c -f "!WRK_ARTIFACT_PATH!" %ZSTD% %EXCLUDE_FROM_WORK% %WORK_PATHS%
-    if errorlevel 1 exit 1
-    echo WRK_ARTIFACT_PATH: !WRK_ARTIFACT_PATH!
+        set "WRK_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%WRK_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.tar.zst"
+        bsdtar -c -f "!WRK_ARTIFACT_PATH!" %ZSTD% %EXCLUDE_FROM_WORK% %WORK_PATHS%
+        if errorlevel 1 exit 1
+        echo WRK_ARTIFACT_PATH: !WRK_ARTIFACT_PATH!
 
-    if "%CI%" == "azure" (
-        echo ##vso[task.setVariable variable=WRK_ARTIFACT_NAME]!WRK_ARTIFACT_NAME!
-        echo ##vso[task.setVariable variable=WRK_ARTIFACT_PATH]!WRK_ARTIFACT_PATH!
-    )
-    if "%CI%" == "github_actions" (
-        echo WRK_ARTIFACT_NAME=!WRK_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
-        echo WRK_ARTIFACT_PATH=!WRK_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
+        if "%CI%" == "azure" (
+            echo ##vso[task.setVariable variable=WRK_ARTIFACT_NAME]!WRK_ARTIFACT_NAME!
+            echo ##vso[task.setVariable variable=WRK_ARTIFACT_PATH]!WRK_ARTIFACT_PATH!
+        )
+        if "%CI%" == "github_actions" (
+            echo WRK_ARTIFACT_NAME=!WRK_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
+            echo WRK_ARTIFACT_PATH=!WRK_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
+        )
     )
 )
 
 rem Make the environment artifact archive
 if defined ENV_ARTIFACT_PREFIX (
-    set ENV_ARTIFACT_NAME=!ENV_ARTIFACT_PREFIX!_%ARTIFACT_UNIQUE_ID%
-    echo ENV_ARTIFACT_NAME: !ENV_ARTIFACT_NAME!
+    if not "%ENVIRONMENT_PATHS%" == "" (
+        set ENV_ARTIFACT_NAME=!ENV_ARTIFACT_PREFIX!_%ARTIFACT_UNIQUE_ID%
+        echo ENV_ARTIFACT_NAME: !ENV_ARTIFACT_NAME!
 
-    set "ENV_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%ENV_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.tar.zst"
-    bsdtar -c -f "!ENV_ARTIFACT_PATH!" %ZSTD% %ENVIRONMENT_PATHS%
-    if errorlevel 1 exit 1
-    echo ENV_ARTIFACT_PATH: !ENV_ARTIFACT_PATH!
+        set "ENV_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%ENV_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.tar.zst"
+        bsdtar -c -f "!ENV_ARTIFACT_PATH!" %ZSTD% %ENVIRONMENT_PATHS%
+        if errorlevel 1 exit 1
+        echo ENV_ARTIFACT_PATH: !ENV_ARTIFACT_PATH!
 
-    if "%CI%" == "azure" (
-        echo ##vso[task.setVariable variable=ENV_ARTIFACT_NAME]!ENV_ARTIFACT_NAME!
-        echo ##vso[task.setVariable variable=ENV_ARTIFACT_PATH]!ENV_ARTIFACT_PATH!
-    )
-    if "%CI%" == "github_actions" (
-        echo ENV_ARTIFACT_NAME=!ENV_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
-        echo ENV_ARTIFACT_PATH=!ENV_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
+        if "%CI%" == "azure" (
+            echo ##vso[task.setVariable variable=ENV_ARTIFACT_NAME]!ENV_ARTIFACT_NAME!
+            echo ##vso[task.setVariable variable=ENV_ARTIFACT_PATH]!ENV_ARTIFACT_PATH!
+        )
+        if "%CI%" == "github_actions" (
+            echo ENV_ARTIFACT_NAME=!ENV_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
+            echo ENV_ARTIFACT_PATH=!ENV_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
+        )
     )
 )

--- a/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.bat.tmpl
@@ -99,16 +99,24 @@ if defined BLD_ARTIFACT_PREFIX (
 
     set "BLD_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%BLD_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.tar.zst"
     bsdtar -c -f "!BLD_ARTIFACT_PATH!" %ZSTD% %EXCLUDE_FROM_BUILD_ARTIFACTS% .
-    if errorlevel 1 exit 1
-    echo BLD_ARTIFACT_PATH: !BLD_ARTIFACT_PATH!
-
-    if "%CI%" == "azure" (
-        echo ##vso[task.setVariable variable=BLD_ARTIFACT_NAME]!BLD_ARTIFACT_NAME!
-        echo ##vso[task.setVariable variable=BLD_ARTIFACT_PATH]!BLD_ARTIFACT_PATH!
+    if errorlevel 1 (
+        if exist "!BLD_ARTIFACT_PATH!" (
+            move "!BLD_ARTIFACT_PATH!" "!BLD_ARTIFACT_PATH:.tar.zst=-broken.tar.zst!"
+            set "BLD_ARTIFACT_PATH=!BLD_ARTIFACT_PATH:.tar.zst=-broken.tar.zst!"
+        )
     )
-    if "%CI%" == "github_actions" (
-        echo BLD_ARTIFACT_NAME=!BLD_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
-        echo BLD_ARTIFACT_PATH=!BLD_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
+
+    if exist "!BLD_ARTIFACT_PATH!" (
+        echo BLD_ARTIFACT_PATH: !BLD_ARTIFACT_PATH!
+
+        if "%CI%" == "azure" (
+            echo ##vso[task.setVariable variable=BLD_ARTIFACT_NAME]!BLD_ARTIFACT_NAME!
+            echo ##vso[task.setVariable variable=BLD_ARTIFACT_PATH]!BLD_ARTIFACT_PATH!
+        )
+        if "%CI%" == "github_actions" (
+            echo BLD_ARTIFACT_NAME=!BLD_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
+            echo BLD_ARTIFACT_PATH=!BLD_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
+        )
     )
 )
 
@@ -120,16 +128,24 @@ if defined WRK_ARTIFACT_PREFIX (
 
         set "WRK_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%WRK_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.tar.zst"
         bsdtar -c -f "!WRK_ARTIFACT_PATH!" %ZSTD% %EXCLUDE_FROM_WORK% %WORK_PATHS%
-        if errorlevel 1 exit 1
-        echo WRK_ARTIFACT_PATH: !WRK_ARTIFACT_PATH!
-
-        if "%CI%" == "azure" (
-            echo ##vso[task.setVariable variable=WRK_ARTIFACT_NAME]!WRK_ARTIFACT_NAME!
-            echo ##vso[task.setVariable variable=WRK_ARTIFACT_PATH]!WRK_ARTIFACT_PATH!
+        if errorlevel 1 (
+            if exist "!WRK_ARTIFACT_PATH!" (
+                move "!WRK_ARTIFACT_PATH!" "!WRK_ARTIFACT_PATH:.tar.zst=-broken.tar.zst!"
+                set "WRK_ARTIFACT_PATH=!WRK_ARTIFACT_PATH:.tar.zst=-broken.tar.zst!"
+            )
         )
-        if "%CI%" == "github_actions" (
-            echo WRK_ARTIFACT_NAME=!WRK_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
-            echo WRK_ARTIFACT_PATH=!WRK_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
+
+        if exist "!WRK_ARTIFACT_PATH!" (
+            echo WRK_ARTIFACT_PATH: !WRK_ARTIFACT_PATH!
+
+            if "%CI%" == "azure" (
+                echo ##vso[task.setVariable variable=WRK_ARTIFACT_NAME]!WRK_ARTIFACT_NAME!
+                echo ##vso[task.setVariable variable=WRK_ARTIFACT_PATH]!WRK_ARTIFACT_PATH!
+            )
+            if "%CI%" == "github_actions" (
+                echo WRK_ARTIFACT_NAME=!WRK_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
+                echo WRK_ARTIFACT_PATH=!WRK_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
+            )
         )
     )
 )
@@ -142,16 +158,24 @@ if defined ENV_ARTIFACT_PREFIX (
 
         set "ENV_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%ENV_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.tar.zst"
         bsdtar -c -f "!ENV_ARTIFACT_PATH!" %ZSTD% %ENVIRONMENT_PATHS%
-        if errorlevel 1 exit 1
-        echo ENV_ARTIFACT_PATH: !ENV_ARTIFACT_PATH!
-
-        if "%CI%" == "azure" (
-            echo ##vso[task.setVariable variable=ENV_ARTIFACT_NAME]!ENV_ARTIFACT_NAME!
-            echo ##vso[task.setVariable variable=ENV_ARTIFACT_PATH]!ENV_ARTIFACT_PATH!
+        if errorlevel 1 (
+            if exist "!ENV_ARTIFACT_PATH!" (
+                move "!ENV_ARTIFACT_PATH!" "!ENV_ARTIFACT_PATH:.tar.zst=-broken.tar.zst!"
+                set "ENV_ARTIFACT_PATH=!ENV_ARTIFACT_PATH:.tar.zst=-broken.tar.zst!"
+            )
         )
-        if "%CI%" == "github_actions" (
-            echo ENV_ARTIFACT_NAME=!ENV_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
-            echo ENV_ARTIFACT_PATH=!ENV_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
+
+        if exist "!ENV_ARTIFACT_PATH!" (
+            echo ENV_ARTIFACT_PATH: !ENV_ARTIFACT_PATH!
+
+            if "%CI%" == "azure" (
+                echo ##vso[task.setVariable variable=ENV_ARTIFACT_NAME]!ENV_ARTIFACT_NAME!
+                echo ##vso[task.setVariable variable=ENV_ARTIFACT_PATH]!ENV_ARTIFACT_PATH!
+            )
+            if "%CI%" == "github_actions" (
+                echo ENV_ARTIFACT_NAME=!ENV_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
+                echo ENV_ARTIFACT_PATH=!ENV_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
+            )
         )
     )
 )

--- a/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
@@ -26,6 +26,19 @@ source .scripts/logging_utils.sh
 # and that might end up inserting extraneous quotation marks in output variables
 set -e
 
+# mangle_homebrew hides zstd on GHA macos 15 runners, so use conda-forge tools
+{%- if conda_install_tool == "pixi" %}
+if [[ -d ~/.pixi/bin ]]; then
+    export PATH="~/.pixi/bin:$PATH"
+    eval "$(pixi shell-hook --environment build)"
+fi
+{%- else %}
+if [[ -d ${MINIFORGE_HOME} ]]; then
+    . "${MINIFORGE_HOME}/etc/profile.d/conda.sh"
+    conda activate
+fi
+{%- endif %}
+
 # Check that the conda-build directory exists
 if [ ! -d "$CONDA_BLD_PATH" ]; then
     echo "conda-build directory does not exist"

--- a/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
@@ -120,6 +120,7 @@ EXCLUDE_FROM_WORK=(
 
 # Make the build artifact archive
 if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
+    echo "Creating build artifact archive ..."
     export BLD_ARTIFACT_NAME="${BLD_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
     export BLD_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${BLD_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.tar.zst"
 
@@ -136,8 +137,8 @@ if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
     fi
 
     if [[ -s ${BLD_ARTIFACT_PATH} ]]; then
-        echo "BLD_ARTIFACT_NAME: $BLD_ARTIFACT_NAME"
-        echo "BLD_ARTIFACT_PATH: $BLD_ARTIFACT_PATH"
+        echo "Archive created:"
+        ls -l -h "${BLD_ARTIFACT_PATH}"
 
         if [[ "$CI" == "azure" ]]; then
             echo "##vso[task.setVariable variable=BLD_ARTIFACT_NAME]$BLD_ARTIFACT_NAME"
@@ -146,11 +147,17 @@ if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
             echo "BLD_ARTIFACT_NAME=$BLD_ARTIFACT_NAME" >> $GITHUB_OUTPUT
             echo "BLD_ARTIFACT_PATH=$BLD_ARTIFACT_PATH" >> $GITHUB_OUTPUT
         fi
+    else
+        echo "No archive created"
     fi
+else
+    echo "Skipping build artifact archive"
 fi
+echo
 
 # Make the workdir artifact archive
 if [[ ! -z "$WRK_ARTIFACT_PREFIX" && -n ${WORK_PATHS[@]} ]]; then
+    echo "Creating work directory archive ..."
     export WRK_ARTIFACT_NAME="${WRK_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
     export WRK_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${WRK_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.tar.zst"
 
@@ -167,8 +174,8 @@ if [[ ! -z "$WRK_ARTIFACT_PREFIX" && -n ${WORK_PATHS[@]} ]]; then
     fi
 
     if [[ -s ${WRK_ARTIFACT_PATH} ]]; then
-        echo "WRK_ARTIFACT_NAME: $WRK_ARTIFACT_NAME"
-        echo "WRK_ARTIFACT_PATH: $WRK_ARTIFACT_PATH"
+        echo "Archive created:"
+        ls -l -h "${WRK_ARTIFACT_PATH}"
 
         if [[ "$CI" == "azure" ]]; then
             echo "##vso[task.setVariable variable=WRK_ARTIFACT_NAME]$WRK_ARTIFACT_NAME"
@@ -177,11 +184,17 @@ if [[ ! -z "$WRK_ARTIFACT_PREFIX" && -n ${WORK_PATHS[@]} ]]; then
             echo "WRK_ARTIFACT_NAME=$WRK_ARTIFACT_NAME" >> $GITHUB_OUTPUT
             echo "WRK_ARTIFACT_PATH=$WRK_ARTIFACT_PATH" >> $GITHUB_OUTPUT
         fi
+    else
+        echo "No archive created"
     fi
+else
+    echo "Skipping work directory artifact archive"
 fi
+echo
 
 # Make the environments artifact archive
 if [[ ! -z "$ENV_ARTIFACT_PREFIX" && -n ${ENVIRONMENT_PATHS[@]} ]]; then
+    echo "Creating build environment artifact archive ..."
     export ENV_ARTIFACT_NAME="${ENV_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
     export ENV_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${ENV_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.tar.zst"
 
@@ -195,8 +208,8 @@ if [[ ! -z "$ENV_ARTIFACT_PREFIX" && -n ${ENVIRONMENT_PATHS[@]} ]]; then
     fi
 
     if [[ -s ${ENV_ARTIFACT_PATH} ]]; then
-        echo "ENV_ARTIFACT_NAME: $ENV_ARTIFACT_NAME"
-        echo "ENV_ARTIFACT_PATH: $ENV_ARTIFACT_PATH"
+        echo "Archive created:"
+        ls -l -h "${ENV_ARTIFACT_PATH}"
 
         if [[ "$CI" == "azure" ]]; then
             echo "##vso[task.setVariable variable=ENV_ARTIFACT_NAME]$ENV_ARTIFACT_NAME"
@@ -205,7 +218,12 @@ if [[ ! -z "$ENV_ARTIFACT_PREFIX" && -n ${ENVIRONMENT_PATHS[@]} ]]; then
             echo "ENV_ARTIFACT_NAME=$ENV_ARTIFACT_NAME" >> $GITHUB_OUTPUT
             echo "ENV_ARTIFACT_PATH=$ENV_ARTIFACT_PATH" >> $GITHUB_OUTPUT
         fi
+    else
+        echo "No archive created"
     fi
+else
+    echo "Skipping environment artifact archive"
 fi
+echo
 
 popd

--- a/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
@@ -12,6 +12,7 @@
 # ARTIFACT_STAGING_DIR (use working directory if unset)
 # BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
 # ENV_ARTIFACT_PREFIX (prefix for the conda build environments artifact name, skip if unset)
+# WRK_ARTIFACT_PREFIX (prefix for the conda build work artifact name, skip if unset)
 
 # OUTPUTS
 #
@@ -19,6 +20,8 @@
 # BLD_ARTIFACT_PATH
 # ENV_ARTIFACT_NAME
 # ENV_ARTIFACT_PATH
+# WRK_ARTIFACT_NAME
+# WRK_ARTIFACT_PATH
 
 source .scripts/logging_utils.sh
 
@@ -90,12 +93,29 @@ ENVIRONMENT_PATHS=(
     ./bld/*_*/*_env*
     ./test/test_*/test_env
 )
-EXCLUDE_FROM_BUILD_ARTIFACTS=(
-    "${ENVIRONMENT_PATHS[@]}"
+WORK_PATHS=(
+    # conda-build
+    ./*_*
 
+    # rattler-build
+    ./bld/*
+    ./test/*
+)
+EXCLUDE_COMMON=(
+    .git
+
+    # caches
     ./pkg_cache
     ./src_cache
     ./*_*/pip_cache
+)
+EXCLUDE_FROM_BUILD_ARTIFACTS=(
+    "${EXCLUDE_COMMON[@]}"
+    "${WORK_PATHS[@]}"
+)
+EXCLUDE_FROM_WORK=(
+    "${EXCLUDE_COMMON[@]}"
+    "${ENVIRONMENT_PATHS[@]}"
 )
 
 # Make the build artifact archive
@@ -106,7 +126,7 @@ if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
     # All our CI services have either GNU tar or bsdtar, and zstd.
     # Keep the command compatible with both!
     tar -c -f "${BLD_ARTIFACT_PATH}" "${ZSTD}" \
-        --exclude='.git' "${EXCLUDE_FROM_BUILD_ARTIFACTS[@]/#/--exclude=}" .
+        "${EXCLUDE_FROM_BUILD_ARTIFACTS[@]/#/--exclude=}" .
 
     echo "BLD_ARTIFACT_NAME: $BLD_ARTIFACT_NAME"
     echo "BLD_ARTIFACT_PATH: $BLD_ARTIFACT_PATH"
@@ -117,6 +137,28 @@ if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
     elif [[ "$CI" == "github_actions" ]]; then
         echo "BLD_ARTIFACT_NAME=$BLD_ARTIFACT_NAME" >> $GITHUB_OUTPUT
         echo "BLD_ARTIFACT_PATH=$BLD_ARTIFACT_PATH" >> $GITHUB_OUTPUT
+    fi
+fi
+
+# Make the workdir artifact archive
+if [[ ! -z "$WRK_ARTIFACT_PREFIX" ]]; then
+    export WRK_ARTIFACT_NAME="${WRK_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+    export WRK_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${WRK_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.tar.zst"
+
+    # All our CI services have either GNU tar or bsdtar, and zstd.
+    # Keep the command compatible with both!
+    tar -c -f "${WRK_ARTIFACT_PATH}" "${ZSTD}" \
+        "${EXCLUDE_FROM_WORK[@]/#/--exclude=}" "${WORK_PATHS[@]}"
+
+    echo "WRK_ARTIFACT_NAME: $WRK_ARTIFACT_NAME"
+    echo "WRK_ARTIFACT_PATH: $WRK_ARTIFACT_PATH"
+
+    if [[ "$CI" == "azure" ]]; then
+        echo "##vso[task.setVariable variable=WRK_ARTIFACT_NAME]$WRK_ARTIFACT_NAME"
+        echo "##vso[task.setVariable variable=WRK_ARTIFACT_PATH]$WRK_ARTIFACT_PATH"
+    elif [[ "$CI" == "github_actions" ]]; then
+        echo "WRK_ARTIFACT_NAME=$WRK_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+        echo "WRK_ARTIFACT_PATH=$WRK_ARTIFACT_PATH" >> $GITHUB_OUTPUT
     fi
 fi
 

--- a/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
@@ -57,21 +57,22 @@ echo "ARTIFACT_UNIQUE_ID: $ARTIFACT_UNIQUE_ID"
 # Set a descriptive ID for the archive(s), specialized for this particular job run
 ARCHIVE_UNIQUE_ID="${CI_RUN_ID}_${CONFIG}"
 
-# Make the build artifact zip
+pushd "${CONDA_BLD_PATH}"
+
+# --use-compress-prog= lets us pass the options to GNU tar and libarchive tar
+# -T0 uses all cores
+# 12 gives reasonable compression while remaining fast
+ZSTD="--use-compress-prog=zstd -T0 -12"
+
+# Make the build artifact archive
 if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
     export BLD_ARTIFACT_NAME="${BLD_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
-    export BLD_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${BLD_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.zip"
+    export BLD_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${BLD_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.tar.zst"
 
-    ( startgroup "Archive conda build directory" ) 2> /dev/null
-
-    # Try 7z and fall back to zip if it fails (for cross-platform use)
-    if ! 7z a "$BLD_ARTIFACT_PATH" "$CONDA_BLD_PATH" '-xr!.git/' '-xr!_*_env*/' '-xr!*_cache/' -bb; then
-        pushd "$CONDA_BLD_PATH"
-        zip -r -y -T "$BLD_ARTIFACT_PATH" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
-        popd
-    fi
-
-    ( endgroup "Archive conda build directory" ) 2> /dev/null
+    # All our CI services have either GNU tar or bsdtar, and zstd.
+    # Keep the command compatible with both!
+    tar -c -f "${BLD_ARTIFACT_PATH}" "${ZSTD}" \
+        --exclude='.git' --exclude='_*_env*' --exclude='*_cache' .
 
     echo "BLD_ARTIFACT_NAME: $BLD_ARTIFACT_NAME"
     echo "BLD_ARTIFACT_PATH: $BLD_ARTIFACT_PATH"
@@ -85,21 +86,12 @@ if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
     fi
 fi
 
-# Make the environments artifact zip
+# Make the environments artifact archive
 if [[ ! -z "$ENV_ARTIFACT_PREFIX" ]]; then
     export ENV_ARTIFACT_NAME="${ENV_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
-    export ENV_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${ENV_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.zip"
+    export ENV_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${ENV_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.tar.zst"
 
-    ( startgroup "Archive conda build environments" ) 2> /dev/null
-
-    # Try 7z and fall back to zip if it fails (for cross-platform use)
-    if ! 7z a "$ENV_ARTIFACT_PATH" -r "$CONDA_BLD_PATH"/'_*_env*/' -bb; then
-        pushd "$CONDA_BLD_PATH"
-        zip -r -y -T "$ENV_ARTIFACT_PATH" . -i '*_*_env*/*'
-        popd
-    fi
-
-    ( endgroup "Archive conda build environments" ) 2> /dev/null
+    tar -c -f "${ENV_ARTIFACT_PATH}" "${ZSTD}" $(find -name '*_*_env*' -prune)
 
     echo "ENV_ARTIFACT_NAME: $ENV_ARTIFACT_NAME"
     echo "ENV_ARTIFACT_PATH: $ENV_ARTIFACT_PATH"
@@ -112,3 +104,5 @@ if [[ ! -z "$ENV_ARTIFACT_PREFIX" ]]; then
         echo "ENV_ARTIFACT_PATH=$ENV_ARTIFACT_PATH" >> $GITHUB_OUTPUT
     fi
 fi
+
+popd

--- a/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
@@ -77,6 +77,27 @@ pushd "${CONDA_BLD_PATH}"
 # 12 gives reasonable compression while remaining fast
 ZSTD="--use-compress-prog=zstd -T0 -12"
 
+# Pattern matching can be quite overzealous, so rather than passing wildcards,
+# we want to expand them into actual paths first.
+shopt -s nullglob
+ENVIRONMENT_PATHS=(
+    # note: always include "./", so that only top-level paths match
+    # conda-build
+    ./*_*/*_env*
+    ./*_*/*_prefix_moved_*
+
+    # rattler-build
+    ./bld/*_*/*_env*
+    ./test/test_*/test_env
+)
+EXCLUDE_FROM_BUILD_ARTIFACTS=(
+    "${ENVIRONMENT_PATHS[@]}"
+
+    ./pkg_cache
+    ./src_cache
+    ./*_*/pip_cache
+)
+
 # Make the build artifact archive
 if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
     export BLD_ARTIFACT_NAME="${BLD_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
@@ -85,7 +106,7 @@ if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
     # All our CI services have either GNU tar or bsdtar, and zstd.
     # Keep the command compatible with both!
     tar -c -f "${BLD_ARTIFACT_PATH}" "${ZSTD}" \
-        --exclude='.git' --exclude='_*_env*' --exclude='*_cache' .
+        --exclude='.git' "${EXCLUDE_FROM_BUILD_ARTIFACTS[@]/#/--exclude=}" .
 
     echo "BLD_ARTIFACT_NAME: $BLD_ARTIFACT_NAME"
     echo "BLD_ARTIFACT_PATH: $BLD_ARTIFACT_PATH"
@@ -104,7 +125,7 @@ if [[ ! -z "$ENV_ARTIFACT_PREFIX" ]]; then
     export ENV_ARTIFACT_NAME="${ENV_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
     export ENV_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${ENV_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.tar.zst"
 
-    tar -c -f "${ENV_ARTIFACT_PATH}" "${ZSTD}" $(find -name '*_*_env*' -prune)
+    tar -c -f "${ENV_ARTIFACT_PATH}" "${ZSTD}" "${ENVIRONMENT_PATHS[@]}"
 
     echo "ENV_ARTIFACT_NAME: $ENV_ARTIFACT_NAME"
     echo "ENV_ARTIFACT_PATH: $ENV_ARTIFACT_PATH"

--- a/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
@@ -125,18 +125,27 @@ if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
 
     # All our CI services have either GNU tar or bsdtar, and zstd.
     # Keep the command compatible with both!
-    tar -c -f "${BLD_ARTIFACT_PATH}" "${ZSTD}" \
-        "${EXCLUDE_FROM_BUILD_ARTIFACTS[@]/#/--exclude=}" .
+    if ! tar -c -f "${BLD_ARTIFACT_PATH}" "${ZSTD}" \
+            "${EXCLUDE_FROM_BUILD_ARTIFACTS[@]/#/--exclude=}" . &&
+        [[ -s ${BLD_ARTIFACT_PATH} ]]
+    then
+        # If tar failed but produced a (partial?) file, upload it as "broken".
+        mv -v "${BLD_ARTIFACT_PATH}" "${BLD_ARTIFACT_PATH/%.tar.zst/-broken&}"
+        BLD_ARTIFACT_NAME+=-broken
+        BLD_ARTIFACT_PATH=${BLD_ARTIFACT_PATH/%.tar.zst/-broken&}
+    fi
 
-    echo "BLD_ARTIFACT_NAME: $BLD_ARTIFACT_NAME"
-    echo "BLD_ARTIFACT_PATH: $BLD_ARTIFACT_PATH"
+    if [[ -s ${BLD_ARTIFACT_PATH} ]]; then
+        echo "BLD_ARTIFACT_NAME: $BLD_ARTIFACT_NAME"
+        echo "BLD_ARTIFACT_PATH: $BLD_ARTIFACT_PATH"
 
-    if [[ "$CI" == "azure" ]]; then
-        echo "##vso[task.setVariable variable=BLD_ARTIFACT_NAME]$BLD_ARTIFACT_NAME"
-        echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_PATH"
-    elif [[ "$CI" == "github_actions" ]]; then
-        echo "BLD_ARTIFACT_NAME=$BLD_ARTIFACT_NAME" >> $GITHUB_OUTPUT
-        echo "BLD_ARTIFACT_PATH=$BLD_ARTIFACT_PATH" >> $GITHUB_OUTPUT
+        if [[ "$CI" == "azure" ]]; then
+            echo "##vso[task.setVariable variable=BLD_ARTIFACT_NAME]$BLD_ARTIFACT_NAME"
+            echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_PATH"
+        elif [[ "$CI" == "github_actions" ]]; then
+            echo "BLD_ARTIFACT_NAME=$BLD_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+            echo "BLD_ARTIFACT_PATH=$BLD_ARTIFACT_PATH" >> $GITHUB_OUTPUT
+        fi
     fi
 fi
 
@@ -147,18 +156,27 @@ if [[ ! -z "$WRK_ARTIFACT_PREFIX" && -n ${WORK_PATHS[@]} ]]; then
 
     # All our CI services have either GNU tar or bsdtar, and zstd.
     # Keep the command compatible with both!
-    tar -c -f "${WRK_ARTIFACT_PATH}" "${ZSTD}" \
-        "${EXCLUDE_FROM_WORK[@]/#/--exclude=}" "${WORK_PATHS[@]}"
+    if ! tar -c -f "${WRK_ARTIFACT_PATH}" "${ZSTD}" \
+            "${EXCLUDE_FROM_WORK[@]/#/--exclude=}" "${WORK_PATHS[@]}" &&
+        [[ -s ${WRK_ARTIFACT_PATH} ]]
+    then
+        # If tar failed but produced a (partial?) file, upload it as "broken".
+        mv -v "${WRK_ARTIFACT_PATH}" "${WRK_ARTIFACT_PATH/%.tar.zst/-broken&}"
+        WRK_ARTIFACT_NAME+=-broken
+        WRK_ARTIFACT_PATH=${WRK_ARTIFACT_PATH/%.tar.zst/-broken&}
+    fi
 
-    echo "WRK_ARTIFACT_NAME: $WRK_ARTIFACT_NAME"
-    echo "WRK_ARTIFACT_PATH: $WRK_ARTIFACT_PATH"
+    if [[ -s ${WRK_ARTIFACT_PATH} ]]; then
+        echo "WRK_ARTIFACT_NAME: $WRK_ARTIFACT_NAME"
+        echo "WRK_ARTIFACT_PATH: $WRK_ARTIFACT_PATH"
 
-    if [[ "$CI" == "azure" ]]; then
-        echo "##vso[task.setVariable variable=WRK_ARTIFACT_NAME]$WRK_ARTIFACT_NAME"
-        echo "##vso[task.setVariable variable=WRK_ARTIFACT_PATH]$WRK_ARTIFACT_PATH"
-    elif [[ "$CI" == "github_actions" ]]; then
-        echo "WRK_ARTIFACT_NAME=$WRK_ARTIFACT_NAME" >> $GITHUB_OUTPUT
-        echo "WRK_ARTIFACT_PATH=$WRK_ARTIFACT_PATH" >> $GITHUB_OUTPUT
+        if [[ "$CI" == "azure" ]]; then
+            echo "##vso[task.setVariable variable=WRK_ARTIFACT_NAME]$WRK_ARTIFACT_NAME"
+            echo "##vso[task.setVariable variable=WRK_ARTIFACT_PATH]$WRK_ARTIFACT_PATH"
+        elif [[ "$CI" == "github_actions" ]]; then
+            echo "WRK_ARTIFACT_NAME=$WRK_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+            echo "WRK_ARTIFACT_PATH=$WRK_ARTIFACT_PATH" >> $GITHUB_OUTPUT
+        fi
     fi
 fi
 
@@ -167,17 +185,26 @@ if [[ ! -z "$ENV_ARTIFACT_PREFIX" && -n ${ENVIRONMENT_PATHS[@]} ]]; then
     export ENV_ARTIFACT_NAME="${ENV_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
     export ENV_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${ENV_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.tar.zst"
 
-    tar -c -f "${ENV_ARTIFACT_PATH}" "${ZSTD}" "${ENVIRONMENT_PATHS[@]}"
+    if ! tar -c -f "${ENV_ARTIFACT_PATH}" "${ZSTD}" "${ENVIRONMENT_PATHS[@]}" &&
+        [[ -s ${ENV_ARTIFACT_PATH} ]]
+    then
+        # If tar failed but produced a (partial?) file, upload it as "broken".
+        mv -v "${ENV_ARTIFACT_PATH}" "${ENV_ARTIFACT_PATH/%.tar.zst/-broken&}"
+        ENV_ARTIFACT_NAME+=-broken
+        ENV_ARTIFACT_PATH=${ENV_ARTIFACT_PATH/%.tar.zst/-broken&}
+    fi
 
-    echo "ENV_ARTIFACT_NAME: $ENV_ARTIFACT_NAME"
-    echo "ENV_ARTIFACT_PATH: $ENV_ARTIFACT_PATH"
+    if [[ -s ${ENV_ARTIFACT_PATH} ]]; then
+        echo "ENV_ARTIFACT_NAME: $ENV_ARTIFACT_NAME"
+        echo "ENV_ARTIFACT_PATH: $ENV_ARTIFACT_PATH"
 
-    if [[ "$CI" == "azure" ]]; then
-        echo "##vso[task.setVariable variable=ENV_ARTIFACT_NAME]$ENV_ARTIFACT_NAME"
-        echo "##vso[task.setVariable variable=ENV_ARTIFACT_PATH]$ENV_ARTIFACT_PATH"
-    elif [[ "$CI" == "github_actions" ]]; then
-        echo "ENV_ARTIFACT_NAME=$ENV_ARTIFACT_NAME" >> $GITHUB_OUTPUT
-        echo "ENV_ARTIFACT_PATH=$ENV_ARTIFACT_PATH" >> $GITHUB_OUTPUT
+        if [[ "$CI" == "azure" ]]; then
+            echo "##vso[task.setVariable variable=ENV_ARTIFACT_NAME]$ENV_ARTIFACT_NAME"
+            echo "##vso[task.setVariable variable=ENV_ARTIFACT_PATH]$ENV_ARTIFACT_PATH"
+        elif [[ "$CI" == "github_actions" ]]; then
+            echo "ENV_ARTIFACT_NAME=$ENV_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+            echo "ENV_ARTIFACT_PATH=$ENV_ARTIFACT_PATH" >> $GITHUB_OUTPUT
+        fi
     fi
 fi
 

--- a/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
+++ b/conda_smithy/templates/create_conda_build_artifacts.sh.tmpl
@@ -141,7 +141,7 @@ if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
 fi
 
 # Make the workdir artifact archive
-if [[ ! -z "$WRK_ARTIFACT_PREFIX" ]]; then
+if [[ ! -z "$WRK_ARTIFACT_PREFIX" && -n ${WORK_PATHS[@]} ]]; then
     export WRK_ARTIFACT_NAME="${WRK_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
     export WRK_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${WRK_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.tar.zst"
 
@@ -163,7 +163,7 @@ if [[ ! -z "$WRK_ARTIFACT_PREFIX" ]]; then
 fi
 
 # Make the environments artifact archive
-if [[ ! -z "$ENV_ARTIFACT_PREFIX" ]]; then
+if [[ ! -z "$ENV_ARTIFACT_PREFIX" && -n ${ENVIRONMENT_PATHS[@]} ]]; then
     export ENV_ARTIFACT_NAME="${ENV_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
     export ENV_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${ENV_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.tar.zst"
 

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -301,6 +301,7 @@ jobs:
         if [ $JOB_STATUS == "failure" ]; then
           export BLD_ARTIFACT_PREFIX="conda_pkgs_failed"
           export ENV_ARTIFACT_PREFIX="conda_envs"
+          export WRK_ARTIFACT_PREFIX="conda_work"
         else
           export BLD_ARTIFACT_PREFIX="conda_pkgs"
         fi
@@ -316,6 +317,16 @@ jobs:
       with:
         name: {% raw %}${{ steps.prepare-artifacts.outputs.BLD_ARTIFACT_NAME }}{% endraw %}
         path: {% raw %}${{ steps.prepare-artifacts.outputs.BLD_ARTIFACT_PATH }}{% endraw %}
+        retention-days: {{ github_actions.artifact_retention_days }}
+        archive: false
+      continue-on-error: true
+
+    - name: Store conda work directory artifacts
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      if: {% raw %}${{ always() && steps.determine-status.outputs.status == 'failure' && steps.prepare-artifacts.outcome == 'success' }}{% endraw %}
+      with:
+        name: {% raw %}${{ steps.prepare-artifacts.outputs.WRK_ARTIFACT_NAME }}{% endraw %}
+        path: {% raw %}${{ steps.prepare-artifacts.outputs.WRK_ARTIFACT_PATH }}{% endraw %}
         retention-days: {{ github_actions.artifact_retention_days }}
         archive: false
       continue-on-error: true

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -286,6 +286,7 @@ jobs:
         CONFIG: {% raw %}${{ matrix.CONFIG }}{% endraw %}
         CONFIG_SHORT: {% raw %}${{ matrix.CONFIG_SHORT }}{% endraw %}
         JOB_STATUS: {% raw %}${{ steps.determine-status.outputs.status }}{% endraw %}
+        MINIFORGE_HOME: {% raw %}${{ matrix.tools_install_dir }}{% endraw %}
         OS: {% raw %}${{ matrix.os }}{% endraw %}
       run: |
         export ARTIFACT_STAGING_DIR="$GITHUB_WORKSPACE"

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -316,6 +316,7 @@ jobs:
         name: {% raw %}${{ steps.prepare-artifacts.outputs.BLD_ARTIFACT_NAME }}{% endraw %}
         path: {% raw %}${{ steps.prepare-artifacts.outputs.BLD_ARTIFACT_PATH }}{% endraw %}
         retention-days: {{ github_actions.artifact_retention_days }}
+        archive: false
       continue-on-error: true
 
     - name: Store conda build environment artifacts
@@ -326,5 +327,6 @@ jobs:
         name: {% raw %}${{ steps.prepare-artifacts.outputs.ENV_ARTIFACT_NAME }}{% endraw %}
         path: {% raw %}${{ steps.prepare-artifacts.outputs.ENV_ARTIFACT_PATH }}{% endraw %}
         retention-days: {{ github_actions.artifact_retention_days }}
+        archive: false
       continue-on-error: true
 {%- endif %}

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -313,7 +313,7 @@ jobs:
 
     - name: Store conda build artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      if: {% raw %}${{ always() && steps.prepare-artifacts.outcome == 'success' }}{% endraw %}
+      if: {% raw %}${{ always() && steps.prepare-artifacts.outcome == 'success' && steps.prepare-artifacts.outputs.BLD_ARTIFACT_PATH != '' }}{% endraw %}
       with:
         name: {% raw %}${{ steps.prepare-artifacts.outputs.BLD_ARTIFACT_NAME }}{% endraw %}
         path: {% raw %}${{ steps.prepare-artifacts.outputs.BLD_ARTIFACT_PATH }}{% endraw %}
@@ -323,7 +323,7 @@ jobs:
 
     - name: Store conda work directory artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      if: {% raw %}${{ always() && steps.determine-status.outputs.status == 'failure' && steps.prepare-artifacts.outcome == 'success' }}{% endraw %}
+      if: {% raw %}${{ always() && steps.prepare-artifacts.outcome == 'success' && steps.prepare-artifacts.outputs.WRK_ARTIFACT_PATH != '' }}{% endraw %}
       with:
         name: {% raw %}${{ steps.prepare-artifacts.outputs.WRK_ARTIFACT_NAME }}{% endraw %}
         path: {% raw %}${{ steps.prepare-artifacts.outputs.WRK_ARTIFACT_PATH }}{% endraw %}
@@ -334,7 +334,7 @@ jobs:
     - name: Store conda build environment artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       # only relevant if build failed, see above
-      if: {% raw %}${{ always() && steps.determine-status.outputs.status == 'failure' && steps.prepare-artifacts.outcome == 'success' }}{% endraw %}
+      if: {% raw %}${{ always() && steps.prepare-artifacts.outcome == 'success' && steps.prepare-artifacts.outputs.ENV_ARTIFACT_PATH != '' }}{% endraw %}
       with:
         name: {% raw %}${{ steps.prepare-artifacts.outputs.ENV_ARTIFACT_NAME }}{% endraw %}
         path: {% raw %}${{ steps.prepare-artifacts.outputs.ENV_ARTIFACT_PATH }}{% endraw %}

--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -299,7 +299,7 @@ jobs:
         # Use different prefix for successful and failed build artifacts
         # so random failures don't prevent rebuilds from creating artifacts.
         if [ $JOB_STATUS == "failure" ]; then
-          export BLD_ARTIFACT_PREFIX="conda_artifacts"
+          export BLD_ARTIFACT_PREFIX="conda_pkgs_failed"
           export ENV_ARTIFACT_PREFIX="conda_envs"
         else
           export BLD_ARTIFACT_PREFIX="conda_pkgs"

--- a/news/artifact-changes-2365.rst
+++ b/news/artifact-changes-2365.rst
@@ -6,6 +6,7 @@
 
 * Artifacts on GitHub Actions are no longer packed into a second zip archive. (#2365)
 * Build and environment artifacts are now uploaded in ``.tar.zst`` format. (#2365)
+* The naming for artifacts from successful and failed builds is more consistent. (#2365)
 
 **Deprecated:**
 

--- a/news/artifact-changes-2365.rst
+++ b/news/artifact-changes-2365.rst
@@ -5,7 +5,7 @@
 **Changed:**
 
 * Artifacts on GitHub Actions are no longer packed into a second zip archive. (#2365)
-* Build and environment artifacts are now uploaded in ``.tar.zst`` format on Unix. (#2365)
+* Build and environment artifacts are now uploaded in ``.tar.zst`` format. (#2365)
 
 **Deprecated:**
 

--- a/news/artifact-changes-2365.rst
+++ b/news/artifact-changes-2365.rst
@@ -21,6 +21,7 @@
 
 * The exclude patterns for artifact uploads no longer accidentally exclude files from work trees. (#2365)
 * Build artifacts and environments are now correctly split when using rattler-build. (#2365)
+* Build artifact creation no longer fails if one of the archives would end up empty, for example when the workflow failed on artifact validation. (#2365)
 
 **Security:**
 

--- a/news/artifact-changes-2365.rst
+++ b/news/artifact-changes-2365.rst
@@ -8,6 +8,7 @@
 * Build and environment artifacts are now uploaded in ``.tar.zst`` format. (#2365)
 * The naming for artifacts from successful and failed builds is more consistent. (#2365)
 * Build artifacts and the work directory are now archived separately when ``store_build_artifacts`` is enabled. (#2365)
+* Partially created build artifacts are uploaded, with an explicit ``-broken`` suffix, for example when some files can't be read. (#2365)
 
 **Deprecated:**
 

--- a/news/artifact-changes-2365.rst
+++ b/news/artifact-changes-2365.rst
@@ -7,6 +7,7 @@
 * Artifacts on GitHub Actions are no longer packed into a second zip archive. (#2365)
 * Build and environment artifacts are now uploaded in ``.tar.zst`` format. (#2365)
 * The naming for artifacts from successful and failed builds is more consistent. (#2365)
+* Build artifacts and the work directory are now archived separately when ``store_build_artifacts`` is enabled. (#2365)
 
 **Deprecated:**
 

--- a/news/artifact-changes-2365.rst
+++ b/news/artifact-changes-2365.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Artifacts on GitHub Actions are no longer packed into a second zip archive. (#2365)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/artifact-changes-2365.rst
+++ b/news/artifact-changes-2365.rst
@@ -17,7 +17,8 @@
 
 **Fixed:**
 
-* <news item>
+* The exclude patterns for artifact uploads no longer accidentally exclude files from work trees. (#2365)
+* Build artifacts and environments are now correctly split when using rattler-build. (#2365)
 
 **Security:**
 

--- a/news/artifact-changes-2365.rst
+++ b/news/artifact-changes-2365.rst
@@ -5,6 +5,7 @@
 **Changed:**
 
 * Artifacts on GitHub Actions are no longer packed into a second zip archive. (#2365)
+* Build and environment artifacts are now uploaded in ``.tar.zst`` format on Unix. (#2365)
 
 **Deprecated:**
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [x] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #2365

<!--
Please add any other relevant info below:
-->
Changes so far:
- [x] disable creating the outer .zip archive for GHA artifacts
- [x] change the archive format to .tar.zst
- [x] fix exclude/include patterns to be less greedy and account for rattler-build better
- [x] split `work` directory from built artifacts?
- [x] extend the above to Windows
- [x] handle (partial) archive creation failures gracefully