### PR TITLE
Use `GITHUB_REF_NAME` simpler for upload checks

### DIFF
--- a/conda_smithy/templates/github-actions.yml.tmpl
+++ b/conda_smithy/templates/github-actions.yml.tmpl
@@ -142,7 +142,7 @@ jobs:
       run: |
         export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export GIT_BRANCH="${GITHUB_REF_NAME}"
         export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
@@ -175,7 +175,7 @@ jobs:
       run: |
         export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export GIT_BRANCH="${GITHUB_REF_NAME}"
         export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -205,7 +205,7 @@ call :end_group
 :: Prepare some environment variables for the upload step
 if /i "%CI%" == "github_actions" (
     set "FEEDSTOCK_NAME=%GITHUB_REPOSITORY:*/=%"
-    set "GIT_BRANCH=%GITHUB_REF:refs/heads/=%"
+    set "GIT_BRANCH=%GITHUB_REF_NAME%"
     if /i "%GITHUB_EVENT_NAME%" == "pull_request" (
         set "IS_PR_BUILD=True"
     ) else (

--- a/news/2632-use_gh_ref_name_var_upld.rst
+++ b/news/2632-use_gh_ref_name_var_upld.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Use ``GITHUB_REF_NAME`` for simpler GHA upload branch checks. (#2632)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -466,7 +466,7 @@ def test_upload_on_branch_github_actions(upload_on_branch_recipe, jinja_env):
         if step["name"] == "Build on Linux"
     )
     assert linux_step["env"]["UPLOAD_ON_BRANCH"] == "foo-branch"
-    assert "$(basename $GITHUB_REF)" in linux_step["run"]
+    assert "${GITHUB_REF_NAME}" in linux_step["run"]
 
     macos_step = next(
         step
@@ -474,7 +474,7 @@ def test_upload_on_branch_github_actions(upload_on_branch_recipe, jinja_env):
         if step["name"] == "Build on macOS"
     )
     assert macos_step["env"]["UPLOAD_ON_BRANCH"] == "foo-branch"
-    assert "$(basename $GITHUB_REF)" in macos_step["run"]
+    assert "${GITHUB_REF_NAME}" in macos_step["run"]
 
     win_build_step = next(
         step
@@ -490,7 +490,7 @@ def test_upload_on_branch_github_actions(upload_on_branch_recipe, jinja_env):
         )
     ) as fp:
         build_script_win = fp.read()
-    assert r"%GITHUB_REF:refs/heads/=%" in build_script_win
+    assert r"%GITHUB_REF_NAME%" in build_script_win
 
 
 def test_upload_on_branch_appveyor(upload_on_branch_recipe, jinja_env):


### PR DESCRIPTION
As `GITHUB_REF_NAME` is the branch name when a `push` event occurs, there is no need to strip unrelated content from it to get the branch name. Instead it can be used as is to populate `GIT_BRANCH`.

Also when a pull request is involved, it is `PR#/merge`, which is not the upstream branch name. So it will also be correctly skipped when a PR is involved.

This also ensures that branch names with other characters like `/` are handled correctly, which `basename` would have missed.

<hr>

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
