### PR TITLE
Allow noarch to be null or jinja conditional

### DIFF
--- a/conda_smithy/data/linter-messages.json
+++ b/conda_smithy/data/linter-messages.json
@@ -466,7 +466,7 @@
       "kind": "lint",
       "added_in": "<3.56",
       "deprecated_in": "",
-      "documentation": "The `build.noarch` field can only take `python` or `generic` as a value.\nRecipe v1 also accepts `null`, `none`, `None` or `~` to leave `noarch` unset.",
+      "documentation": "The `build.noarch` field can only take `python` or `generic` as a value.\nRecipe v1 also accepts a jinja expression that renders to an empty value, none, \"null\" or \"~\" to leave `noarch` unset.\"",
       "message": "Invalid `noarch` value `${given}`. Should be one of `${valid}`.",
       "examples": [],
       "path": "recipe/(meta|recipe).yaml"

--- a/conda_smithy/data/linter-messages.json
+++ b/conda_smithy/data/linter-messages.json
@@ -466,7 +466,7 @@
       "kind": "lint",
       "added_in": "<3.56",
       "deprecated_in": "",
-      "documentation": "The `build.noarch` field can only take `python` or `generic` as a value.",
+      "documentation": "The `build.noarch` field can only take `python` or `generic` as a value.\nRecipe v1 also accepts `null`, `none`, `None` or `~` to leave `noarch` unset.",
       "message": "Invalid `noarch` value `${given}`. Should be one of `${valid}`.",
       "examples": [],
       "path": "recipe/(meta|recipe).yaml"

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -315,7 +315,7 @@ def lintify_meta_yaml(
 
     # 17: Validate noarch
     noarch_value = build_section.get("noarch")
-    lint_noarch(noarch_value, lints)
+    lint_noarch(noarch_value, lints, recipe_version, meta)
 
     # Interlude: load recipe config
     recipe_config_keys = _get_recipe_config_keys(recipe_dir)
@@ -331,6 +331,7 @@ def lintify_meta_yaml(
                 build_section,
                 noarch_platforms,
                 lints,
+                meta,
             )
         else:
             lint_noarch_and_runtime_dependencies(

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -297,8 +297,8 @@ def lint_subheaders(major_sections, meta, lints):
 def lint_noarch(
     noarch_value: Optional[str],
     lints,
-    recipe_version: msg.r.RECIPE_VERSIONS = 0,
-    meta: Optional[dict[str, Any]] = None,
+    recipe_version: msg.r.RECIPE_VERSIONS,
+    meta: dict[str, Any],
 ):
     if noarch_value is not None:
         if not msg.r.NoarchValue.is_valid(
@@ -322,8 +322,9 @@ def lint_recipe_v1_noarch_and_runtime_dependencies(
     lints: list[str],
     meta: Optional[dict[str, Any]] = None,
 ) -> None:
-    noarch_value = msg.r.NoarchValue.concrete_noarch_value(noarch_value, 1, meta)
-    if noarch_value:
+    # Only run this test if noarch_value is a literal
+    # Skip if it's a jinja conditional as it's expected to be not noarch depending on the context
+    if noarch_value in msg.r.NoarchValue.valid:
         conda_recipe_v1_linter.lint_usage_of_selectors_for_noarch(
             noarch_value,
             raw_requirements_section,

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -294,10 +294,24 @@ def lint_subheaders(major_sections, meta, lints):
                         )
 
 
-def lint_noarch(noarch_value: Optional[str], lints):
+def lint_noarch(
+    noarch_value: Optional[str],
+    lints,
+    recipe_version: msg.r.RECIPE_VERSIONS = 0,
+    meta: Optional[dict[str, Any]] = None,
+):
     if noarch_value is not None:
-        if noarch_value not in msg.r.NoarchValue.valid:
-            lints.append(msg.r.NoarchValue(given=noarch_value).as_string())
+        if not msg.r.NoarchValue.is_valid(
+            noarch_value,
+            recipe_version,
+            meta,
+        ):
+            lints.append(
+                msg.r.NoarchValue(
+                    given=noarch_value,
+                    recipe_version=recipe_version,
+                ).as_string()
+            )
 
 
 def lint_recipe_v1_noarch_and_runtime_dependencies(
@@ -306,7 +320,9 @@ def lint_recipe_v1_noarch_and_runtime_dependencies(
     build_section: dict[str, Any],
     noarch_platforms: bool,
     lints: list[str],
+    meta: Optional[dict[str, Any]] = None,
 ) -> None:
+    noarch_value = msg.r.NoarchValue.concrete_noarch_value(noarch_value, 1, meta)
     if noarch_value:
         conda_recipe_v1_linter.lint_usage_of_selectors_for_noarch(
             noarch_value,

--- a/conda_smithy/linter/messages/recipe.py
+++ b/conda_smithy/linter/messages/recipe.py
@@ -369,13 +369,18 @@ class SourceHash(LinterMessage, _AnyRecipeMessage):
 class NoarchValue(LinterMessage, _AnyRecipeMessage):
     """
     The `build.noarch` field can only take `python` or `generic` as a value.
-    Recipe v1 also accepts `null`, `none`, `None` or `~` to leave `noarch` unset.
+    Recipe v1 also accepts a jinja expression that renders to an empty value, none, "null" or "~" to leave `noarch` unset."
     """
 
     kind = "lint"
     identifier = "R-020"
     valid: ClassVar[list[str]] = ["python", "generic"]
-    valid_v1: ClassVar[list[str]] = [*valid, "null", "none", "None", "~"]
+    # Note that null and none literals are accepted by rattler-build, but not by the linter
+    # A jinja expression is required outside python and generic
+    valid_v1: ClassVar[list[str]] = [
+        *valid,
+        "a jinja expression that renders to an empty value, none, 'null' or '~'",
+    ]
     message = "Invalid `noarch` value `${given}`. Should be one of `${valid}`."
     given: str
     recipe_version: RECIPE_VERSIONS
@@ -395,7 +400,7 @@ class NoarchValue(LinterMessage, _AnyRecipeMessage):
     ) -> object | None:
         """
         Render the value when a jinja expression is given in v1 recipe
-        Return None if the expression can't be rendered - check ignored
+        Return the given input otherwise
         """
         from conda_smithy.linter import conda_recipe_v1_linter
 
@@ -404,17 +409,21 @@ class NoarchValue(LinterMessage, _AnyRecipeMessage):
             and isinstance(given, str)
             and conda_recipe_v1_linter.JINJA_VAR_PAT.search(given)
         ):
-            if meta is None:
-                # No context, can't render the jinja expression - skip
-                return None
-            given = render_recipe_with_context(meta).get("build", {}).get("noarch")
-            if given is None or (
-                isinstance(given, str)
-                and conda_recipe_v1_linter.JINJA_VAR_PAT.search(given)
-            ):
-                # expression rendered to unset/null
-                # or expression could not be resolved from known context
-                return None
+            # Note that render_recipe_with_context will treat undefined variables as False
+            # due to _MissingUndefined used in jinja_env
+            rendered_value = (
+                render_recipe_with_context(meta).get("build", {}).get("noarch")
+            )
+            # An expression that renders to an empty or null-like value (`none`, `null`,
+            # `~`, or the empty string) is treated the same as omitting the `noarch`
+            # key entirely by rattler-build.
+            # The linter allows:
+            # - empty string (no else) -> rendered as None
+            # - none or None -> rendered as "None"
+            # - "none" -> rendered as "none"
+            # - "null" -> rendered as None
+            #  - "~" -> rendered as None
+            return None if rendered_value in ("none", "None") else rendered_value
         return given
 
     @classmethod
@@ -422,22 +431,10 @@ class NoarchValue(LinterMessage, _AnyRecipeMessage):
         cls,
         given: object,
         recipe_version: RECIPE_VERSIONS,
-        meta: dict[str, Any] | None = None,
+        meta: dict[str, Any],
     ) -> bool:
         given = cls.rendered_value(given, recipe_version, meta)
-        return given is None or given in cls.valid_values(recipe_version)
-
-    @classmethod
-    def concrete_noarch_value(
-        cls,
-        given: object,
-        recipe_version: RECIPE_VERSIONS,
-        meta: dict[str, Any] | None = None,
-    ) -> str | None:
-        given = cls.rendered_value(given, recipe_version, meta)
-        if isinstance(given, str) and given in cls.valid:
-            return given
-        return None
+        return given is None or given in cls.valid
 
     def _render_attributes(self):
         return {

--- a/conda_smithy/linter/messages/recipe.py
+++ b/conda_smithy/linter/messages/recipe.py
@@ -3,9 +3,10 @@ Messages concerning recipe files (`meta.yaml`, `recipe.yaml`).
 """
 
 from dataclasses import asdict, dataclass
-from typing import ClassVar, Literal, Self, TypeAlias
+from typing import Any, ClassVar, Literal, Self, TypeAlias
 
 from conda.deprecations import deprecated
+from rattler_build_conda_compat.jinja.jinja import render_recipe_with_context
 
 from conda_smithy.linter.messages.base import LinterMessage
 
@@ -368,16 +369,81 @@ class SourceHash(LinterMessage, _AnyRecipeMessage):
 class NoarchValue(LinterMessage, _AnyRecipeMessage):
     """
     The `build.noarch` field can only take `python` or `generic` as a value.
+    Recipe v1 also accepts `null`, `none`, `None` or `~` to leave `noarch` unset.
     """
 
     kind = "lint"
     identifier = "R-020"
     valid: ClassVar[list[str]] = ["python", "generic"]
+    valid_v1: ClassVar[list[str]] = [*valid, "null", "none", "None", "~"]
     message = "Invalid `noarch` value `${given}`. Should be one of `${valid}`."
     given: str
+    recipe_version: RECIPE_VERSIONS
+
+    @classmethod
+    def valid_values(cls, recipe_version: RECIPE_VERSIONS) -> list[str]:
+        if recipe_version == 1:
+            return cls.valid_v1
+        return cls.valid
+
+    @classmethod
+    def rendered_value(
+        cls,
+        given: object,
+        recipe_version: RECIPE_VERSIONS,
+        meta: dict[str, Any] | None = None,
+    ) -> object | None:
+        """
+        Render the value when a jinja expression is given in v1 recipe
+        Return None if the expression can't be rendered - check ignored
+        """
+        from conda_smithy.linter import conda_recipe_v1_linter
+
+        if (
+            recipe_version == 1
+            and isinstance(given, str)
+            and conda_recipe_v1_linter.JINJA_VAR_PAT.search(given)
+        ):
+            if meta is None:
+                # No context, can't render the jinja expression - skip
+                return None
+            given = render_recipe_with_context(meta).get("build", {}).get("noarch")
+            if given is None or (
+                isinstance(given, str)
+                and conda_recipe_v1_linter.JINJA_VAR_PAT.search(given)
+            ):
+                # expression rendered to unset/null
+                # or expression could not be resolved from known context
+                return None
+        return given
+
+    @classmethod
+    def is_valid(
+        cls,
+        given: object,
+        recipe_version: RECIPE_VERSIONS,
+        meta: dict[str, Any] | None = None,
+    ) -> bool:
+        given = cls.rendered_value(given, recipe_version, meta)
+        return given is None or given in cls.valid_values(recipe_version)
+
+    @classmethod
+    def concrete_noarch_value(
+        cls,
+        given: object,
+        recipe_version: RECIPE_VERSIONS,
+        meta: dict[str, Any] | None = None,
+    ) -> str | None:
+        given = cls.rendered_value(given, recipe_version, meta)
+        if isinstance(given, str) and given in cls.valid:
+            return given
+        return None
 
     def _render_attributes(self):
-        return {"given": self.given, "valid": ", ".join(self.valid)}
+        return {
+            "given": self.given,
+            "valid": ", ".join(self.valid_values(self.recipe_version)),
+        }
 
 
 @dataclass(kw_only=True)

--- a/news/2425-v1-noarch-conditional.rst
+++ b/news/2425-v1-noarch-conditional.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed v1 recipe linting for conditional ``build.noarch`` values such as ``${{ "python" if use_noarch }}``. (#2425)
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -559,6 +559,57 @@ def test_lint_macdt(recipe_version, config_file):
         assert any(lint.startswith("The `MACOSX_DEPLOYMENT_TARGET`") for lint in lints)
 
 
+@pytest.mark.parametrize("recipe_version", [0, 1])
+def test_noarch_value(recipe_version):
+    meta = {"build": {"noarch": "true"}}
+    expected = "Invalid `noarch` value `true`. Should be one of"
+    lints, _ = linter.lintify_meta_yaml(meta, recipe_version=recipe_version)
+    assert any(lint.startswith(expected) for lint in lints)
+
+
+def test_noarch_value_recipe_v0_rejects_conditional():
+    meta = {"build": {"noarch": '{{ "python" if use_noarch }}'}}
+    expected = 'Invalid `noarch` value `{{ "python" if use_noarch }}`. Should be one of'
+    lints, _ = linter.lintify_meta_yaml(meta)
+    assert any(lint.startswith(expected) for lint in lints)
+
+
+def test_noarch_value_recipe_v1_allows_conditional_no_context():
+    meta = {"build": {"noarch": '${{ "python" if use_noarch }}'}}
+    unexpected_lint = "Invalid `noarch` value"
+    lints, _ = linter.lintify_meta_yaml(meta, recipe_version=1)
+    assert not any(lint.startswith(unexpected_lint) for lint in lints)
+
+
+@pytest.mark.parametrize("use_noarch", [True, False])
+def test_noarch_value_recipe_v1_allows_rendered_conditional(use_noarch):
+    unexpected_lint = "Invalid `noarch` value"
+    meta = {
+        "context": {"use_noarch": use_noarch},
+        "build": {"noarch": '${{ "python" if use_noarch }}'},
+    }
+    lints, _ = linter.lintify_meta_yaml(meta, recipe_version=1)
+    assert not any(lint.startswith(unexpected_lint) for lint in lints)
+
+
+def test_noarch_value_recipe_v1_rejects_invalid_rendered_conditional():
+    meta = {
+        "context": {"use_noarch": True},
+        "build": {"noarch": '${{ "banana" if use_noarch else null }}'},
+    }
+    expected = "Invalid `noarch` value"
+    lints, _ = linter.lintify_meta_yaml(meta, recipe_version=1)
+    assert any(lint.startswith(expected) for lint in lints)
+
+
+@pytest.mark.parametrize("noarch_value", ("null", "None", "none", "~"))
+def test_noarch_value_recipe_v1_allows_null_value(noarch_value):
+    unexpected_lint = "Invalid `noarch` value"
+    meta = {"build": {"noarch": noarch_value}}
+    lints, _ = linter.lintify_meta_yaml(meta, recipe_version=1)
+    assert not any(lint.startswith(unexpected_lint) for lint in lints)
+
+
 class TestLinter(unittest.TestCase):
     def test_bad_top_level(self):
         meta = OrderedDict([["package", {}], ["build", {}], ["sources", {}]])
@@ -644,53 +695,6 @@ class TestLinter(unittest.TestCase):
 
         expected_message = "The summary item is expected in the about section."
         self.assertIn(expected_message, lints)
-
-    def test_noarch_value(self):
-        meta = {"build": {"noarch": "true"}}
-        expected = "Invalid `noarch` value `true`. Should be one of"
-        for recipe_version in (0, 1):
-            lints, hints = linter.lintify_meta_yaml(meta, recipe_version=recipe_version)
-            self.assertTrue(any(lint.startswith(expected) for lint in lints))
-
-    def test_noarch_value_recipe_v0_rejects_conditional(self):
-        meta = {"build": {"noarch": '{{ "python" if use_noarch }}'}}
-        expected = (
-            'Invalid `noarch` value `{{ "python" if use_noarch }}`. Should be one of'
-        )
-        lints, _ = linter.lintify_meta_yaml(meta)
-        self.assertTrue(any(lint.startswith(expected) for lint in lints))
-
-    def test_noarch_value_recipe_v1_allows_conditional_no_context(self):
-        meta = {"build": {"noarch": '${{ "python" if use_noarch }}'}}
-        unexpected_lint = "Invalid `noarch` value"
-        lints, hints = linter.lintify_meta_yaml(meta, recipe_version=1)
-        self.assertFalse(any(lint.startswith(unexpected_lint) for lint in lints))
-
-    def test_noarch_value_recipe_v1_allows_rendered_conditional(self):
-        unexpected_lint = "Invalid `noarch` value"
-        for use_noarch in (True, False):
-            meta = {
-                "context": {"use_noarch": use_noarch},
-                "build": {"noarch": '${{ "python" if use_noarch }}'},
-            }
-            lints, hints = linter.lintify_meta_yaml(meta, recipe_version=1)
-            self.assertFalse(any(lint.startswith(unexpected_lint) for lint in lints))
-
-    def test_noarch_value_recipe_v1_rejects_invalid_rendered_conditional(self):
-        meta = {
-            "context": {"use_noarch": True},
-            "build": {"noarch": '${{ "banana" if use_noarch else null }}'},
-        }
-        expected = "Invalid `noarch` value"
-        lints, hints = linter.lintify_meta_yaml(meta, recipe_version=1)
-        self.assertTrue(any(lint.startswith(expected) for lint in lints))
-
-    def test_noarch_value_recipe_v1_allows_null_value(self):
-        unexpected_lint = "Invalid `noarch` value"
-        for noarch_value in ("null", "None", "none", "~"):
-            meta = {"build": {"noarch": noarch_value}}
-            lints, hints = linter.lintify_meta_yaml(meta, recipe_version=1)
-            self.assertFalse(any(lint.startswith(unexpected_lint) for lint in lints))
 
     def test_maintainers_section(self):
         expected_message = (

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -648,8 +648,9 @@ class TestLinter(unittest.TestCase):
     def test_noarch_value(self):
         meta = {"build": {"noarch": "true"}}
         expected = "Invalid `noarch` value `true`. Should be one of"
-        lints, hints = linter.lintify_meta_yaml(meta)
-        self.assertTrue(any(lint.startswith(expected) for lint in lints))
+        for recipe_version in (0, 1):
+            lints, hints = linter.lintify_meta_yaml(meta, recipe_version=recipe_version)
+            self.assertTrue(any(lint.startswith(expected) for lint in lints))
 
     def test_noarch_value_recipe_v0_rejects_conditional(self):
         meta = {"build": {"noarch": '{{ "python" if use_noarch }}'}}

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -559,12 +559,22 @@ def test_lint_macdt(recipe_version, config_file):
         assert any(lint.startswith("The `MACOSX_DEPLOYMENT_TARGET`") for lint in lints)
 
 
+@pytest.mark.parametrize("noarch_value", [True, "true", "foo", "null", "none"])
 @pytest.mark.parametrize("recipe_version", [0, 1])
-def test_noarch_value(recipe_version):
-    meta = {"build": {"noarch": "true"}}
-    expected = "Invalid `noarch` value `true`. Should be one of"
+def test_noarch_value_invalid(recipe_version, noarch_value):
+    meta = {"build": {"noarch": noarch_value}}
+    expected = f"Invalid `noarch` value `{noarch_value}`. Should be one of"
     lints, _ = linter.lintify_meta_yaml(meta, recipe_version=recipe_version)
     assert any(lint.startswith(expected) for lint in lints)
+
+
+@pytest.mark.parametrize("noarch_value", ["python", "generic"])
+@pytest.mark.parametrize("recipe_version", [0, 1])
+def test_noarch_value_valid(recipe_version, noarch_value):
+    meta = {"build": {"noarch": noarch_value}}
+    unexpected_lint = "Invalid `noarch` value"
+    lints, _ = linter.lintify_meta_yaml(meta, recipe_version=recipe_version)
+    assert not any(lint.startswith(unexpected_lint) for lint in lints)
 
 
 def test_noarch_value_recipe_v0_rejects_conditional():
@@ -575,14 +585,41 @@ def test_noarch_value_recipe_v0_rejects_conditional():
 
 
 def test_noarch_value_recipe_v1_allows_conditional_no_context():
-    meta = {"build": {"noarch": '${{ "python" if use_noarch }}'}}
+    # unknown variables are rendered as False by render_recipe_with_context
+    meta = {"build": {"noarch": '${{ "python" if unknown_var }}'}}
     unexpected_lint = "Invalid `noarch` value"
     lints, _ = linter.lintify_meta_yaml(meta, recipe_version=1)
     assert not any(lint.startswith(unexpected_lint) for lint in lints)
 
 
 @pytest.mark.parametrize("use_noarch", [True, False])
-def test_noarch_value_recipe_v1_allows_rendered_conditional(use_noarch):
+@pytest.mark.parametrize("value", ["~", "null", "none", None])
+def test_noarch_value_recipe_v1_allows_rendered_conditional(use_noarch, value):
+    unexpected_lint = "Invalid `noarch` value"
+    meta = {
+        "context": {"use_noarch": use_noarch},
+        "build": {"noarch": f'${{{{ "python" if use_noarch else "{value}" }}}}'},
+    }
+    lints, _ = linter.lintify_meta_yaml(meta, recipe_version=1)
+    assert not any(lint.startswith(unexpected_lint) for lint in lints)
+
+
+@pytest.mark.parametrize("use_noarch", [True, False])
+@pytest.mark.parametrize("value", ["none", None])
+def test_noarch_value_recipe_v1_allows_rendered_conditional_value_not_quoted(
+    use_noarch, value
+):
+    unexpected_lint = "Invalid `noarch` value"
+    meta = {
+        "context": {"use_noarch": use_noarch},
+        "build": {"noarch": f'${{{{ "python" if use_noarch else {value} }}}}'},
+    }
+    lints, _ = linter.lintify_meta_yaml(meta, recipe_version=1)
+    assert not any(lint.startswith(unexpected_lint) for lint in lints)
+
+
+@pytest.mark.parametrize("use_noarch", [True, False])
+def test_noarch_value_recipe_v1_allows_rendered_conditional_no_else(use_noarch):
     unexpected_lint = "Invalid `noarch` value"
     meta = {
         "context": {"use_noarch": use_noarch},
@@ -595,19 +632,11 @@ def test_noarch_value_recipe_v1_allows_rendered_conditional(use_noarch):
 def test_noarch_value_recipe_v1_rejects_invalid_rendered_conditional():
     meta = {
         "context": {"use_noarch": True},
-        "build": {"noarch": '${{ "banana" if use_noarch else null }}'},
+        "build": {"noarch": '${{ "banana" if use_noarch else none }}'},
     }
-    expected = "Invalid `noarch` value"
+    expected = 'Invalid `noarch` value `${{ "banana" if use_noarch else none }}`. Should be one of'
     lints, _ = linter.lintify_meta_yaml(meta, recipe_version=1)
     assert any(lint.startswith(expected) for lint in lints)
-
-
-@pytest.mark.parametrize("noarch_value", ("null", "None", "none", "~"))
-def test_noarch_value_recipe_v1_allows_null_value(noarch_value):
-    unexpected_lint = "Invalid `noarch` value"
-    meta = {"build": {"noarch": noarch_value}}
-    lints, _ = linter.lintify_meta_yaml(meta, recipe_version=1)
-    assert not any(lint.startswith(unexpected_lint) for lint in lints)
 
 
 class TestLinter(unittest.TestCase):

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -651,6 +651,14 @@ class TestLinter(unittest.TestCase):
         lints, hints = linter.lintify_meta_yaml(meta)
         self.assertTrue(any(lint.startswith(expected) for lint in lints))
 
+    def test_noarch_value_recipe_v0_rejects_conditional(self):
+        meta = {"build": {"noarch": '{{ "python" if use_noarch }}'}}
+        expected = (
+            'Invalid `noarch` value `{{ "python" if use_noarch }}`. Should be one of'
+        )
+        lints, _ = linter.lintify_meta_yaml(meta)
+        self.assertTrue(any(lint.startswith(expected) for lint in lints))
+
     def test_recipe_v1_noarch_value_allows_conditional_no_context(self):
         meta = {"build": {"noarch": '${{ "python" if use_noarch }}'}}
         unexpected_lint = "Invalid `noarch` value"

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -651,6 +651,38 @@ class TestLinter(unittest.TestCase):
         lints, hints = linter.lintify_meta_yaml(meta)
         self.assertTrue(any(lint.startswith(expected) for lint in lints))
 
+    def test_recipe_v1_noarch_value_allows_conditional_no_context(self):
+        meta = {"build": {"noarch": '${{ "python" if use_noarch }}'}}
+        expected = "Invalid `noarch` value"
+        lints, hints = linter.lintify_meta_yaml(meta, recipe_version=1)
+        self.assertFalse(any(lint.startswith(expected) for lint in lints))
+
+    def test_recipe_v1_noarch_value_allows_rendered_conditional(self):
+        expected = "Invalid `noarch` value"
+        for use_noarch in (True, False):
+            meta = {
+                "context": {"use_noarch": use_noarch},
+                "build": {"noarch": '${{ "python" if use_noarch }}'},
+            }
+            lints, hints = linter.lintify_meta_yaml(meta, recipe_version=1)
+            self.assertFalse(any(lint.startswith(expected) for lint in lints))
+
+    def test_recipe_v1_noarch_value_rejects_invalid_rendered_conditional(self):
+        meta = {
+            "context": {"use_noarch": True},
+            "build": {"noarch": '${{ "banana" if use_noarch else null }}'},
+        }
+        expected = "Invalid `noarch` value"
+        lints, hints = linter.lintify_meta_yaml(meta, recipe_version=1)
+        self.assertTrue(any(lint.startswith(expected) for lint in lints))
+
+    def test_recipe_v1_noarch_value_allows_null_value(self):
+        expected = "Invalid `noarch` value"
+        for noarch_value in ("null", "None", "none", "~"):
+            meta = {"build": {"noarch": noarch_value}}
+            lints, hints = linter.lintify_meta_yaml(meta, recipe_version=1)
+            self.assertFalse(any(lint.startswith(expected) for lint in lints))
+
     def test_maintainers_section(self):
         expected_message = (
             "The recipe could do with some maintainers listed "
@@ -1310,6 +1342,22 @@ linter:
                             """,
                 is_good=True,
                 has_noarch=True,
+            )
+            assert_noarch_selector(
+                """
+                            build:
+                              noarch: ${{ "python" if use_noarch }}
+                            requirements:
+                              host:
+                                - if: use_noarch
+                                  then: python ${{ python_min }}.*
+                                  else: python
+                              run:
+                                - if: use_noarch
+                                  then: python >=${{ python_min }}
+                                  else: python
+                            """,
+                is_good=True,
             )
             assert_noarch_selector("""
                             build:

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -659,13 +659,13 @@ class TestLinter(unittest.TestCase):
         lints, _ = linter.lintify_meta_yaml(meta)
         self.assertTrue(any(lint.startswith(expected) for lint in lints))
 
-    def test_recipe_v1_noarch_value_allows_conditional_no_context(self):
+    def test_noarch_value_recipe_v1_allows_conditional_no_context(self):
         meta = {"build": {"noarch": '${{ "python" if use_noarch }}'}}
         unexpected_lint = "Invalid `noarch` value"
         lints, hints = linter.lintify_meta_yaml(meta, recipe_version=1)
         self.assertFalse(any(lint.startswith(unexpected_lint) for lint in lints))
 
-    def test_recipe_v1_noarch_value_allows_rendered_conditional(self):
+    def test_noarch_value_recipe_v1_allows_rendered_conditional(self):
         unexpected_lint = "Invalid `noarch` value"
         for use_noarch in (True, False):
             meta = {
@@ -675,7 +675,7 @@ class TestLinter(unittest.TestCase):
             lints, hints = linter.lintify_meta_yaml(meta, recipe_version=1)
             self.assertFalse(any(lint.startswith(unexpected_lint) for lint in lints))
 
-    def test_recipe_v1_noarch_value_rejects_invalid_rendered_conditional(self):
+    def test_noarch_value_recipe_v1_rejects_invalid_rendered_conditional(self):
         meta = {
             "context": {"use_noarch": True},
             "build": {"noarch": '${{ "banana" if use_noarch else null }}'},
@@ -684,7 +684,7 @@ class TestLinter(unittest.TestCase):
         lints, hints = linter.lintify_meta_yaml(meta, recipe_version=1)
         self.assertTrue(any(lint.startswith(expected) for lint in lints))
 
-    def test_recipe_v1_noarch_value_allows_null_value(self):
+    def test_noarch_value_recipe_v1_allows_null_value(self):
         unexpected_lint = "Invalid `noarch` value"
         for noarch_value in ("null", "None", "none", "~"):
             meta = {"build": {"noarch": noarch_value}}

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -653,19 +653,19 @@ class TestLinter(unittest.TestCase):
 
     def test_recipe_v1_noarch_value_allows_conditional_no_context(self):
         meta = {"build": {"noarch": '${{ "python" if use_noarch }}'}}
-        expected = "Invalid `noarch` value"
+        unexpected_lint = "Invalid `noarch` value"
         lints, hints = linter.lintify_meta_yaml(meta, recipe_version=1)
-        self.assertFalse(any(lint.startswith(expected) for lint in lints))
+        self.assertFalse(any(lint.startswith(unexpected_lint) for lint in lints))
 
     def test_recipe_v1_noarch_value_allows_rendered_conditional(self):
-        expected = "Invalid `noarch` value"
+        unexpected_lint = "Invalid `noarch` value"
         for use_noarch in (True, False):
             meta = {
                 "context": {"use_noarch": use_noarch},
                 "build": {"noarch": '${{ "python" if use_noarch }}'},
             }
             lints, hints = linter.lintify_meta_yaml(meta, recipe_version=1)
-            self.assertFalse(any(lint.startswith(expected) for lint in lints))
+            self.assertFalse(any(lint.startswith(unexpected_lint) for lint in lints))
 
     def test_recipe_v1_noarch_value_rejects_invalid_rendered_conditional(self):
         meta = {
@@ -677,11 +677,11 @@ class TestLinter(unittest.TestCase):
         self.assertTrue(any(lint.startswith(expected) for lint in lints))
 
     def test_recipe_v1_noarch_value_allows_null_value(self):
-        expected = "Invalid `noarch` value"
+        unexpected_lint = "Invalid `noarch` value"
         for noarch_value in ("null", "None", "none", "~"):
             meta = {"build": {"noarch": noarch_value}}
             lints, hints = linter.lintify_meta_yaml(meta, recipe_version=1)
-            self.assertFalse(any(lint.startswith(expected) for lint in lints))
+            self.assertFalse(any(lint.startswith(unexpected_lint) for lint in lints))
 
     def test_maintainers_section(self):
         expected_message = (


### PR DESCRIPTION


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [X] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [X] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fix #2425

<!--
Please add any other relevant info below:
-->

Since rattler-build [0.69.0](https://github.com/prefix-dev/rattler-build/blob/main/CHANGELOG.md#0690---2026-07-15), conditional can be used for `noarch`.  Empty/null-like noarch values are treated as absent.

See https://github.com/prefix-dev/rattler-build/pull/2626

