### PR TITLE
Pixi: pass environment to list on Linux

### DIFF
--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -49,7 +49,7 @@ if [[ "$arch" == "x86_64" ]]; then
   arch="64"
 fi
 {#- We patch the pixi.toml file to only solve for one platform, and to create a platform-specific
-environment identical to 'default'. Otherwise local usage might result in 'default' being clobbered
+environment identical to 'build'. Otherwise local usage might result in 'build' being clobbered
 by the OS-specific builds (e.g. running Docker Linux on macOS). #}
 sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
 echo "Creating environment"

--- a/conda_smithy/templates/build_steps.sh.tmpl
+++ b/conda_smithy/templates/build_steps.sh.tmpl
@@ -54,7 +54,7 @@ by the OS-specific builds (e.g. running Docker Linux on macOS). #}
 sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
 echo "Creating environment"
 PIXI_CACHE_DIR=/opt/conda pixi install --environment docker-build-linux-$arch
-pixi list
+pixi list --environment docker-build-linux-$arch
 echo "Activating environment"
 eval "$(pixi shell-hook --environment docker-build-linux-$arch)"
 mv pixi.toml.bak pixi.toml

--- a/conda_smithy/templates/run_osx_build.sh.tmpl
+++ b/conda_smithy/templates/run_osx_build.sh.tmpl
@@ -45,10 +45,10 @@ if [[ "$arch" == "x86_64" ]]; then
 fi
 sed -i.bak "s/platforms = .*/platforms = [\"osx-${arch}\"]/" pixi.toml
 echo "Creating environment"
-pixi install
-pixi list
+pixi install --environment build
+pixi list --environment build
 echo "Activating environment"
-eval "$(pixi shell-hook)"
+eval "$(pixi shell-hook --environment build)"
 mv pixi.toml.bak pixi.toml
 ( endgroup "Provisioning base env with pixi" ) 2> /dev/null
 {%- else %}

--- a/conda_smithy/templates/run_win_build.bat.tmpl
+++ b/conda_smithy/templates/run_win_build.bat.tmpl
@@ -74,12 +74,12 @@ powershell -NoProfile -ExecutionPolicy unrestricted -Command "(Get-Content pixi.
 :: Git on Windows needs to run post link scripts to properly set up SSL certificates
 pixi config set --global run-post-link-scripts insecure
 if !errorlevel! neq 0 exit /b !errorlevel!
-pixi install
+pixi install --environment build
 if !errorlevel! neq 0 exit /b !errorlevel!
-pixi list
+pixi list --environment build
 if !errorlevel! neq 0 exit /b !errorlevel!
 set "ACTIVATE_PIXI=%TMP%\pixi-activate-%RANDOM%.bat"
-pixi shell-hook > "%ACTIVATE_PIXI%"
+pixi shell-hook --environment build > "%ACTIVATE_PIXI%"
 if !errorlevel! neq 0 exit /b !errorlevel!
 call "%ACTIVATE_PIXI%"
 if !errorlevel! neq 0 exit /b !errorlevel!

--- a/news/rattler-build-tasks-exec.rst
+++ b/news/rattler-build-tasks-exec.rst
@@ -5,6 +5,7 @@
 **Changed:**
 
 * Non-build ``pixi.toml`` tasks now rely on ``pixi exec`` instead of a workspace environment. (#2598)
+* The tooling environment in Pixi-enabled feedstocks is ``build`` now. ``default`` is empty. (#2598, #2644)
 
 **Deprecated:**
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Fix for regression in https://github.com/conda-forge/conda-smithy/pull/2598 observed at https://github.com/conda-forge/numpy-feedstock/pull/392. We need to pass `--environment <non-default>` explicitly.