### PR TITLE
Fix crash on unexpected v1 recipe sections and lint properly for them

### DIFF
--- a/conda_smithy/data/linter-messages.json
+++ b/conda_smithy/data/linter-messages.json
@@ -226,7 +226,7 @@
       "kind": "lint",
       "added_in": "<3.56",
       "deprecated_in": "",
-      "documentation": "Recipe files must not contain unknown top-level keys.\n\nFor recipe version 0, the allowed keys are (in this order):\n\n- `package`\n- `source`\n- `build`\n- `requirements`\n- `test`\n- `app`\n- `outputs`\n- `about`\n- `extra`\n\nFor recipe version 1, it depends if you are generating one or\nmultiple artifacts. For single artifacts, the expected keys are\n(in this order):\n\n- `schema_version`\n- `context`\n- `package`\n- `source`\n- `build`\n- `requirements`\n- `tests`\n- `about`\n- `extra`\n\nFor multiple artifacts, the expected keys are (in this order):\n\n- `schema_version`\n- `context`\n- `recipe`\n- `source`\n- `build`\n- `outputs`\n- `about`\n- `extra`",
+      "documentation": "Recipe files must not contain unknown top-level keys.\n\nFor recipe version 0, the allowed keys are (in this order):\n\n- `package`\n- `source`\n- `build`\n- `requirements`\n- `test`\n- `app`\n- `outputs`\n- `about`\n- `extra`\n\nFor recipe version 1, it depends if you are generating one or\nmultiple artifacts. For single artifacts, the expected keys are\n(in this order):\n\n- `schema_version`\n- `context`\n- `package`\n- `source`\n- `build`\n- `requirements`\n- `tests`\n- `about`\n- `extra`\n\nFor multiple artifacts, the expected keys are (in this order):\n\n- `schema_version`\n- `context`\n- `recipe`\n- `source`\n- `build`\n- `tests`\n- `outputs`\n- `about`\n- `extra`",
       "message": "The top level meta key ${section} is unexpected",
       "examples": [],
       "path": "recipe/(meta|recipe).yaml"

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -209,8 +209,9 @@ def lintify_meta_yaml(
         expected_keys = EXPECTED_SECTION_ORDER
     else:
         expected_keys = (
-            conda_recipe_v1_linter.EXPECTED_SINGLE_OUTPUT_SECTION_ORDER
-            + conda_recipe_v1_linter.EXPECTED_MULTIPLE_OUTPUT_SECTION_ORDER
+            conda_recipe_v1_linter.EXPECTED_MULTIPLE_OUTPUT_SECTION_ORDER
+            if "outputs" in major_sections
+            else conda_recipe_v1_linter.EXPECTED_SINGLE_OUTPUT_SECTION_ORDER
         )
 
     for section in major_sections:

--- a/conda_smithy/linter/conda_recipe_v1_linter.py
+++ b/conda_smithy/linter/conda_recipe_v1_linter.py
@@ -36,6 +36,7 @@ EXPECTED_MULTIPLE_OUTPUT_SECTION_ORDER = [
     "recipe",
     "source",
     "build",
+    "tests",
     "outputs",
     "about",
     "extra",

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -54,9 +54,10 @@ def lint_section_order(
             order = conda_recipe_v1_linter.EXPECTED_MULTIPLE_OUTPUT_SECTION_ORDER
         else:
             order = conda_recipe_v1_linter.EXPECTED_SINGLE_OUTPUT_SECTION_ORDER
-    section_order_sorted = sorted(major_sections, key=order.index)
+    known_sections = [x for x in major_sections if x in order]
+    section_order_sorted = sorted(known_sections, key=order.index)
 
-    if major_sections != section_order_sorted:
+    if known_sections != section_order_sorted:
         lints.append(msg.r.SectionOrder(order=section_order_sorted).as_string())
 
 

--- a/news/recipe-section-lint-2650.rst
+++ b/news/recipe-section-lint-2650.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* The linter now distinguishes between single-output and multi-output v1 recipes when reporting unknown keys. (#2650)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* The linter no longer crashes on unexpected sections. (#2650)
+* The top-level ``tests`` keys are permitted in multi-output v1 recipes. (#2650)
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -652,6 +652,20 @@ class TestLinter(unittest.TestCase):
         expected_msg = "The top level meta key sources is unexpected"
         self.assertIn(expected_msg, lints)
 
+    def test_recipe_v1_bad_top_level_single_output(self):
+        meta = OrderedDict([["recipe", {}], ["build", {}], ["source", {}]])
+        lints, hints = linter.lintify_meta_yaml(meta, recipe_version=1)
+        expected_msg = "The top level meta key recipe is unexpected"
+        self.assertIn(expected_msg, lints)
+
+    def test_recipe_v1_bad_top_level_multi_output(self):
+        meta = OrderedDict(
+            [["package", {}], ["build", {}], ["source", {}], ["outputs", []]]
+        )
+        lints, hints = linter.lintify_meta_yaml(meta, recipe_version=1)
+        expected_msg = "The top level meta key package is unexpected"
+        self.assertIn(expected_msg, lints)
+
     def test_bad_order(self):
         meta = OrderedDict([["package", {}], ["build", {}], ["source", {}]])
         lints, hints = linter.lintify_meta_yaml(meta)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [x] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
- fix linter crashing when unexpected top-level sections are found (when linting section order)
- update the unexpected section lint to distinguish multi-output / single-output v1 recipes (by the presence of `outputs` section) and lint appropriate
- add missing `tests` key to allowed multi-output v1 recipe keys