### PR TITLE
(DNM) Temporarily run CI with conda 26.7.1 (tagged but unreleased) as a downstream testing replacement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,7 @@ jobs:
       - name: install conda-smithy
         run: |
           python -m pip install -v https://github.com/conda/conda/archive/refs/tags/26.7.1.zip --no-deps
+          python -m conda init
           python -m pip install -v --no-build-isolation -e .
 
       - name: install additional dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: install conda-smithy
         run: |
+          python -m pip install -v https://github.com/conda/conda/archive/refs/tags/26.7.1.zip --no-deps
           python -m pip install -v --no-build-isolation -e .
 
       - name: install additional dependencies


### PR DESCRIPTION
Comes from https://github.com/conda-forge/conda-feedstock/pull/312#issuecomment-5340002852