### PR TITLE
Don't ask for abi3audit when the test is conditional

### DIFF
--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -537,11 +537,33 @@ def hint_abi3_cross_python_run_exports(
             return
 
 
+def _flatten_v1_test_elements(test_section) -> list:
+    """Expand top-level `if`/`then`/`else` blocks in a v1 `tests` list.
+
+    `flatten_v1_if_else` cannot be reused here because it treats every mapping
+    as a conditional, while a v1 test element is itself a mapping.
+    """
+    flattened = []
+    for test in test_section:
+        if isinstance(test, Mapping) and "if" in test:
+            for branch in ("then", "else"):
+                value = test.get(branch)
+                if isinstance(value, list):
+                    flattened.extend(_flatten_v1_test_elements(value))
+                elif value is not None:
+                    flattened.append(value)
+        else:
+            flattened.append(test)
+    return flattened
+
+
 def _mentions_abi3audit(test_section, recipe_version) -> bool:
     """True if any test declares `abi3audit` as a requirement or runs it."""
     if recipe_version == 1:
-        # v1: a list of test elements, each with `requirements.run` and `script`
-        tests = test_section or []
+        # v1: a list of test elements, each with `requirements.run` and
+        # `script`. A test element may itself be an `if`/`then`/`else` block,
+        # as when the abi3audit test is guarded by `if: is_abi3`.
+        tests = _flatten_v1_test_elements(test_section or [])
     else:
         # v0: a single mapping with `requires` and `commands`
         tests = [test_section] if isinstance(test_section, Mapping) else []
@@ -614,9 +636,10 @@ def hint_abi3_missing_abi3audit(
     for tests, build, requirements in scopes:
         if not isinstance(build, Mapping):
             continue
-        # `noarch: python` packages ship no compiled extension, so there is
-        # nothing for abi3audit to check
-        if build.get("noarch") == "python":
+        # `noarch` packages ship no compiled extension, so there is nothing
+        # for abi3audit to check. `generic` covers the alias output that abi3
+        # recipes often add alongside the real, architecture-specific package.
+        if build.get("noarch") in ("python", "generic"):
             continue
         if not get_version_independent(build, "python", recipe_version):
             continue

--- a/news/abi3audit-conditional-tests.rst
+++ b/news/abi3audit-conditional-tests.rst
@@ -1,0 +1,26 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* The ``hint_abi3_missing_abi3audit`` hint no longer fires when the
+  ``abi3audit`` test is nested inside an ``if``/``then`` block, such as a test
+  guarded by ``if: is_abi3``. The hint is also skipped for ``noarch: generic``
+  outputs, which ship no extension module for ``abi3audit`` to check.
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -5358,6 +5358,72 @@ def test_lint_recipe_v1_abi3_cross_python_run_exports(text, expected_hint):
                 """),
             False,
         ),
+        # abi3audit test guarded by `if: is_abi3` -> no hint
+        (
+            "recipe.yaml",
+            textwrap.dedent("""
+                recipe:
+                  name: mypackage
+                  version: 1.0.0
+
+                outputs:
+                  - package:
+                      name: myoutput
+                    build:
+                      python:
+                        version_independent: ${{ is_abi3 }}
+                    requirements:
+                      host:
+                        - python ${{ python_min }}.*
+                        - if: is_abi3
+                          then:
+                            - python-abi3
+                      run:
+                        - python
+                    tests:
+                      - python:
+                          imports:
+                            - myoutput
+                      - if: is_abi3
+                        then:
+                          requirements:
+                            run:
+                              - abi3audit
+                          script:
+                            - if: unix
+                              then: abi3audit $SP_DIR/myoutput.abi3.so -s -v
+                              else: abi3audit %SP_DIR%/myoutput.pyd -s -v
+                """),
+            False,
+        ),
+        # a `noarch: generic` alias output ships no extension module -> no hint
+        (
+            "recipe.yaml",
+            textwrap.dedent("""
+                recipe:
+                  name: mypackage
+                  version: 1.0.0
+
+                outputs:
+                  - package:
+                      name: myoutput
+                    build:
+                      noarch: generic
+                      python:
+                        version_independent: true
+                    requirements:
+                      host:
+                        - python-abi3
+                        - python ${{ python_min }}.*
+                      run:
+                        - ${{ pin_subpackage('myoutput-impl') }}
+                    tests:
+                      - python:
+                          imports:
+                            - myoutput
+                """),
+            False,
+        ),
     ],
     ids=(f"recipe-{i}" for i in count(1)),
 )


### PR DESCRIPTION
The `abi3audit` hint fires on recipes that already run `abi3audit`, when the test sits behind a conditional.

`_mentions_abi3audit` iterated the v1 `tests` list directly, so a test element that is an `if`/`then` block never matched: the mapping has `if`/`then` keys, not `requirements`/`script`. A guarded `abi3audit` test was invisible and the hint fired anyway:

```yaml
    tests:
      - python:
          imports:
            - mylib
      - if: is_abi3
        then:
          requirements:
            run:
              - abi3audit
          script:
            - if: unix
              then: abi3audit $SP_DIR/mylib/mylib.abi3.so -s -v
              else: abi3audit %SP_DIR%/mylib/mylib.pyd -s -v
```

`flatten_v1_if_else` can't be reused here. It treats every mapping as a conditional, but a v1 test element is itself a mapping, so a plain `- python: {imports: [...]}` entry would hit `req["then"]` and raise `KeyError`. This adds a small flattener for the tests list instead.

### Checked against a real feedstock

`conda-forge/finance_enums-feedstock` has this shape. Its `recipe.yaml` currently duplicates the whole `abi3audit` test into the `noarch: generic` alias output, which is what made this look like an alias problem. Running the hint over three variants of that recipe:

| variant | `main` | this PR |
| --- | --- | --- |
| upstream as-is (audit duplicated into the alias) | no hint | no hint |
| duplicate dropped from the alias output | no hint | no hint |
| audit guarded by `if: is_abi3` | **hint** | no hint |

So the alias was never the trigger, and that duplicated test in the alias is already unnecessary today. Guarding the audit with `if: is_abi3` is what trips the hint.

Separately, an alias output should not be asked to audit an extension module it does not ship, so `noarch: generic` is now skipped alongside `noarch: python`.

Both behaviours are covered by new parametrized tests. They fail on `main` and pass here; the eleven existing `abi3audit` cases are unaffected.

Checklist

* [x] Added a `news` entry with any new deprecations added to the `Deprecated` section.
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`) (no schema change)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`) (no message change)

