### PR TITLE
Fix hint bug for python_min redefinitions

### DIFF
--- a/conda_smithy/linter/hints.py
+++ b/conda_smithy/linter/hints.py
@@ -381,7 +381,7 @@ def hint_redundant_python_min(meta, recipe_text, recipe_version, hints):
         )
         declared = match.group(1) if match else None
 
-    if declared is None:
+    if declared is None or "${{" in declared or declared == "python_min":
         return
 
     global_python_min = get_global_pinning_python_min()

--- a/news/2662-hintfix.rst
+++ b/news/2662-hintfix.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Linter rule R-052, ``RedundantPythonMin``, will not choke on Jinja redefinitions. (#2662)
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -4810,6 +4810,33 @@ def test_lint_recipe_v1_python_version_independent_test_latest(text, expected_hi
             "3.10",
             False,
         ),
+        # v0: jinja redefinition -> no hint
+        (
+            "meta.yaml",
+            textwrap.dedent("""
+                {% set python_min = python_min %}
+
+                package:
+                  name: mypackage
+                  version: 1.0.0
+                """),
+            "3.10",
+            False,
+        ),
+        # v1: jinja redefinition -> no hint
+        (
+            "recipe.yaml",
+            textwrap.dedent("""
+                context:
+                  python_min: ${{ python_min }}
+
+                package:
+                  name: mypackage
+                  version: 1.0.0
+                """),
+            None,
+            False,
+        ),
     ],
     ids=(f"recipe-{i}" for i in count(1)),
 )


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Observed at https://github.com/conda-forge/py-rattler-build-feedstock/pull/50#issuecomment-5283346911. Logs: https://github.com/conda-forge/conda-forge-webservices/actions/runs/32961756635/job/98155421279