### PR TITLE
Pass `--target-platform` to rattler-build in Pixi.toml tasks

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2530,9 +2530,11 @@ def render_pixi(jinja_env, forge_config, forge_dir):
             if filename.endswith(".yaml"):
                 variant_name, _ = os.path.splitext(filename)
                 variants[variant_name] = variant_config = {}
-                with open(filename) as f:
-                    data = yaml.load(f)
+                with open(os.path.join(ci_support_path, filename)) as f:
+                    data = yaml.safe_load(f)
                 if target_platform := data.get("target_platform"):
+                    if not isinstance(target_platform, str):
+                        target_platform = target_platform[0]
                     variant_config["target_platform_flag"] = (
                         f"--target-platform {target_platform}"
                     )

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -2524,12 +2524,20 @@ def render_pixi(jinja_env, forge_config, forge_dir):
         return
     template = jinja_env.get_template("pixi.toml.tmpl")
     ci_support_path = os.path.join(forge_dir, ".ci_support")
-    variants = []
+    variants: dict[str, str] = {}
     if os.path.exists(ci_support_path):
-        for filename in os.listdir(ci_support_path):
+        for filename in sorted(os.listdir(ci_support_path)):
             if filename.endswith(".yaml"):
                 variant_name, _ = os.path.splitext(filename)
-                variants.append(variant_name)
+                variants[variant_name] = variant_config = {}
+                with open(filename) as f:
+                    data = yaml.load(f)
+                if target_platform := data.get("target_platform"):
+                    variant_config["target_platform_flag"] = (
+                        f"--target-platform {target_platform}"
+                    )
+                else:
+                    variant_config["target_platform_flag"] = ""
 
     pixi_platforms = set()
 

--- a/conda_smithy/templates/pixi.toml.tmpl
+++ b/conda_smithy/templates/pixi.toml.tmpl
@@ -53,25 +53,25 @@ description = "Debug {{ feedstock_name }} directly (without setup scripts), no p
 cmd = "{{ conda_build_tool }} build --recipe {{ recipe_dir }}"
 description = "Build {{ feedstock_name }} directly (without setup scripts), no particular variant specified"
 {%- endif %}
-{%- for variant in variants | sort %}
+{%- for variant_name, variant_config in variants | items %}
 {%- if conda_build_tool != "rattler-build" %}
 [feature.build.tasks."build-{{ variant }}"]
-cmd = "{{ conda_build_tool }} build {{ recipe_dir }} -m .ci_support/{{ variant }}.yaml --suppress-variables --clobber-file .ci_support/clobber_{{ variant }}.yaml"
-description = "Build {{ feedstock_name }} with variant {{ variant }} directly (without setup scripts)"
-[feature.build.tasks."debug-{{ variant }}"]
-cmd = "{{ conda_build_tool }} debug {{ recipe_dir }} -m .ci_support/{{ variant }}.yaml"
-description = "Debug {{ feedstock_name }} with variant {{ variant }} directly (without setup scripts)"
+cmd = "{{ conda_build_tool }} build {{ recipe_dir }} -m .ci_support/{{ variant_name }}.yaml --suppress-variables --clobber-file .ci_support/clobber_{{ variant_name }}.yaml"
+description = "Build {{ feedstock_name }} with variant {{ variant_name }} directly (without setup scripts)"
+[feature.build.tasks."debug-{{ variant_name }}"]
+cmd = "{{ conda_build_tool }} debug {{ recipe_dir }} -m .ci_support/{{ variant_name }}.yaml"
+description = "Debug {{ feedstock_name }} with variant {{ variant_name }} directly (without setup scripts)"
 {%- else %}
-[feature.build.tasks."build-{{ variant }}"]
-cmd = "{{ conda_build_tool }} build --recipe {{ recipe_dir }} -m .ci_support/{{ variant }}.yaml"
-description = "Build {{ feedstock_name }} with variant {{ variant }} directly (without setup scripts)"
-[feature.build.tasks."debug-{{ variant }}"]
-cmd = "{{ conda_build_tool }} debug setup --recipe {{ recipe_dir }} -m .ci_support/{{ variant }}.yaml"
-description = "Build {{ feedstock_name }} with variant {{ variant }} directly (without setup scripts)"
+[feature.build.tasks."build-{{ variant_name }}"]
+cmd = "{{ conda_build_tool }} build --recipe {{ recipe_dir }} -m .ci_support/{{ variant_name }}.yaml {{ variant_config['target_platform_flag'] }}"
+description = "Build {{ feedstock_name }} with variant {{ variant_name }} directly (without setup scripts)"
+[feature.build.tasks."debug-{{ variant_name }}"]
+cmd = "{{ conda_build_tool }} debug setup --recipe {{ recipe_dir }} -m .ci_support/{{ variant_name }}.yaml {{ variant_config['target_platform_flag'] }}"
+description = "Debug {{ feedstock_name }} with variant {{ variant_name }} directly (without setup scripts)"
 {%- endif %}
-[feature.build.tasks."inspect-{{ variant }}"]
-cmd = "inspect_artifacts --recipe-dir {{ recipe_dir }} -m .ci_support/{{ variant }}.yaml"
-description = "List contents of {{ feedstock_name }} packages built for variant {{ variant }}"
+[feature.build.tasks."inspect-{{ variant_name }}"]
+cmd = "inspect_artifacts --recipe-dir {{ recipe_dir }} -m .ci_support/{{ variant_name }}.yaml"
+description = "List contents of {{ feedstock_name }} packages built for variant {{ variant_name }}"
 {%- endfor %}
 
 [environments]

--- a/news/2663-target-platform-pixi-tasks.rst
+++ b/news/2663-target-platform-pixi-tasks.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Pass ``--target-platform`` to ``rattler-build`` in ``Pixi.toml`` tasks. (#2663)
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This was missing, which can cause confusing issues while debugging in emulated platforms. I'm not passing `--build-platform` but folks can override that locally in `pixi run`.