### PR TITLE
Fix default `workflow_settings` paths values for unix/win cross

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1992,7 +1992,7 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
         fill_workflow_settings_defaults(
             workflow_settings,
             "github_actions",
-            data["platform"],
+            platform,
             "D:" if on_hosted_runner or on_namespace else "C:",
         )
         data.update(workflow_settings)
@@ -2134,7 +2134,7 @@ def _azure_specific_setup(jinja_env, forge_config, forge_dir, platform):
 
         # fmt: off
         workflow_settings = get_workflow_settings(forge_config["workflow_settings"], "azure", data["platform"])
-        fill_workflow_settings_defaults(workflow_settings, "azure", data["platform"], "D:" if data["platform"] == "win-64" else "C:")
+        fill_workflow_settings_defaults(workflow_settings, "azure", platform, "D:" if data["build_platform"] == "win-64" else "C:")
         data.update(workflow_settings)
 
         if platform == "linux":

--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -1984,7 +1984,8 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
         workflow_settings = get_workflow_settings(
             forge_config["workflow_settings"], "github_actions", data["platform"]
         )
-        on_hosted_runner = {
+        # Note that win-arm64 runners do not have D:
+        on_hosted_win_64_runner = {
             "windows-latest",
             "windows-2022",
             "windows-2025",
@@ -1993,7 +1994,7 @@ def _github_actions_specific_setup(jinja_env, forge_config, forge_dir, platform)
             workflow_settings,
             "github_actions",
             platform,
-            "D:" if on_hosted_runner or on_namespace else "C:",
+            "D:" if on_hosted_win_64_runner or on_namespace else "C:",
         )
         data.update(workflow_settings)
         # support scripts are all executable, and may also be templates (for artifact creation)

--- a/conda_smithy/linter/licenses.txt
+++ b/conda_smithy/linter/licenses.txt
@@ -74,6 +74,7 @@ BSD-2-Clause-Darwin
 BSD-2-Clause-first-lines
 BSD-2-Clause-Patent
 BSD-2-Clause-pkgconf-disclaimer
+BSD-2-Clause-pos-unchanged
 BSD-2-Clause-Views
 BSD-3-Clause
 BSD-3-Clause-acpica
@@ -96,6 +97,7 @@ BSD-4-Clause-UC
 BSD-4.3RENO
 BSD-4.3TAHOE
 BSD-Advertising-Acknowledgement
+BSD-ask-to-endorse
 BSD-Attribution-HPND-disclaimer
 BSD-Inferno-Nettverk
 BSD-Mark-Modifications

--- a/conda_smithy/utils.py
+++ b/conda_smithy/utils.py
@@ -364,27 +364,25 @@ def get_workflow_settings(
 def fill_workflow_settings_defaults(
     workflow_settings: dict[str, Any],
     provider: str,
-    platform: str,
+    system: str,
     win_default_drive: str,
 ) -> None:
     """
     Fill the missing entries from `workflow_settings` with defaults for
-    the given provider-platform combination.
+    the given provider-system combination.
     """
 
-    assert "-" in platform
     assert len(win_default_drive) == 2
     assert win_default_drive[1] == ":"
 
-    os = platform.split("-", 1)[0]
     if workflow_settings.get("tools_install_dir") is None:
         workflow_settings["tools_install_dir"] = (
-            rf"{win_default_drive}\Miniforge" if os == "win" else "~/miniforge3"
+            rf"{win_default_drive}\Miniforge" if system == "win" else "~/miniforge3"
         )
     if workflow_settings.get("build_workspace_dir") is None:
         tools_drive = (
             PureWindowsPath(workflow_settings["tools_install_dir"]).drive
-            if os == "win"
+            if system == "win"
             else ""
         )
         workflow_settings["build_workspace_dir"] = {
@@ -394,7 +392,7 @@ def fill_workflow_settings_defaults(
             # https://github.com/conda-forge/conda-forge-ci-setup-feedstock/blob/29b3d39d4c21cd96c6274231f295bacd5c860611/recipe/run_conda_forge_build_setup_win.bat#L32-L42
             # TODO: switch to normalizing all paths once we're ready
             "win": rf"{tools_drive}\\bld\\",
-        }[os]
+        }[system]
 
     simple_defaults = {
         "pagefile_size": 0,

--- a/news/workflow-settings-defaults-platform-2658.rst
+++ b/news/workflow-settings-defaults-platform-2658.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix the default ``build_workspace_dir`` and ``tools_install_dir`` values for cross Unix-Windows builds, by basing them on the build platform rather than the target platform. (#2658)
+
+**Security:**
+
+* <news item>

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -2916,16 +2916,16 @@ def test_tools_build_paths_gha(py_recipe, jinja_env, win64_label: str, cross: bo
     with conda_build_yml.open() as f:
         workflow = yaml.safe_load(f)
 
-    built_on_linux_64 = "win_64" if cross else "linux_64"
-    built_on_osx_arm64 = "win_arm64" if cross else "osx_arm64"
-    built_on_win_64 = "linux_64" if cross else "win_64"
-    built_on_win_arm64 = "osx_arm64" if cross else "win_arm64"
+    target_built_on_linux_64 = "win_64" if cross else "linux_64"
+    target_built_on_osx_arm64 = "win_arm64" if cross else "osx_arm64"
+    target_built_on_win_64 = "linux_64" if cross else "win_64"
+    target_built_on_win_arm64 = "osx_arm64" if cross else "win_arm64"
 
     expected = {
-        built_on_linux_64: ("~/miniforge3", "build_artifacts"),
-        built_on_osx_arm64: ("~/miniforge3", "~/miniforge3/conda-bld"),
-        built_on_win_arm64: (r"C:\Miniforge", r"C:\\bld\\"),
-        built_on_win_64: (
+        target_built_on_linux_64: ("~/miniforge3", "build_artifacts"),
+        target_built_on_osx_arm64: ("~/miniforge3", "~/miniforge3/conda-bld"),
+        target_built_on_win_arm64: (r"C:\Miniforge", r"C:\\bld\\"),
+        target_built_on_win_64: (
             (r"C:\Miniforge", r"C:\\bld\\")
             if (win64_label or "").startswith("blacksmith")
             else (r"D:\Miniforge", r"D:\\bld\\")
@@ -2974,21 +2974,21 @@ def test_tools_build_paths_azure(py_recipe, jinja_env, cross: bool):
         forge_dir=forge_dir,
     )
 
-    built_on_linux_64 = "win_64" if cross else "linux_64"
-    built_on_osx_arm64 = "win_arm64" if cross else "osx_arm64"
-    built_on_win_64 = "linux_64" if cross else "win_64"
-    built_on_win_arm64 = "osx_arm64" if cross else "win_arm64"
+    target_built_on_linux_64 = "win_64" if cross else "linux_64"
+    target_built_on_osx_arm64 = "win_arm64" if cross else "osx_arm64"
+    target_built_on_win_64 = "linux_64" if cross else "win_64"
+    target_built_on_win_arm64 = "osx_arm64" if cross else "win_arm64"
 
     expected = {
         "linux": {
-            built_on_linux_64: ("~/miniforge3", "build_artifacts"),
+            target_built_on_linux_64: ("~/miniforge3", "build_artifacts"),
         },
         "osx": {
-            built_on_osx_arm64: ("~/miniforge3", "~/miniforge3/conda-bld"),
+            target_built_on_osx_arm64: ("~/miniforge3", "~/miniforge3/conda-bld"),
         },
         "win": {
-            built_on_win_64: (r"D:\Miniforge", r"D:\\bld\\"),
-            built_on_win_arm64: (r"C:\Miniforge", r"C:\\bld\\"),
+            target_built_on_win_64: (r"D:\Miniforge", r"D:\\bld\\"),
+            target_built_on_win_arm64: (r"C:\Miniforge", r"C:\\bld\\"),
         },
     }
 

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -2863,7 +2863,7 @@ def test_store_build_artifacts_gha_and_azure_conditions(py_recipe, jinja_env):
 
 
 @pytest.mark.parametrize(
-    "label",
+    "win64_label",
     [
         None,
         "default",
@@ -2874,21 +2874,34 @@ def test_store_build_artifacts_gha_and_azure_conditions(py_recipe, jinja_env):
         "namespace-profile-16cpu-on-win-64",
     ],
 )
-def test_tools_build_paths_gha(py_recipe, jinja_env, label: str):
+@pytest.mark.parametrize("cross", [False, True])
+def test_tools_build_paths_gha(py_recipe, jinja_env, win64_label: str, cross: bool):
     forge_dir = py_recipe.recipe
     forge_yml = Path(forge_dir, "conda-forge.yml")
 
     with open(forge_yml, "a") as f:
+        if cross:
+            f.write(textwrap.dedent("""\
+                build_platform:
+                  linux_64: win_64
+                  osx_arm64: win_arm64
+                  win_arm64: osx_arm64
+                  win_64: linux_64
+            """))
         f.write(textwrap.dedent("""\
             provider:
               linux_64: github_actions
-              osx_64: github_actions
+              osx_64: null
+              osx_arm64: github_actions
               win_arm64: github_actions
               win_64: github_actions
         """))
-    if label:
+    if win64_label:
+        win64_builder = "linux64" if cross else "win64"
         with open(py_recipe.config["exclusive_config_file"], "a") as f:
-            f.write(f"\ngithub_actions_labels:\n  - {label}  # [win64]\n")
+            f.write(
+                f"\ngithub_actions_labels:\n  - {win64_label}  # [{win64_builder}]\n"
+            )
 
     config = configure_feedstock._load_forge_config(
         forge_dir, "recipe/default_config.yaml"
@@ -2903,20 +2916,25 @@ def test_tools_build_paths_gha(py_recipe, jinja_env, label: str):
     with conda_build_yml.open() as f:
         workflow = yaml.safe_load(f)
 
+    built_on_linux_64 = "win_64" if cross else "linux_64"
+    built_on_osx_arm64 = "win_arm64" if cross else "osx_arm64"
+    built_on_win_64 = "linux_64" if cross else "win_64"
+    built_on_win_arm64 = "osx_arm64" if cross else "win_arm64"
+
     expected = {
-        "macos-15-intel": ("~/miniforge3", "~/miniforge3/conda-bld"),
-        "ubuntu-latest": ("~/miniforge3", "build_artifacts"),
-        "windows-11-arm": (r"C:\Miniforge", r"C:\\bld\\"),
+        built_on_linux_64: ("~/miniforge3", "build_artifacts"),
+        built_on_osx_arm64: ("~/miniforge3", "~/miniforge3/conda-bld"),
+        built_on_win_arm64: (r"C:\Miniforge", r"C:\\bld\\"),
+        built_on_win_64: (
+            (r"C:\Miniforge", r"C:\\bld\\")
+            if (win64_label or "").startswith("blacksmith")
+            else (r"D:\Miniforge", r"D:\\bld\\")
+        ),
     }
-    expected_label = "windows-2022" if label in (None, "default", "hosted") else label
-    if expected_label.startswith("blacksmith"):
-        expected[expected_label] = (r"C:\Miniforge", r"C:\\bld\\")
-    else:
-        expected[expected_label] = (r"D:\Miniforge", r"D:\\bld\\")
 
     matrix = workflow["jobs"]["build"]["strategy"]["matrix"]["include"]
     assert {
-        " ".join(entry["runs_on"]): (
+        "_".join(entry["CONFIG"].split("_")[:2]): (
             entry["tools_install_dir"],
             entry["build_workspace_dir"],
         )
@@ -2924,15 +2942,25 @@ def test_tools_build_paths_gha(py_recipe, jinja_env, label: str):
     } == expected
 
 
-def test_tools_build_paths_azure(py_recipe, jinja_env):
+@pytest.mark.parametrize("cross", [False, True])
+def test_tools_build_paths_azure(py_recipe, jinja_env, cross: bool):
     forge_dir = py_recipe.recipe
     forge_yml = Path(forge_dir, "conda-forge.yml")
 
     with open(forge_yml, "a") as f:
+        if cross:
+            f.write(textwrap.dedent("""\
+                build_platform:
+                  linux_64: win_64
+                  osx_arm64: win_arm64
+                  win_arm64: osx_arm64
+                  win_64: linux_64
+            """))
         f.write(textwrap.dedent("""\
             provider:
               linux_64: azure
-              osx_64: azure
+              osx_64: null
+              osx_arm64: azure
               win_arm64: azure
               win_64: azure
         """))
@@ -2946,16 +2974,21 @@ def test_tools_build_paths_azure(py_recipe, jinja_env):
         forge_dir=forge_dir,
     )
 
+    built_on_linux_64 = "win_64" if cross else "linux_64"
+    built_on_osx_arm64 = "win_arm64" if cross else "osx_arm64"
+    built_on_win_64 = "linux_64" if cross else "win_64"
+    built_on_win_arm64 = "osx_arm64" if cross else "win_arm64"
+
     expected = {
         "linux": {
-            "linux_64": ("~/miniforge3", "build_artifacts"),
+            built_on_linux_64: ("~/miniforge3", "build_artifacts"),
         },
         "osx": {
-            "osx_64": ("~/miniforge3", "~/miniforge3/conda-bld"),
+            built_on_osx_arm64: ("~/miniforge3", "~/miniforge3/conda-bld"),
         },
         "win": {
-            "win_64": (r"D:\Miniforge", r"D:\\bld\\"),
-            "win_arm64": (r"C:\Miniforge", r"C:\\bld\\"),
+            built_on_win_64: (r"D:\Miniforge", r"D:\\bld\\"),
+            built_on_win_arm64: (r"C:\Miniforge", r"C:\\bld\\"),
         },
     }
 

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -741,7 +741,6 @@ def test_secrets(py_recipe, jinja_env):
     )
     with open(config_yaml) as fo:
         config = yaml.safe_load(fo)
-        print(config)
         if "steps" in config:
             any(
                 step.get("env", {}).get("BINSTAR_TOKEN", None) == "$(BINSTAR_TOKEN)"
@@ -2466,7 +2465,6 @@ def test_github_actions_labels(py_recipe, jinja_env, label):
     forge_dir = py_recipe.recipe
     config = copy.deepcopy(py_recipe.config)
     conda_build_yml = Path(forge_dir, ".github/workflows/conda-build.yml")
-    print(conda_build_yml)
 
     config["provider"]["linux_64"] = "github_actions"
     config["provider"]["osx"] = "azure"


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [ ] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #2658


<!--
Please add any other relevant info below:
-->
Fix the default ``build_workspace_dir`` and ``tools_install_dir`` values for cross Unix-Windows builds, by basing them on the build platform rather than the target platform.

