### PR TITLE
Zip MACOSX_DEPLOYMENT_TARGET/MACOSX_SDK_VERSION with c_stdlib_version

### DIFF
--- a/conda_smithy/configure_feedstock.py
+++ b/conda_smithy/configure_feedstock.py
@@ -691,8 +691,60 @@ def _merge_deployment_target(container_of_dicts, has_macdt):
             }
         )
         result.append(new_dict)
+    result = _zip_osx_versions_with_stdlib(result)
     # ensure we keep type of wrapper container (set stays set, etc.)
     return type(container_of_dicts)(result)
+
+
+def _zip_osx_versions_with_stdlib(list_of_dicts):
+    """Record that MACOSX_DEPLOYMENT_TARGET/MACOSX_SDK_VERSION follow c_stdlib_version.
+
+    ``_merge_deployment_target`` above derives both keys from ``c_stdlib_version``
+    for every variant, so the three co-vary by construction.  Neither of the two
+    is a loop variable of its own though, so unless that relationship is spelled
+    out in ``zip_keys``, a feedstock that builds several deployment-target tiers
+    side by side (i.e. one that gives ``c_stdlib_version`` more than one value)
+    gets *all* the tiers' values written into *every* rendered .ci_support file,
+    and the build tool then builds each tier once per tier.
+
+    This is a no-op unless ``c_stdlib_version`` actually varies, so the single
+    tier case -- which is nearly every feedstock -- renders exactly as before.
+    """
+    stdlib_versions = {
+        var_dict["c_stdlib_version"]
+        for var_dict in list_of_dicts
+        if "c_stdlib_version" in var_dict
+    }
+    if len(stdlib_versions) < 2:
+        return list_of_dicts
+
+    result = []
+    for var_dict in list_of_dicts:
+        keys_to_zip = [
+            key
+            for key in ("MACOSX_DEPLOYMENT_TARGET", "MACOSX_SDK_VERSION")
+            if key in var_dict
+        ]
+        if "c_stdlib_version" not in var_dict or not keys_to_zip:
+            result.append(var_dict)
+            continue
+
+        groups = var_dict.get("zip_keys", [])
+        # zip_keys may be a single group given as a flat list of keys
+        if groups and not isinstance(groups[0], (list, tuple)):
+            groups = [groups]
+        groups = [list(group) for group in groups]
+
+        for group in groups:
+            if "c_stdlib_version" in group:
+                break
+        else:
+            group = ["c_stdlib_version"]
+            groups.append(group)
+        group.extend(key for key in keys_to_zip if key not in group)
+
+        result.append(HashableDict({**var_dict, "zip_keys": groups}))
+    return result
 
 
 def _collapse_subpackage_variants(

--- a/news/zip-macos-deployment-target.rst
+++ b/news/zip-macos-deployment-target.rst
@@ -1,0 +1,28 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``MACOSX_DEPLOYMENT_TARGET`` and ``MACOSX_SDK_VERSION`` are now zipped with
+  ``c_stdlib_version`` when a feedstock builds more than one macOS deployment
+  target tier. Both keys are derived per variant from ``c_stdlib_version``, but
+  that relationship was not recorded in ``zip_keys``, so every rendered
+  ``.ci_support/osx_*`` file listed all of the tiers' values instead of its own.
+  Single-tier feedstocks, which are nearly all of them, render unchanged.
+
+**Security:**
+
+* <news item>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -370,6 +370,38 @@ MACOSX_SDK_VERSION:             # [osx]
 
 
 @pytest.fixture(scope="function")
+def stdlib_multiple_deployment_targets_recipe(
+    config_yaml: ConfigYAML, stdlib_recipe
+):
+    # overwrite the osx-64 part of stdlib_config.yaml from stdlib_recipe so that
+    # osx-64 is built for two deployment targets side by side
+    with open(
+        os.path.join(config_yaml.workdir, "recipe", "stdlib_config.yaml"), "w"
+    ) as f:
+        f.write("""\
+c_stdlib:
+  - sysroot                     # [linux]
+  - macosx_deployment_target    # [osx]
+  - vs                          # [win]
+c_stdlib_version:               # [unix]
+  - 2.12                        # [linux64]
+  - 2.17                        # [aarch64 or ppc64le]
+  - 10.13                       # [osx and x86_64]
+  - 10.15                       # [osx and x86_64]
+  - 11.0                        # [osx and arm64]
+""")
+    return RecipeConfigPair(
+        str(config_yaml.workdir),
+        _load_forge_config(
+            config_yaml.workdir,
+            exclusive_config_file=os.path.join(
+                config_yaml.workdir, "recipe", "stdlib_config.yaml"
+            ),
+        ),
+    )
+
+
+@pytest.fixture(scope="function")
 def mixed_python_min_recipe(config_yaml: ConfigYAML):
     # check that we can render recipe that has a mix of noarch and non-noarch outputs
     with open(os.path.join(config_yaml.workdir, "recipe", "meta.yaml"), "w") as fh:

--- a/tests/test_configure_feedstock.py
+++ b/tests/test_configure_feedstock.py
@@ -322,6 +322,43 @@ def test_stdlib_deployment_target(
     assert re.match(r"(?s).*MACOSX_SDK_VERSION:\s*- ['\"]?10\.14", content)
 
 
+def test_stdlib_multiple_deployment_targets(
+    stdlib_multiple_deployment_targets_recipe, jinja_env, request
+):
+    conda_build_param = request.node.callspec.params["config_yaml"]
+    if conda_build_param == "rattler-build":
+        # fixture doesn't have a recipe.yaml variant
+        pytest.skip("skipping test for rattler-build usecase")
+
+    default_providers = sorted({prov for _, prov in DEFAULT_PROVIDERS.items()})
+    for provider in default_providers:
+        render_func = getattr(configure_feedstock, f"render_{provider}")
+        render_func(
+            jinja_env=jinja_env,
+            forge_config=stdlib_multiple_deployment_targets_recipe.config,
+            forge_dir=stdlib_multiple_deployment_targets_recipe.recipe,
+        )
+    matrix_dir = os.path.join(
+        stdlib_multiple_deployment_targets_recipe.recipe, ".ci_support"
+    )
+    assert os.path.isdir(matrix_dir)
+
+    # one .ci_support file per deployment target, each pinned to a single
+    # MACOSX_DEPLOYMENT_TARGET matching its own c_stdlib_version; if the keys
+    # aren't zipped together, every file lists both targets and the build tool
+    # ends up building each target twice
+    for version in ["10.13", "10.15"]:
+        config_file = os.path.join(
+            matrix_dir, f"osx_64_c_stdlib_version{version}.yaml"
+        )
+        assert os.path.isfile(config_file)
+        with open(config_file) as f:
+            content = yaml.safe_load(f)
+        assert content["c_stdlib_version"] == [version]
+        assert content["MACOSX_DEPLOYMENT_TARGET"] == [version]
+        assert content["MACOSX_SDK_VERSION"] == [version]
+
+
 def test_mixed_python_min(mixed_python_min_recipe, jinja_env, caplog, request):
     conda_build_param = request.node.callspec.params["config_yaml"]
     if conda_build_param == "rattler-build":


### PR DESCRIPTION
> [!NOTE]
> **Disclaimer:** this PR was written by Claude, Anthropic's coding agent, acting as my bot under my direction. I've reviewed it and I take responsibility for it, but I'm flagging the provenance so you can weight the analysis accordingly. Opening as a draft for that reason — happy to iterate on the approach before it's considered for real.

### Problem

`_merge_deployment_target` rewrites `MACOSX_DEPLOYMENT_TARGET` and `MACOSX_SDK_VERSION` per variant so they track `c_stdlib_version`. Neither key is a loop variable of its own, and nothing records that relationship in `zip_keys` — they survive only via the `always_keep_keys` set. So `_get_used_key_values_by_input_order` falls through to its "rest of the keys that are not zipped" branch and hands *every* config the full list of values.

That is invisible while `c_stdlib_version` has a single value, which is nearly every feedstock. But a feedstock that builds several macOS deployment target tiers side by side gets every tier's value written into every one of its `.ci_support/osx_*` files:

```yaml
# .ci_support/osx_arm64_c_stdlib_version14.5python3.13.____cp313.yaml
MACOSX_DEPLOYMENT_TARGET:
- '14.5'
- '26.0'      # <- belongs to the other tier
MACOSX_SDK_VERSION:
- '14.5'
c_stdlib_version:
- '14.5'
```

`MACOSX_SDK_VERSION` escapes only because that feedstock happens to zip it explicitly.

### Why it matters

The build tool then reads the two-valued key as a variant axis of its own and builds each tier twice. From `rattler-build build --render-only` on the 14.5 config above, two outputs:

| build string | `c_stdlib_version` | `MACOSX_DEPLOYMENT_TARGET` |
| --- | --- | --- |
| `py313h5605d13_1400` | 14.5 | 14.5 |
| `py313hd7257d0_1400` | 14.5 | 26.0 |

Same name, version and build number; they differ only in the hash, and one of them carries a deployment target that has nothing to do with its own tier. On conda-forge/mlx-feedstock#104 the osx jobs took 15–25 min with the duplicate present against 7–14 min once each config built once.

The current workaround is to hand-edit the offending value out of each rendered file after every re-render, which silently regresses the moment anyone (or the autotick bot) re-renders.

### Fix

Add the two keys to the `zip_keys` group that holds `c_stdlib_version`, creating one when the feedstock does not already zip it, so the existing zip machinery in `_get_used_key_values_by_input_order` and `break_up_top_level_values` slices them per config.

Guarded on `c_stdlib_version` actually having more than one distinct value, so **single-tier feedstocks render byte-for-byte as before** and this introduces no mass re-render churn. I verified that directly: re-rendering a single-tier feedstock with and without the patch produces identical `.ci_support` output.

### Testing

- New `test_stdlib_multiple_deployment_targets` plus a `stdlib_multiple_deployment_targets_recipe` fixture. It fails on `main` (`assert content["MACOSX_DEPLOYMENT_TARGET"] == [version]`) and passes with the fix.
- Full `tests/test_configure_feedstock.py`: 269 passed, 13 skipped.
- `tests/test_configure_feedstock.py` + `tests/test_lint_recipe.py`: 4524 passed. Two `test_lint_recipe.py` failures (`test_lint_recipe_parses_v1_duplicate_keys`, `test_license_files_up_to_date`) reproduce on unpatched `main` and are unrelated.
- Both branches of the new helper are exercised: the pre-existing-zip-group case (mlx's real config) and the no-zip-group case (a synthetic CBC with a bare two-value `c_stdlib_version`).

### Alternatives considered

Declaring `MACOSX_DEPLOYMENT_TARGET` in the recipe-local `conda_build_config.yaml` and zipping it there does render correctly, but it trips `lint_osx_pins` (*"needs to be removed or replaced by `c_stdlib_version`"*), which has no `linter.skip` guard, and it promotes the key to a top-level loop variable so every osx job is renamed to `osx_arm64_MACOSX_DEPLOYMENT_TARGET14.5c_stdlib_version14.5python3.13...`. Adding it to `zip_keys` without declaring values fails earlier, in conda-build: `zip_key entry MACOSX_DEPLOYMENT_TARGET in group frozenset({...}) does not have any settings`.

mlx-feedstock has since worked around this on its own side with rattler-build's `build.variant.ignore_keys`, which is available because the deployment target in that file is inert for the build anyway — `MACOSX_DEPLOYMENT_TARGET` in the build environment comes from the `activate.d` script of `macosx_deployment_target_osx-arm64`, which sets it (and `-mmacosx-version-min`, and `-DCMAKE_OSX_DEPLOYMENT_TARGET`) unconditionally from its own version. That workaround is recipe-format-specific though, and the rendered files are still wrong.

### Motivating case

conda-forge/mlx-feedstock#104 — an osx-arm64 matrix building 14.5 and 26.0 tiers so macOS 26 users get MLX's NAX/Metal 4 kernels while older macOS keeps a working package.
