### PR TITLE
Lint on redundant `build_platform` and `provider` entries

### DIFF
--- a/conda_smithy/data/linter-messages.json
+++ b/conda_smithy/data/linter-messages.json
@@ -208,6 +208,18 @@
       "path": ""
     },
     {
+      "name": "RedundantBuildPlatform",
+      "identifier": "CF-015",
+      "category": "CF",
+      "kind": "lint",
+      "added_in": "2026.9",
+      "deprecated_in": "",
+      "documentation": "Lint when `build_platform` is the same as the platform.",
+      "message": "Platform ${platform} specifies redundant build_platform=${platform}. Please remove the unnecessary entry.\n",
+      "examples": [],
+      "path": ""
+    },
+    {
       "name": "NoDuplicateKeys",
       "identifier": "FC-001",
       "category": "FC",

--- a/conda_smithy/data/linter-messages.json
+++ b/conda_smithy/data/linter-messages.json
@@ -196,6 +196,18 @@
       "path": ""
     },
     {
+      "name": "RedundantBuildPlatformAndProvider",
+      "identifier": "CF-014",
+      "category": "CF",
+      "kind": "lint",
+      "added_in": "2026.9",
+      "deprecated_in": "",
+      "documentation": "Lint when the same platform is listed in `build_platform` and `provider`.",
+      "message": "Platform ${platform} specifies both build_platform=${build_platform} and provider=${provider}. Use the former for cross-compilation or the latter for native build.\n",
+      "examples": [],
+      "path": ""
+    },
+    {
       "name": "NoDuplicateKeys",
       "identifier": "FC-001",
       "category": "FC",

--- a/conda_smithy/lint_recipe.py
+++ b/conda_smithy/lint_recipe.py
@@ -77,6 +77,7 @@ from conda_smithy.linter.lints import (
     lint_recipe_maintainers,
     lint_recipe_name,
     lint_recipe_v1_noarch_and_runtime_dependencies,
+    lint_redundant_platform_definitions,
     lint_require_lower_bound_on_python_version,
     lint_rust_licenses_are_bundled,
     lint_section_order,
@@ -934,6 +935,9 @@ def run_conda_forge_specific(
 
     # 19: Check for missing feedstock-name (if necessary).
     lint_feedstock_name(meta, feedstock_config, recipe_version, recipe_dir, lints)
+
+    # 20: Lint redundant platform definitions
+    lint_redundant_platform_definitions(feedstock_config, lints)
 
 
 def _format_validation_msg(error: jsonschema.ValidationError):

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -1234,3 +1234,21 @@ def lint_feedstock_name(
                 current=feedstock_name, expected=expected_name
             ).as_string()
         )
+
+
+def lint_redundant_platform_definitions(
+    forge_config: dict,
+    lints: list[str],
+):
+    """Lint for redundancy between `build_platforms` and `provider` keys"""
+
+    providers = forge_config.get("provider", {})
+    for platform, build_platform in forge_config.get("build_platform", {}).items():
+        if (provider := providers.get(platform)) is not None:
+            lints.append(
+                msg.cf.RedundantBuildPlatformAndProvider(
+                    platform=platform,
+                    build_platform=build_platform,
+                    provider=provider,
+                ).as_string()
+            )

--- a/conda_smithy/linter/lints.py
+++ b/conda_smithy/linter/lints.py
@@ -1244,7 +1244,13 @@ def lint_redundant_platform_definitions(
 
     providers = forge_config.get("provider", {})
     for platform, build_platform in forge_config.get("build_platform", {}).items():
-        if (provider := providers.get(platform)) is not None:
+        if platform == build_platform:
+            lints.append(
+                msg.cf.RedundantBuildPlatform(
+                    platform=platform,
+                ).as_string()
+            )
+        elif (provider := providers.get(platform)) is not None:
             lints.append(
                 msg.cf.RedundantBuildPlatformAndProvider(
                     platform=platform,

--- a/conda_smithy/linter/messages/conda_forge.py
+++ b/conda_smithy/linter/messages/conda_forge.py
@@ -273,3 +273,18 @@ class MismatchedFeedstockName(LinterMessage):
     message = "Mismatched feedstock name in the recipe: ${current}. Specify `extra.feedstock_name: ${expected}`.\n"
     current: str
     expected: str
+
+
+@dataclass(kw_only=True)
+class RedundantBuildPlatformAndProvider(LinterMessage):
+    """
+    Lint when the same platform is listed in `build_platform` and `provider`.
+    """
+
+    kind = "lint"
+    identifier = "CF-014"
+    added_in = "2026.9"
+    message = "Platform ${platform} specifies both build_platform=${build_platform} and provider=${provider}. Use the former for cross-compilation or the latter for native build.\n"
+    platform: str
+    build_platform: str
+    provider: str

--- a/conda_smithy/linter/messages/conda_forge.py
+++ b/conda_smithy/linter/messages/conda_forge.py
@@ -288,3 +288,16 @@ class RedundantBuildPlatformAndProvider(LinterMessage):
     platform: str
     build_platform: str
     provider: str
+
+
+@dataclass(kw_only=True)
+class RedundantBuildPlatform(LinterMessage):
+    """
+    Lint when `build_platform` is the same as the platform.
+    """
+
+    kind = "lint"
+    identifier = "CF-015"
+    added_in = "2026.9"
+    message = "Platform ${platform} specifies redundant build_platform=${platform}. Please remove the unnecessary entry.\n"
+    platform: str

--- a/news/lint-redundant-build-platform-and-provider.rst
+++ b/news/lint-redundant-build-platform-and-provider.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* A lint for redundant ``build_platform`` and ``provider`` entries. (#2654)
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -6696,5 +6696,40 @@ def test_invalid_type_lint_message():
     )
 
 
+def test_redundant_build_platform_and_provider(tmp_path):
+    cfyml = tmp_path / "conda-forge.yml"
+    recipe_dir = tmp_path / "recipe"
+    recipe_dir.mkdir()
+    (recipe_dir / "meta.yaml").write_text(textwrap.dedent("""
+        package:
+          name: foo
+        """))
+
+    cfyml.write_text(textwrap.dedent(r"""
+        build_platform:
+          linux_aarch64: linux_64
+          osx_arm64: osx_64
+          win_arm64: win_64
+        provider:
+          linux_64: default
+          linux_aarch64: default
+          osx_arm64: github_actions
+          win_64: azure
+        """))
+
+    lints, hints = linter.main(tmp_path, return_hints=True, conda_forge=True)
+
+    expected = {
+        "Platform linux_aarch64 specifies both build_platform=linux_64 and "
+        "provider=default. Use the former for cross-compilation or the latter "
+        "for native build.",
+        "Platform osx_arm64 specifies both build_platform=osx_64 and "
+        "provider=github_actions. Use the former for cross-compilation or the "
+        "latter for native build.",
+    }
+
+    assert {x for x in lints if "provider" in x} == expected
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_lint_recipe.py
+++ b/tests/test_lint_recipe.py
@@ -6707,6 +6707,7 @@ def test_redundant_build_platform_and_provider(tmp_path):
 
     cfyml.write_text(textwrap.dedent(r"""
         build_platform:
+          linux_64: linux_64
           linux_aarch64: linux_64
           osx_arm64: osx_64
           win_arm64: win_64
@@ -6720,6 +6721,8 @@ def test_redundant_build_platform_and_provider(tmp_path):
     lints, hints = linter.main(tmp_path, return_hints=True, conda_forge=True)
 
     expected = {
+        "Platform linux_64 specifies redundant build_platform=linux_64. Please "
+        "remove the unnecessary entry.",
         "Platform linux_aarch64 specifies both build_platform=linux_64 and "
         "provider=default. Use the former for cross-compilation or the latter "
         "for native build.",
@@ -6728,7 +6731,7 @@ def test_redundant_build_platform_and_provider(tmp_path):
         "latter for native build.",
     }
 
-    assert {x for x in lints if "provider" in x} == expected
+    assert {x for x in lints if x.startswith("Platform")} == expected
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Added a ``news`` entry with any new deprecations added to the ``Deprecated`` section.
* [ ] Regenerated schema JSON if schema altered (`python -m conda_smithy.schema`)
* [x] Regenerated linter documentation if any rules were added, removed or modified (`python -m conda_smithy.linter.messages`)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #2654

<!--
Please add any other relevant info below:
-->
